### PR TITLE
feat: auto-detect Fire Pass keys and apply correct defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ For non-interactive setup:
 curl -fsSL https://raw.githubusercontent.com/fw-ai/fireconnect/main/install.sh | FIREWORKS_API_KEY="fw_..." bash
 ```
 
+Fire Pass users can use a `fpk_...` key directly — FireConnect detects the key type and
+uses the correct defaults for Fire Pass (kimi-k2p6-turbo for all aliases).
+
 If you prefer installing from an SSH checkout:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,7 @@ read_api_key() {
 
   echo "Create a Fireworks API key here:"
   echo "https://app.fireworks.ai/settings/users/api-keys"
+  echo "(Fire Pass users: paste your fpk_... key directly.)"
   echo
 
   # Support interactive, piped (`curl | bash`), and non-interactive stdin flows.

--- a/packages/setup-cli/bin/fireconnect.mjs
+++ b/packages/setup-cli/bin/fireconnect.mjs
@@ -8,10 +8,12 @@ import {
   FIREWORKS_BASE_URL,
   applyModelMapping,
   defaultModelIds,
+  detectApiKeyType,
   disableFireworksProvider,
   enableFireworksProvider,
   isSafeDataDirRemoval,
   mappingFromEnv,
+  providerStatePath,
   providerStatusFromEnv,
   readJsonIfExists,
   resolveModelMapping,
@@ -19,6 +21,7 @@ import {
   userSettingsPath,
 } from "../lib/fireconnect-core.mjs";
 import {
+  OPENCODE_API_KEY_ENV_REF,
   disableOpencodeFireworks,
   enableOpencodeFireworks,
   opencodeConfigPath,
@@ -284,12 +287,15 @@ async function listCommand(options) {
     await opencodeListCommand(options);
     return;
   }
-  const { settingsPath } = pathsFor(options);
+  const { settingsPath, dataDir } = pathsFor(options);
   const settings = await readJsonIfExists(settingsPath);
+  const state = await readJsonIfExists(providerStatePath(dataDir));
   const env = settings.env ?? {};
+  const token = env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN || state.fireworksApiKey || "";
+  const keyType = detectApiKeyType(token);
 
   const payload = {
-    defaults: defaultModelIds(),
+    defaults: defaultModelIds(keyType),
     current: mappingFromEnv(env),
     provider: providerStatusFromEnv(env),
   };
@@ -300,15 +306,20 @@ async function listCommand(options) {
   }
 
   const defaults = payload.defaults;
-  console.log("Default mapping:");
-  console.log(`  main     -> ${defaults.main}`);
-  console.log(`  opus     -> ${defaults.opus}`);
-  console.log(`  sonnet   -> ${defaults.sonnet}`);
-  console.log(`  haiku    -> ${defaults.haiku}`);
-  console.log(`  subagent -> ${defaults.subagent}`);
+  if (keyType !== "firepass") {
+    console.log("Default mapping:");
+    console.log(`  main     -> ${defaults.main}`);
+    console.log(`  opus     -> ${defaults.opus}`);
+    console.log(`  sonnet   -> ${defaults.sonnet}`);
+    console.log(`  haiku    -> ${defaults.haiku}`);
+    console.log(`  subagent -> ${defaults.subagent}`);
+    console.log("");
+  }
 
-  console.log("");
   console.log(`Current provider: ${payload.provider}`);
+  if (keyType === "firepass") {
+    console.log("Key type: Fire Pass (kimi-k2p6-turbo only)");
+  }
   console.log("Current mapping:");
   console.log(`  main     -> ${payload.current.main ?? "(unset)"}`);
   console.log(`  opus     -> ${payload.current.opus ?? "(unset)"}`);
@@ -387,20 +398,32 @@ async function setCommand(options, commandName = "set") {
     const modelId = commandName === "reset"
       ? options.main || defaultModelIds().main
       : options.main;
+    const rawKey = options.apiKeyFromFlag ? options.apiKey : existingKey;
+    const effectiveKey = rawKey === OPENCODE_API_KEY_ENV_REF
+      ? (process.env.FIREWORKS_API_KEY ?? "")
+      : rawKey;
+    const keyType = detectApiKeyType(effectiveKey);
     const result = await enableOpencodeFireworks({
       configPath,
       dataDir,
       apiKey: options.apiKeyFromFlag ? options.apiKey : existingKey || options.apiKey,
       apiKeyFromFlag: options.apiKeyFromFlag || Boolean(existingKey),
       modelId,
+      keyType,
     });
     console.log(`Updated OpenCode model: ${result.model}`);
     return;
   }
-  const { settingsPath } = pathsFor(options);
+  const { settingsPath, dataDir } = pathsFor(options);
+  // Resolve the key type from the currently stored token, not just the CLI flag.
+  const settings = await readJsonIfExists(settingsPath);
+  const state = await readJsonIfExists(providerStatePath(dataDir));
+  const env = settings.env ?? {};
+  const token = options.apiKey || env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN || state.fireworksApiKey || "";
+  const keyType = detectApiKeyType(token);
   await applyModelMapping({
     settingsPath,
-    mapping: resolveModelMapping(modelOverridesFrom(options)),
+    mapping: resolveModelMapping(modelOverridesFrom(options), keyType),
   });
   console.log("Updated Claude Code model aliases for Fireworks.");
 }
@@ -424,12 +447,18 @@ async function onCommand(options) {
         reusedExistingKey = true;
       }
     }
+    // Resolve env-ref placeholder to the real key before detecting type.
+    const effectiveApiKey = apiKey === OPENCODE_API_KEY_ENV_REF
+      ? (process.env.FIREWORKS_API_KEY ?? "")
+      : apiKey;
+    const keyType = detectApiKeyType(effectiveApiKey);
     const result = await enableOpencodeFireworks({
       configPath,
       dataDir,
       apiKey,
       apiKeyFromFlag,
       modelId: options.main,
+      keyType,
     });
     console.log(`Fireworks provider enabled for OpenCode (model: ${result.model}).`);
     if (reusedExistingKey) {
@@ -439,18 +468,32 @@ async function onCommand(options) {
     } else {
       console.log("API key written into opencode.json (passed via --api-key).");
     }
+    if (result.keyType === "firepass") {
+      console.log("Fire Pass key detected: using kimi-k2p6-turbo for all aliases.");
+    }
     console.log("Restart OpenCode for full effect.");
     return;
   }
   const { settingsPath, dataDir } = pathsFor(options);
+  // Resolve the actual token from the same sources enableFireworksProvider uses
+  // so the key type detection is accurate even when the CLI key is empty.
+  const settings = await readJsonIfExists(settingsPath);
+  const state = await readJsonIfExists(providerStatePath(dataDir));
+  const env = settings.env ?? {};
+  const token = options.apiKey || env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN || state.fireworksApiKey || "";
+  const keyType = detectApiKeyType(token);
   await enableFireworksProvider({
     settingsPath,
     dataDir,
     apiKey: options.apiKey,
     baseUrl: options.baseUrl,
-    mapping: resolveModelMapping(modelOverridesFrom(options)),
+    mapping: resolveModelMapping(modelOverridesFrom(options), keyType),
+    keyType,
   });
   console.log("Fireworks provider enabled. Restart Claude Code for full effect.");
+  if (keyType === "firepass") {
+    console.log("Fire Pass key detected: using kimi-k2p6-turbo for all aliases.");
+  }
 }
 
 async function offCommand(options) {

--- a/packages/setup-cli/lib/fireconnect-core.mjs
+++ b/packages/setup-cli/lib/fireconnect-core.mjs
@@ -51,6 +51,13 @@ export const DEFAULT_FIREWORKS_PRESET = {
   CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE: "0",
 };
 
+export const DEFAULT_FIREPASS_PRESET = {
+  ...DEFAULT_FIREWORKS_PRESET,
+  ANTHROPIC_DEFAULT_SONNET_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
+  CLAUDE_CODE_SUBAGENT_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
+};
+
 export async function readJsonIfExists(filePath) {
   try {
     return JSON.parse(await readFile(filePath, "utf8"));
@@ -140,7 +147,16 @@ export function validateModelId(model, flag) {
   }
 }
 
-export function defaultModelIds() {
+export function defaultModelIds(keyType = "fireworks") {
+  if (keyType === "firepass") {
+    return {
+      main: DEFAULT_MAIN_MODEL,
+      opus: DEFAULT_MAIN_MODEL,
+      sonnet: DEFAULT_MAIN_MODEL,
+      haiku: DEFAULT_MAIN_MODEL,
+      subagent: DEFAULT_MAIN_MODEL,
+    };
+  }
   return {
     main: DEFAULT_MAIN_MODEL,
     opus: DEFAULT_OPUS_MODEL,
@@ -150,8 +166,8 @@ export function defaultModelIds() {
   };
 }
 
-export function resolveModelMapping(overrides = {}) {
-  const defaults = defaultModelIds();
+export function resolveModelMapping(overrides = {}, keyType = "fireworks") {
+  const defaults = defaultModelIds(keyType);
   const main = normalizeModelId(overrides.main || defaults.main);
   const opus = normalizeModelId(overrides.opus || defaults.opus);
   const sonnet = normalizeModelId(overrides.sonnet || defaults.sonnet);
@@ -224,6 +240,15 @@ export function isFireworksModelId(model) {
   return typeof model === "string" && model.startsWith("accounts/fireworks/");
 }
 
+/** Detect whether a key is a Fire Pass subscription key (fpk_...) or a
+ *  standard Fireworks API key (fw_...). Returns "firepass" or "fireworks". */
+export function detectApiKeyType(key) {
+  if (typeof key === "string" && key.trim().startsWith("fpk_")) {
+    return "firepass";
+  }
+  return "fireworks";
+}
+
 export function applyTopLevelBackup(settings, topLevelBackup) {
   const next = { ...settings };
   if (!topLevelBackup?.values) {
@@ -271,10 +296,12 @@ export function buildFireworksProviderEnv(env, {
   baseUrl = FIREWORKS_BASE_URL,
   mapping,
   preset = DEFAULT_FIREWORKS_PRESET,
+  keyType = "fireworks",
 }) {
+  const resolvedPreset = keyType === "firepass" ? DEFAULT_FIREPASS_PRESET : preset;
   const nextEnv = {
     ...env,
-    ...preset,
+    ...resolvedPreset,
     ...mergeModelsIntoEnv({}, mapping),
     ANTHROPIC_BASE_URL: baseUrl,
     ANTHROPIC_API_KEY: apiKey,
@@ -292,6 +319,7 @@ export async function enableFireworksProvider({
   baseUrl = FIREWORKS_BASE_URL,
   mapping = resolveModelMapping(),
   preset = DEFAULT_FIREWORKS_PRESET,
+  keyType = "fireworks",
 }) {
   const backupPath = providerBackupPath(dataDir);
   const statePath = providerStatePath(dataDir);
@@ -316,9 +344,11 @@ export async function enableFireworksProvider({
     throw new Error("No Fireworks API key found. Pass --api-key or set FIREWORKS_API_KEY.");
   }
 
+  const resolvedKeyType = keyType === "fireworks" ? detectApiKeyType(token) : keyType;
+
   const next = {
     ...settings,
-    env: buildFireworksProviderEnv(env, { apiKey: token, baseUrl, mapping, preset }),
+    env: buildFireworksProviderEnv(env, { apiKey: token, baseUrl, mapping, preset, keyType: resolvedKeyType }),
   };
 
   await writeJson(settingsPath, next);

--- a/packages/setup-cli/lib/opencode-core.mjs
+++ b/packages/setup-cli/lib/opencode-core.mjs
@@ -1,8 +1,10 @@
 import { createHash } from "node:crypto";
 import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
+import process from "node:process";
 import {
   DEFAULT_MAIN_MODEL,
+  detectApiKeyType,
   normalizeModelId,
   readJsonIfExists,
   writeJson,
@@ -84,6 +86,7 @@ export async function enableOpencodeFireworks({
   apiKey,
   apiKeyFromFlag = false,
   modelId,
+  keyType = "fireworks",
 }) {
   if (!apiKey) {
     throw new Error("No Fireworks API key found. Pass --api-key or set FIREWORKS_API_KEY.");
@@ -99,12 +102,27 @@ export async function enableOpencodeFireworks({
     }
   }
 
+  // Resolve the {env:FIREWORKS_API_KEY} placeholder to the real env value before
+  // detecting key type — otherwise env-ref stored keys always detect as "fireworks".
+  const effectiveApiKey = apiKey === OPENCODE_API_KEY_ENV_REF
+    ? (process.env.FIREWORKS_API_KEY ?? "")
+    : apiKey;
+  const resolvedKeyType = keyType === "fireworks" ? detectApiKeyType(effectiveApiKey) : keyType;
+
   // Model precedence: explicit request > model already configured by a previous
   // `on` > default. A repeat `on` without --main must not reset the user's choice.
   const currentModelId = typeof config.model === "string" && config.model.startsWith("fireworks/")
     ? config.model.slice("fireworks/".length)
     : "";
-  const resolvedModel = normalizeModelId(modelId || currentModelId || DEFAULT_MAIN_MODEL);
+
+  // Fire Pass only covers kimi-k2p6-turbo; when no explicit model is requested,
+  // default to that router so the user gets a working config out of the box.
+  let effectiveModelId = modelId;
+  if (resolvedKeyType === "firepass" && !modelId) {
+    effectiveModelId = DEFAULT_MAIN_MODEL;
+  }
+
+  const resolvedModel = normalizeModelId(effectiveModelId || currentModelId || DEFAULT_MAIN_MODEL);
 
   const backupPath = opencodeBackupPath(dataDir, configPath);
   // Snapshot only when the live config carries no trace of FireConnect (no
@@ -143,7 +161,7 @@ export async function enableOpencodeFireworks({
   await writeJson(configPath, next);
   await writeJson(opencodeStatePath(dataDir), { enabled: true });
 
-  return { model: next.model, apiKeyMode: apiKeyFromFlag ? "literal" : "env-reference" };
+  return { model: next.model, apiKeyMode: apiKeyFromFlag ? "literal" : "env-reference", keyType: resolvedKeyType };
 }
 
 export async function disableOpencodeFireworks({ configPath, dataDir }) {


### PR DESCRIPTION
Fire Pass API keys (fpk_...) only cover kimi-k2p6-turbo. When a key is detected as
Fire Pass, all model aliases default to that router instead of the usual mixed
mapping (opus -> kimi-k2p6-turbo, sonnet -> glm-5p1, haiku -> minimax-m2p5).

Changes:
- Add detectApiKeyType(key) in fireconnect-core.mjs
- Add DEFAULT_FIREPASS_PRESET for Claude Code settings
- defaultModelIds and resolveModelMapping accept a keyType argument
- enableFireworksProvider and buildFireworksProviderEnv use the key-type preset
- enableOpencodeFireworks defaults to kimi-k2p6-turbo when no explicit model is given
- CLI prints a hint when a Fire Pass key is detected
- install.sh and README mention fpk_... keys

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local CLI/config defaults only; no auth protocol changes beyond prefix-based routing to supported models.
> 
> **Overview**
> Adds **Fire Pass** (`fpk_...`) support alongside standard Fireworks (`fw_...`) keys. **`detectApiKeyType`** classifies the key; Fire Pass is treated as **kimi-k2p6-turbo only** for every model alias instead of the usual mixed defaults (glm-5p1, minimax-m2p5, etc.).
> 
> **Claude Code path:** new **`DEFAULT_FIREPASS_PRESET`**, and **`defaultModelIds` / `resolveModelMapping` / `buildFireworksProviderEnv` / `enableFireworksProvider`** take a `keyType` so enable, set, reset, and list apply the right mapping and env preset. **`list`** reads the stored token and labels Fire Pass keys in the UI.
> 
> **OpenCode path:** **`enableOpencodeFireworks`** resolves `{env:FIREWORKS_API_KEY}` before detection, defaults the model to kimi-k2p6-turbo when Fire Pass has no explicit `--main`, and returns `keyType` for CLI hints.
> 
> **Docs/install:** README and **`install.sh`** note that Fire Pass users can paste `fpk_...` keys; **`on`** prints a short message when Fire Pass is detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12565e36e72f285d5493aa3a1885995d59eab25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->