### PR TITLE
release: v0.3.0 — standalone CLI, model picker, OpenCode harness, and Fire Pass defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ hi
 Default models:
 
 ```text
-opus     -> kimi-k2p6-turbo
+opus     -> kimi-k2p7-code-fast
 sonnet   -> glm-5p1
 haiku    -> minimax-m2p5
 subagent -> minimax-m2p5
@@ -89,8 +89,8 @@ The setup writes these Claude Code settings:
     "ANTHROPIC_BASE_URL": "https://api.fireworks.ai/inference",
     "ANTHROPIC_API_KEY": "fw_YOUR_FIREWORKS_API_KEY",
     "ANTHROPIC_AUTH_TOKEN": "fw_YOUR_FIREWORKS_API_KEY",
-    "ANTHROPIC_MODEL": "accounts/fireworks/routers/kimi-k2p6-turbo",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "accounts/fireworks/routers/kimi-k2p6-turbo",
+    "ANTHROPIC_MODEL": "accounts/fireworks/routers/kimi-k2p7-code-fast",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "accounts/fireworks/routers/kimi-k2p7-code-fast",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "accounts/fireworks/models/glm-5p1",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "accounts/fireworks/models/minimax-m2p5",
     "CLAUDE_CODE_SUBAGENT_MODEL": "accounts/fireworks/models/minimax-m2p5"
@@ -100,7 +100,67 @@ The setup writes these Claude Code settings:
 
 The setup writes both `ANTHROPIC_API_KEY` (preferred) and `ANTHROPIC_AUTH_TOKEN` (compatibility alias) with the same Fireworks key. It saves a backup of your previous provider settings so `fireconnect off` can restore them.
 
-Short model IDs are accepted everywhere. For example, `kimi-k2p6-turbo` is written to Claude Code settings as `accounts/fireworks/routers/kimi-k2p6-turbo`.
+Short model IDs are accepted everywhere. For example, `kimi-k2p7-code-fast` is written to Claude Code settings as `accounts/fireworks/routers/kimi-k2p7-code-fast`.
+
+## Browsing and Picking Models
+
+After `fireconnect on`, FireConnect prints hints for browsing the Fireworks catalog and
+picking a model interactively.
+
+```bash
+fireconnect model list              # browse callable serverless endpoints
+fireconnect model select            # pick a model for Claude Code
+fireconnect model select --slot sonnet   # update one Claude Code alias
+fireconnect model select --harness opencode   # pick OpenCode's default model
+```
+
+### `fireconnect model list`
+
+Harness-agnostic by default: lists the same Fireworks serverless catalog regardless of Claude
+Code or OpenCode. Fetches serverless models from the Fireworks API (`supports_serverless=true`)
+and merges the two known public platform routers (`kimi-k2p6-turbo` and `kimi-k2p7-code-fast`).
+Every row is tagged `serverless` (on-demand endpoints will be added later).
+
+```bash
+fireconnect model list
+fireconnect model list --search glm
+fireconnect model list --json
+fireconnect model list --harness opencode
+```
+
+Uses `FIREWORKS_API_KEY`, or a key already stored in Claude Code or OpenCode settings. By
+default both sources are checked, but non-Fireworks-shaped keys (for example, an Anthropic
+`sk-ant-...` token) are skipped. Use `--harness opencode` to force the OpenCode key source, or
+`--harness claude` to force the Claude Code source.
+
+Fire Pass keys (`fpk_...`) only show the `kimi-k2p6-turbo` router.
+
+### `fireconnect model select`
+
+Interactive picker. Requires a terminal and Fireworks to be enabled. On confirm, writes
+the chosen model to your harness settings.
+
+**Claude Code** — pick one of five aliases (`main`, `opus`, `sonnet`, `haiku`, `subagent`):
+
+```bash
+fireconnect model select
+fireconnect model select --slot sonnet
+fireconnect model select --slot sonnet --search glm
+```
+
+**OpenCode** — single default model (no `--slot`):
+
+```bash
+fireconnect model select --harness opencode
+fireconnect model select --harness opencode --search glm
+```
+
+### `fireconnect list` vs `fireconnect model list`
+
+| Command | Shows |
+|---------|--------|
+| `fireconnect list` | Your configured alias mapping in Claude Code settings |
+| `fireconnect model list` | Available serverless endpoints from the Fireworks API |
 
 ## FireConnect CLI
 
@@ -109,6 +169,7 @@ fireconnect on         Route Claude Code through Fireworks.
 fireconnect off        Restore your previous provider.
 fireconnect status     Show the current provider.
 fireconnect list       Show the model mapping.
+fireconnect model      Browse or pick serverless models (list, select).
 fireconnect set        Change model aliases.
 fireconnect reset      Reset models to defaults.
 fireconnect uninstall  Remove FireConnect from this machine.

--- a/packages/setup-cli/bin/fireconnect.mjs
+++ b/packages/setup-cli/bin/fireconnect.mjs
@@ -28,6 +28,9 @@ import {
   opencodeDataDir,
   opencodeProviderStatus,
 } from "../lib/opencode-core.mjs";
+import { runModelListCommand } from "../lib/model-list.mjs";
+import { runModelSelectCommand } from "../lib/model-select.mjs";
+import { DEFAULT_HARNESS, HARNESS, parseHarness } from "../lib/harness.mjs";
 
 const CLI_NAME = "fireconnect";
 
@@ -37,7 +40,7 @@ function parseArgs(argv) {
     home: process.env.HOME ?? "",
     settingsPath: "",
     configPath: "",
-    harness: "claude-code",
+    harness: DEFAULT_HARNESS,
     dataDir: "",
     apiKey: process.env.FIREWORKS_API_KEY ?? "",
     apiKeyFromFlag: false,
@@ -47,6 +50,8 @@ function parseArgs(argv) {
     sonnet: "",
     haiku: "",
     subagent: "",
+    slot: "",
+    search: "",
     json: false,
     positional: [],
   };
@@ -69,10 +74,7 @@ function parseArgs(argv) {
       options.configPath = requireValue(arg, next);
       i += 1;
     } else if (arg === "--harness") {
-      options.harness = requireValue(arg, next);
-      if (options.harness !== "claude-code" && options.harness !== "opencode") {
-        throw new Error(`--harness must be "claude-code" or "opencode", got: ${options.harness}`);
-      }
+      options.harness = parseHarness(requireValue(arg, next));
       i += 1;
     } else if (arg === "--data-dir") {
       options.dataDir = requireValue(arg, next);
@@ -99,6 +101,12 @@ function parseArgs(argv) {
     } else if (arg === "--subagent") {
       options.subagent = requireValue(arg, next);
       i += 1;
+    } else if (arg === "--slot") {
+      options.slot = requireValue(arg, next);
+      i += 1;
+    } else if (arg === "--search") {
+      options.search = requireValue(arg, next);
+      i += 1;
     } else if (arg.startsWith("--")) {
       throw new Error(`Unknown argument: ${arg}`);
     } else {
@@ -123,7 +131,7 @@ function ensureNoPositional(options, command) {
 }
 
 function ensureHome(options) {
-  if (options.harness === "opencode") {
+  if (options.harness === HARNESS.OPENCODE) {
     if (!options.configPath && !options.home) {
       throw new Error("HOME is not set; pass --home or --config-path");
     }
@@ -213,6 +221,27 @@ Reset model aliases to the defaults.`,
 
 Turn off Fireworks routing and remove FireConnect from this machine
 (local data and the CLI launcher).`,
+    model: `Usage:
+  ${CLI_NAME} model list [--json] [--search <query>] [--harness opencode]
+  ${CLI_NAME} model select [--slot <alias>] [--search <query>] [--harness opencode]
+
+Browse or interactively pick serverless Fireworks models.
+
+Subcommands:
+  list     List callable serverless models and routers.
+  select   Pick a model and update harness settings (Claude Code or OpenCode).
+
+Options:
+  --slot <alias>       Claude Code alias: main, opus, sonnet, haiku, subagent.
+  --harness opencode   Use OpenCode config/key instead of Claude Code.
+  --search <query>     Filter by id or display name (list or select).
+  --api-key <key>      Fireworks API key. Defaults to FIREWORKS_API_KEY.
+  --json               Machine-readable output (list only).
+  --home <path>        Override HOME for settings resolution.
+  --settings-path <path>
+                       Explicit Claude Code settings file.
+  --config-path <path>
+                       Explicit opencode.json path.`,
   };
 
   if (command && commandHelp[command]) {
@@ -230,6 +259,7 @@ Commands:
   off        Restore your previous provider.
   status     Show the current provider.
   list       Show the model mapping.
+  model      Browse or pick serverless models (list, select).
   set        Change model aliases.
   reset      Reset models to defaults.
   uninstall  Remove FireConnect from this machine.
@@ -243,7 +273,7 @@ Common options:
 Examples:
   ${CLI_NAME} on --api-key fw_...
   ${CLI_NAME} status
-  ${CLI_NAME} set --main kimi-k2p6-turbo
+  ${CLI_NAME} set --main kimi-k2p7-code-fast
   ${CLI_NAME} off
   ${CLI_NAME} on --harness opencode
 
@@ -261,7 +291,7 @@ async function opencodeListCommand(options) {
   // OpenCode routes a single default model (no opus/sonnet/haiku alias slots),
   // so the mapping has one entry — same defaults/current shape as Claude Code.
   const payload = {
-    harness: "opencode",
+    harness: HARNESS.OPENCODE,
     defaults: { main: defaultModelIds().main },
     current: { main: model },
     provider: opencodeProviderStatus(config),
@@ -283,7 +313,7 @@ async function opencodeListCommand(options) {
 async function listCommand(options) {
   ensureNoPositional(options, "list");
   ensureHome(options);
-  if (options.harness === "opencode") {
+  if (options.harness === HARNESS.OPENCODE) {
     await opencodeListCommand(options);
     return;
   }
@@ -333,7 +363,7 @@ async function opencodeStatusCommand(options) {
   const config = await readJsonIfExists(configPath);
   const fireworks = config.provider?.fireworks ?? null;
   const payload = {
-    harness: "opencode",
+    harness: HARNESS.OPENCODE,
     provider: opencodeProviderStatus(config),
     baseUrl: fireworks?.options?.baseURL ?? null,
     hasAuthToken: Boolean(fireworks?.options?.apiKey),
@@ -355,7 +385,7 @@ async function opencodeStatusCommand(options) {
 async function statusCommand(options) {
   ensureNoPositional(options, "status");
   ensureHome(options);
-  if (options.harness === "opencode") {
+  if (options.harness === HARNESS.OPENCODE) {
     await opencodeStatusCommand(options);
     return;
   }
@@ -383,7 +413,7 @@ async function statusCommand(options) {
 async function setCommand(options, commandName = "set") {
   ensureNoPositional(options, commandName);
   ensureHome(options);
-  if (options.harness === "opencode") {
+  if (options.harness === HARNESS.OPENCODE) {
     // OpenCode has a single default model; re-run `on` with the new --main.
     const { configPath, dataDir } = opencodePathsFor(options);
     const config = await readJsonIfExists(configPath);
@@ -393,16 +423,16 @@ async function setCommand(options, commandName = "set") {
     // Reuse the existing configured key verbatim (it may be a literal key or the
     // {env:...} reference); apiKeyFromFlag=true makes enable write it back as-is.
     const existingKey = config.provider?.fireworks?.options?.apiKey ?? "";
-    // `set` without --main keeps the configured model (enable's precedence does
-    // that); `reset` must explicitly apply the default, like the Claude Code path.
-    const modelId = commandName === "reset"
-      ? options.main || defaultModelIds().main
-      : options.main;
     const rawKey = options.apiKeyFromFlag ? options.apiKey : existingKey;
     const effectiveKey = rawKey === OPENCODE_API_KEY_ENV_REF
       ? (process.env.FIREWORKS_API_KEY ?? "")
       : rawKey;
     const keyType = detectApiKeyType(effectiveKey);
+    // `set` without --main keeps the configured model (enable's precedence does
+    // that); `reset` must explicitly apply the default, like the Claude Code path.
+    const modelId = commandName === "reset"
+      ? options.main || defaultModelIds(keyType).main
+      : options.main;
     const result = await enableOpencodeFireworks({
       configPath,
       dataDir,
@@ -431,7 +461,7 @@ async function setCommand(options, commandName = "set") {
 async function onCommand(options) {
   ensureNoPositional(options, "on");
   ensureHome(options);
-  if (options.harness === "opencode") {
+  if (options.harness === HARNESS.OPENCODE) {
     const { configPath, dataDir } = opencodePathsFor(options);
     // Re-running `on` without a key in the flag or environment should reuse the
     // key already configured (literal or {env:...} reference), like `set` does.
@@ -470,6 +500,9 @@ async function onCommand(options) {
     }
     if (result.keyType === "firepass") {
       console.log("Fire Pass key detected: using kimi-k2p6-turbo for all aliases.");
+    } else {
+      console.log("Browse models: fireconnect model list");
+      console.log("Pick a model:  fireconnect model select --harness opencode");
     }
     console.log("Restart OpenCode for full effect.");
     return;
@@ -493,13 +526,16 @@ async function onCommand(options) {
   console.log("Fireworks provider enabled. Restart Claude Code for full effect.");
   if (keyType === "firepass") {
     console.log("Fire Pass key detected: using kimi-k2p6-turbo for all aliases.");
+  } else {
+    console.log("Browse models: fireconnect model list");
+    console.log("Pick a model:  fireconnect model select");
   }
 }
 
 async function offCommand(options) {
   ensureNoPositional(options, "off");
   ensureHome(options);
-  if (options.harness === "opencode") {
+  if (options.harness === HARNESS.OPENCODE) {
     const { configPath, dataDir } = opencodePathsFor(options);
     await disableOpencodeFireworks({ configPath, dataDir });
     console.log("Fireworks provider disabled for OpenCode; original config restored.");
@@ -524,7 +560,7 @@ async function removePath(pathToRemove) {
 
 async function uninstallCommand(options) {
   ensureNoPositional(options, "uninstall");
-  if (options.harness === "opencode") {
+  if (options.harness === HARNESS.OPENCODE) {
     throw new Error("uninstall does not support --harness opencode; use: fireconnect off --harness opencode");
   }
   const home = process.env.HOME ?? "";
@@ -574,11 +610,56 @@ async function uninstallCommand(options) {
   console.log("Restart Claude Code to fully apply changes.");
 }
 
+async function modelCommand(options) {
+  const subcommand = options.positional[0] ?? "";
+  const trailingPositional = options.positional.slice(1);
+  if (trailingPositional.length > 0) {
+    throw new Error(`model ${subcommand} does not accept positional arguments`);
+  }
+  ensureHome(options);
+
+  const { settingsPath, dataDir } = pathsFor(options);
+  const { configPath, dataDir: opencodeDataDirPath } = opencodePathsFor(options);
+
+  if (subcommand === "list") {
+    await runModelListCommand({ options, settingsPath, dataDir, configPath });
+    return;
+  }
+
+  if (subcommand === "select") {
+    if (options.harness === HARNESS.OPENCODE) {
+      await runModelSelectCommand({
+        options,
+        harness: HARNESS.OPENCODE,
+        settingsPath,
+        configPath,
+        opencodeDataDir: opencodeDataDirPath,
+      });
+    } else {
+      await runModelSelectCommand({
+        options,
+        harness: DEFAULT_HARNESS,
+        settingsPath,
+        dataDir,
+        configPath,
+      });
+    }
+    return;
+  }
+
+  throw new Error(`Usage: ${CLI_NAME} model list|select`);
+}
+
 async function run() {
   const { command, options } = parseArgs(process.argv.slice(2));
 
   if (command === "help") {
     printHelp(options.positional[0] || "");
+    return;
+  }
+
+  if (command === "model") {
+    await modelCommand(options);
     return;
   }
 

--- a/packages/setup-cli/lib/claude-code-context.mjs
+++ b/packages/setup-cli/lib/claude-code-context.mjs
@@ -1,0 +1,41 @@
+export const CLAUDE_CODE_1M_CONTEXT_MODELS = new Set([
+  "deepseek-v4-pro",
+]);
+
+const CLAUDE_CODE_1M_SUFFIX = "[1m]";
+
+export function stripClaudeCodeContextSuffix(modelId) {
+  if (typeof modelId !== "string") {
+    return modelId;
+  }
+  return modelId.replace(/\[1m\]$/i, "");
+}
+
+function modelShortId(modelId) {
+  const stripped = stripClaudeCodeContextSuffix(modelId);
+  if (!stripped) {
+    return "";
+  }
+  return stripped.split("/").at(-1) ?? stripped;
+}
+
+function needsClaudeCode1mContext(modelId) {
+  return CLAUDE_CODE_1M_CONTEXT_MODELS.has(modelShortId(modelId));
+}
+
+export function claudeCodeModelId(modelId) {
+  if (!modelId || !needsClaudeCode1mContext(modelId)) {
+    return modelId;
+  }
+  return `${stripClaudeCodeContextSuffix(modelId)}${CLAUDE_CODE_1M_SUFFIX}`;
+}
+
+export function applyClaudeCodeContextPolicy(env, mapping) {
+  const next = { ...env };
+  if (needsClaudeCode1mContext(mapping.main)) {
+    delete next.CLAUDE_CODE_DISABLE_1M_CONTEXT;
+  } else {
+    next.CLAUDE_CODE_DISABLE_1M_CONTEXT = "1";
+  }
+  return next;
+}

--- a/packages/setup-cli/lib/fireconnect-core.mjs
+++ b/packages/setup-cli/lib/fireconnect-core.mjs
@@ -2,8 +2,17 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  applyClaudeCodeContextPolicy,
+  claudeCodeModelId,
+  stripClaudeCodeContextSuffix,
+} from "./claude-code-context.mjs";
+
+export { CLAUDE_CODE_1M_CONTEXT_MODELS } from "./claude-code-context.mjs";
+
 export const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference";
-export const DEFAULT_OPUS_MODEL = "kimi-k2p6-turbo";
+export const DEFAULT_OPUS_MODEL = "kimi-k2p7-code-fast";
+export const DEFAULT_FIREPASS_MAIN_MODEL = "kimi-k2p6-turbo";
 export const DEFAULT_SONNET_MODEL = "glm-5p1";
 export const DEFAULT_HAIKU_MODEL = "minimax-m2p5";
 export const DEFAULT_MAIN_MODEL = DEFAULT_OPUS_MODEL;
@@ -38,13 +47,13 @@ export const FIREWORKS_TOP_LEVEL_KEYS = [
 ];
 
 export const DEFAULT_FIREWORKS_PRESET = {
-  ANTHROPIC_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
-  ANTHROPIC_DEFAULT_OPUS_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
+  ANTHROPIC_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  ANTHROPIC_DEFAULT_OPUS_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
   ANTHROPIC_DEFAULT_SONNET_MODEL: "accounts/fireworks/models/glm-5p1",
   ANTHROPIC_DEFAULT_HAIKU_MODEL: "accounts/fireworks/models/minimax-m2p5",
   CLAUDE_CODE_SUBAGENT_MODEL: "accounts/fireworks/models/minimax-m2p5",
-  ANTHROPIC_CUSTOM_MODEL_OPTION: "accounts/fireworks/routers/kimi-k2p6-turbo",
-  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "Kimi K2.6 Turbo via Fireworks",
+  ANTHROPIC_CUSTOM_MODEL_OPTION: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "Kimi K2.7 Code Fast via Fireworks",
   ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION: "Fireworks Anthropic-compatible open model",
   CLAUDE_CODE_DISABLE_1M_CONTEXT: "1",
   CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1",
@@ -53,9 +62,13 @@ export const DEFAULT_FIREWORKS_PRESET = {
 
 export const DEFAULT_FIREPASS_PRESET = {
   ...DEFAULT_FIREWORKS_PRESET,
+  ANTHROPIC_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
+  ANTHROPIC_DEFAULT_OPUS_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
   ANTHROPIC_DEFAULT_SONNET_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
   ANTHROPIC_DEFAULT_HAIKU_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
   CLAUDE_CODE_SUBAGENT_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
+  ANTHROPIC_CUSTOM_MODEL_OPTION: "accounts/fireworks/routers/kimi-k2p6-turbo",
+  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "Kimi K2.6 Turbo via Fireworks",
 };
 
 export async function readJsonIfExists(filePath) {
@@ -129,6 +142,7 @@ export function providerBackupPath(dataDir) {
 }
 
 export function normalizeModelId(model) {
+  model = stripClaudeCodeContextSuffix(model);
   if (model.startsWith("accounts/")) {
     return model;
   }
@@ -138,23 +152,26 @@ export function normalizeModelId(model) {
   if (model === "kimi-k2p6-turbo") {
     return "accounts/fireworks/routers/kimi-k2p6-turbo";
   }
+  if (model === "kimi-k2p7-code-fast") {
+    return "accounts/fireworks/routers/kimi-k2p7-code-fast";
+  }
   return `accounts/fireworks/models/${model}`;
 }
 
 export function validateModelId(model, flag) {
   if (!model.startsWith("accounts/") && model.includes("/")) {
-    throw new Error(`${flag} must be a Fireworks model or router ID like kimi-k2p6-turbo or accounts/fireworks/routers/kimi-k2p6-turbo`);
+    throw new Error(`${flag} must be a Fireworks model or router ID like kimi-k2p7-code-fast or accounts/fireworks/routers/kimi-k2p7-code-fast`);
   }
 }
 
 export function defaultModelIds(keyType = "fireworks") {
   if (keyType === "firepass") {
     return {
-      main: DEFAULT_MAIN_MODEL,
-      opus: DEFAULT_MAIN_MODEL,
-      sonnet: DEFAULT_MAIN_MODEL,
-      haiku: DEFAULT_MAIN_MODEL,
-      subagent: DEFAULT_MAIN_MODEL,
+      main: DEFAULT_FIREPASS_MAIN_MODEL,
+      opus: DEFAULT_FIREPASS_MAIN_MODEL,
+      sonnet: DEFAULT_FIREPASS_MAIN_MODEL,
+      haiku: DEFAULT_FIREPASS_MAIN_MODEL,
+      subagent: DEFAULT_FIREPASS_MAIN_MODEL,
     };
   }
   return {
@@ -184,12 +201,13 @@ export function resolveModelMapping(overrides = {}, keyType = "fireworks") {
 }
 
 export function mappingFromEnv(env) {
+  const strip = (value) => (value ? stripClaudeCodeContextSuffix(value) : value);
   return {
-    main: env.ANTHROPIC_MODEL ?? null,
-    opus: env.ANTHROPIC_DEFAULT_OPUS_MODEL ?? null,
-    sonnet: env.ANTHROPIC_DEFAULT_SONNET_MODEL ?? null,
-    haiku: env.ANTHROPIC_DEFAULT_HAIKU_MODEL ?? null,
-    subagent: env.CLAUDE_CODE_SUBAGENT_MODEL ?? null,
+    main: strip(env.ANTHROPIC_MODEL ?? null),
+    opus: strip(env.ANTHROPIC_DEFAULT_OPUS_MODEL ?? null),
+    sonnet: strip(env.ANTHROPIC_DEFAULT_SONNET_MODEL ?? null),
+    haiku: strip(env.ANTHROPIC_DEFAULT_HAIKU_MODEL ?? null),
+    subagent: strip(env.CLAUDE_CODE_SUBAGENT_MODEL ?? null),
   };
 }
 
@@ -274,11 +292,11 @@ export function clearFireworksTopLevelWithoutBackup(settings) {
 
 export function modelEnvFromMapping(mapping) {
   return {
-    ANTHROPIC_MODEL: mapping.main,
-    ANTHROPIC_DEFAULT_OPUS_MODEL: mapping.opus,
-    ANTHROPIC_DEFAULT_SONNET_MODEL: mapping.sonnet,
-    ANTHROPIC_DEFAULT_HAIKU_MODEL: mapping.haiku,
-    CLAUDE_CODE_SUBAGENT_MODEL: mapping.subagent,
+    ANTHROPIC_MODEL: claudeCodeModelId(mapping.main),
+    ANTHROPIC_DEFAULT_OPUS_MODEL: claudeCodeModelId(mapping.opus),
+    ANTHROPIC_DEFAULT_SONNET_MODEL: claudeCodeModelId(mapping.sonnet),
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: claudeCodeModelId(mapping.haiku),
+    CLAUDE_CODE_SUBAGENT_MODEL: claudeCodeModelId(mapping.subagent),
   };
 }
 
@@ -309,7 +327,7 @@ export function buildFireworksProviderEnv(env, {
   };
   delete nextEnv.ANTHROPIC_SMALL_FAST_MODEL;
   delete nextEnv.ENABLE_TOOL_SEARCH;
-  return nextEnv;
+  return applyClaudeCodeContextPolicy(nextEnv, mapping);
 }
 
 export async function enableFireworksProvider({
@@ -402,6 +420,6 @@ export async function applyModelMapping({ settingsPath, mapping }) {
   const env = settings.env ?? {};
   await writeJson(settingsPath, {
     ...settings,
-    env: mergeModelsIntoEnv(env, mapping),
+    env: applyClaudeCodeContextPolicy(mergeModelsIntoEnv(env, mapping), mapping),
   });
 }

--- a/packages/setup-cli/lib/fireworks-models.mjs
+++ b/packages/setup-cli/lib/fireworks-models.mjs
@@ -1,0 +1,250 @@
+import {
+  detectApiKeyType,
+  providerStatePath,
+  readJsonIfExists,
+} from "./fireconnect-core.mjs";
+import { HARNESS } from "./harness.mjs";
+import { OPENCODE_API_KEY_ENV_REF } from "./opencode-core.mjs";
+
+export const FIREWORKS_GATEWAY_URL = "https://api.fireworks.ai";
+export const PLATFORM_ACCOUNT_ID = "fireworks";
+export const KIND_SERVERLESS = "serverless";
+export const FIREPASS_ROUTER_ID = "accounts/fireworks/routers/kimi-k2p6-turbo";
+
+const BUILTIN_ROUTERS = [
+  {
+    id: "accounts/fireworks/routers/kimi-k2p6-turbo",
+    shortId: "kimi-k2p6-turbo",
+    displayName: "Kimi K2.6 Turbo via Fireworks",
+    kind: KIND_SERVERLESS,
+  },
+  {
+    id: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+    shortId: "kimi-k2p7-code-fast",
+    displayName: "Kimi K2.7 Code Fast via Fireworks",
+    kind: KIND_SERVERLESS,
+  },
+];
+
+/** @typedef {{ id: string, shortId: string, displayName: string, kind: "serverless" }} CatalogEntry */
+
+export function shortIdFromResourceName(name) {
+  if (typeof name !== "string" || !name) {
+    return "";
+  }
+  const segments = name.split("/");
+  return segments.at(-1) ?? name;
+}
+
+export function isTruthy(value) {
+  return value === true || value === "true";
+}
+
+export function effectiveOpencodeApiKey(storedKey) {
+  if (!storedKey) {
+    return "";
+  }
+  if (storedKey === OPENCODE_API_KEY_ENV_REF) {
+    return process.env.FIREWORKS_API_KEY ?? "";
+  }
+  return storedKey;
+}
+
+function isFireworksKey(key) {
+  return typeof key === "string" && (key.startsWith("fw_") || key.startsWith("fpk_"));
+}
+
+async function resolveClaudeFireworksKey({ settingsPath, dataDir }) {
+  const settings = settingsPath ? await readJsonIfExists(settingsPath) : {};
+  const state = dataDir ? await readJsonIfExists(providerStatePath(dataDir)) : {};
+  const env = settings.env ?? {};
+  if (isFireworksKey(env.ANTHROPIC_API_KEY)) {
+    return env.ANTHROPIC_API_KEY.trim();
+  }
+  if (isFireworksKey(env.ANTHROPIC_AUTH_TOKEN)) {
+    return env.ANTHROPIC_AUTH_TOKEN.trim();
+  }
+  if (isFireworksKey(state.fireworksApiKey)) {
+    return state.fireworksApiKey.trim();
+  }
+  return "";
+}
+
+async function resolveOpencodeFireworksKey({ configPath }) {
+  if (!configPath) {
+    return "";
+  }
+  const config = await readJsonIfExists(configPath);
+  const opencodeKey = effectiveOpencodeApiKey(config.provider?.fireworks?.options?.apiKey ?? "");
+  if (isFireworksKey(opencodeKey)) {
+    return opencodeKey.trim();
+  }
+  return "";
+}
+
+const HARNESS_KEY_RESOLVERS = {
+  [HARNESS.CLAUDE]: resolveClaudeFireworksKey,
+  [HARNESS.OPENCODE]: resolveOpencodeFireworksKey,
+};
+
+export async function resolveFireworksApiKey({
+  apiKey = "",
+  harness = "",
+  settingsPath = "",
+  dataDir = "",
+  configPath = "",
+}) {
+  if (apiKey) {
+    return apiKey.trim();
+  }
+
+  if (process.env.FIREWORKS_API_KEY) {
+    return process.env.FIREWORKS_API_KEY.trim();
+  }
+
+  const resolveKey = HARNESS_KEY_RESOLVERS[harness];
+  if (!resolveKey) {
+    return "";
+  }
+
+  return resolveKey({ settingsPath, dataDir, configPath });
+}
+
+async function fetchGatewayPage(path, apiKey) {
+  const response = await fetch(`${FIREWORKS_GATEWAY_URL}${path}`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    const detail = body ? `: ${body.slice(0, 200)}` : "";
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `Fireworks API rejected the API key (${response.status}). `
+        + "Check FIREWORKS_API_KEY and ensure the key can access account model listings.",
+      );
+    }
+    throw new Error(`Fireworks API ${response.status} ${response.statusText}${detail}`);
+  }
+
+  return response.json();
+}
+
+async function fetchAllPages(path, apiKey, collectionKey) {
+  const items = [];
+  let pageToken = "";
+
+  do {
+    const separator = path.includes("?") ? "&" : "?";
+    const tokenQuery = pageToken ? `${separator}pageToken=${encodeURIComponent(pageToken)}` : "";
+    const page = await fetchGatewayPage(`${path}${tokenQuery}`, apiKey);
+    items.push(...(page[collectionKey] ?? []));
+    pageToken = page.nextPageToken ?? "";
+  } while (pageToken);
+
+  return items;
+}
+
+function normalizeModelEntry(model) {
+  const supportsServerless = isTruthy(model.supportsServerless ?? model.supports_serverless);
+  if (!supportsServerless) {
+    return null;
+  }
+
+  const name = model.name ?? "";
+  if (!name.includes("/models/")) {
+    return null;
+  }
+
+  return {
+    id: name,
+    shortId: shortIdFromResourceName(name),
+    displayName: model.displayName ?? model.display_name ?? shortIdFromResourceName(name),
+    kind: KIND_SERVERLESS,
+  };
+}
+
+function dedupeCatalog(entries) {
+  const byId = new Map();
+  for (const entry of entries) {
+    if (entry?.id) {
+      byId.set(entry.id, entry);
+    }
+  }
+  return [...byId.values()].sort((a, b) => a.shortId.localeCompare(b.shortId));
+}
+
+export async function fetchServerlessCatalog(apiKey) {
+  const models = await fetchAllPages(
+    `/v1/accounts/${PLATFORM_ACCOUNT_ID}/models?filter=${encodeURIComponent("supports_serverless=true")}&pageSize=200`,
+    apiKey,
+    "models",
+  );
+
+  const modelEntries = models.map(normalizeModelEntry).filter(Boolean);
+
+  return {
+    catalog: dedupeCatalog([...modelEntries, ...BUILTIN_ROUTERS]),
+    routersUnavailable: false,
+  };
+}
+
+export function filterCatalogForKeyType(catalog, keyType) {
+  if (keyType !== "firepass") {
+    return catalog;
+  }
+  return catalog.filter((entry) => entry.id === FIREPASS_ROUTER_ID);
+}
+
+export function filterCatalogBySearch(catalog, search = "") {
+  const query = search.trim().toLowerCase();
+  if (!query) {
+    return catalog;
+  }
+
+  return catalog.filter((entry) => (
+    entry.shortId.toLowerCase().includes(query)
+    || entry.displayName.toLowerCase().includes(query)
+    || entry.id.toLowerCase().includes(query)
+  ));
+}
+
+export async function loadServerlessCatalog({
+  apiKey,
+  harness = "",
+  settingsPath = "",
+  dataDir = "",
+  configPath = "",
+  keyType = "",
+}) {
+  const resolvedKey = await resolveFireworksApiKey({ apiKey, harness, settingsPath, dataDir, configPath });
+  if (!resolvedKey) {
+    throw new Error("No Fireworks API key found. Pass --api-key or set FIREWORKS_API_KEY.");
+  }
+
+  const resolvedKeyType = keyType || detectApiKeyType(resolvedKey);
+
+  // Fire Pass keys cannot list the account catalog, so return the known
+  // Fire Pass router directly without hitting the API.
+  if (resolvedKeyType === "firepass") {
+    return {
+      apiKey: resolvedKey,
+      keyType: resolvedKeyType,
+      catalog: filterCatalogForKeyType(BUILTIN_ROUTERS, "firepass"),
+      routersUnavailable: false,
+    };
+  }
+
+  const { catalog, routersUnavailable } = await fetchServerlessCatalog(resolvedKey);
+  const filteredCatalog = filterCatalogForKeyType(catalog, resolvedKeyType);
+
+  return {
+    apiKey: resolvedKey,
+    keyType: resolvedKeyType,
+    catalog: filteredCatalog,
+    routersUnavailable,
+  };
+}

--- a/packages/setup-cli/lib/harness.mjs
+++ b/packages/setup-cli/lib/harness.mjs
@@ -1,0 +1,17 @@
+/** @typedef {"claude" | "opencode"} HarnessId */
+
+export const HARNESS = Object.freeze({
+  CLAUDE: "claude",
+  OPENCODE: "opencode",
+});
+
+export const HARNESSES = Object.freeze(Object.values(HARNESS));
+
+export const DEFAULT_HARNESS = HARNESS.CLAUDE;
+
+export function parseHarness(value) {
+  if (!HARNESSES.includes(value)) {
+    throw new Error(`--harness must be one of: ${HARNESSES.join(", ")}, got: ${value}`);
+  }
+  return value;
+}

--- a/packages/setup-cli/lib/model-list.mjs
+++ b/packages/setup-cli/lib/model-list.mjs
@@ -1,0 +1,53 @@
+import {
+  filterCatalogBySearch,
+  loadServerlessCatalog,
+} from "./fireworks-models.mjs";
+
+function formatTable(catalog) {
+  const idWidth = Math.max(8, ...catalog.map((entry) => entry.shortId.length));
+  const nameWidth = Math.max(12, ...catalog.map((entry) => entry.displayName.length));
+
+  const header = `${"ID".padEnd(idWidth)}  ${"NAME".padEnd(nameWidth)}  KIND`;
+  const lines = catalog.map((entry) => (
+    `${entry.shortId.padEnd(idWidth)}  ${entry.displayName.padEnd(nameWidth)}  ${entry.kind}`
+  ));
+
+  return [header, ...lines].join("\n");
+}
+
+export async function runModelListCommand({ options, settingsPath, dataDir, configPath }) {
+  const { catalog, keyType } = await loadServerlessCatalog({
+    apiKey: options.apiKey,
+    harness: options.harness,
+    settingsPath,
+    dataDir,
+    configPath,
+  });
+
+  const filtered = filterCatalogBySearch(catalog, options.search);
+
+  if (options.json) {
+    console.log(JSON.stringify({
+      keyType,
+      count: filtered.length,
+      models: filtered,
+    }, null, 2));
+    return;
+  }
+
+  if (keyType === "firepass") {
+    console.log("Fire Pass key: showing the kimi-k2p7-code-fast serverless router only.");
+    console.log("");
+  }
+
+  if (filtered.length === 0) {
+    console.log("No serverless models matched your query.");
+    return;
+  }
+
+  console.log(formatTable(filtered));
+  console.log("");
+  console.log(`Showing ${filtered.length} serverless endpoint${filtered.length === 1 ? "" : "s"}.`);
+  console.log("Pick interactively: fireconnect model select");
+  console.log("OpenCode:           fireconnect model select --harness opencode");
+}

--- a/packages/setup-cli/lib/model-select.mjs
+++ b/packages/setup-cli/lib/model-select.mjs
@@ -1,0 +1,276 @@
+import readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import {
+  applyModelMapping,
+  detectApiKeyType,
+  mappingFromEnv,
+  normalizeModelId,
+  providerStatusFromEnv,
+  readJsonIfExists,
+  resolveModelMapping,
+} from "./fireconnect-core.mjs";
+import {
+  OPENCODE_API_KEY_ENV_REF,
+  enableOpencodeFireworks,
+  opencodeProviderStatus,
+} from "./opencode-core.mjs";
+import {
+  effectiveOpencodeApiKey,
+  filterCatalogBySearch,
+  loadServerlessCatalog,
+} from "./fireworks-models.mjs";
+import { DEFAULT_HARNESS, HARNESS } from "./harness.mjs";
+
+export const CLAUDE_CODE_SLOTS = [
+  { key: "main", label: "main (primary conversation model)" },
+  { key: "opus", label: "opus" },
+  { key: "sonnet", label: "sonnet" },
+  { key: "haiku", label: "haiku" },
+  { key: "subagent", label: "subagent" },
+];
+
+function ensureInteractiveTerminal(harness) {
+  if (!input.isTTY || !output.isTTY) {
+    if (harness === HARNESS.OPENCODE) {
+      throw new Error("model select requires an interactive terminal. Use: fireconnect set --harness opencode --main <id>");
+    }
+    throw new Error("model select requires an interactive terminal. Use: fireconnect set --<slot> <id>");
+  }
+}
+
+function parseSlotChoice(value) {
+  const slot = value.trim().toLowerCase();
+  const match = CLAUDE_CODE_SLOTS.find((entry) => entry.key === slot);
+  if (!match) {
+    throw new Error(`Unknown slot: ${value}. Choose one of: ${CLAUDE_CODE_SLOTS.map((entry) => entry.key).join(", ")}`);
+  }
+  return match.key;
+}
+
+async function promptChoice(rl, question, choices) {
+  console.log(question);
+  choices.forEach((choice, index) => {
+    console.log(`  ${index + 1}) ${choice.label}`);
+  });
+  console.log("  q) Cancel");
+
+  while (true) {
+    const answer = (await rl.question("\nEnter choice: ")).trim().toLowerCase();
+    if (answer === "q" || answer === "quit") {
+      return null;
+    }
+
+    const index = Number.parseInt(answer, 10);
+    if (Number.isInteger(index) && index >= 1 && index <= choices.length) {
+      return choices[index - 1];
+    }
+
+    console.log("Invalid choice. Enter a number from the list, or q to cancel.");
+  }
+}
+
+function buildMappingForSlot({ env, slot, pickedId, keyType }) {
+  const defaults = resolveModelMapping({}, keyType);
+  const current = mappingFromEnv(env);
+
+  const mapping = {
+    main: current.main ?? defaults.main,
+    opus: current.opus ?? defaults.opus,
+    sonnet: current.sonnet ?? defaults.sonnet,
+    haiku: current.haiku ?? defaults.haiku,
+    subagent: current.subagent ?? defaults.subagent,
+  };
+
+  mapping[slot] = normalizeModelId(pickedId);
+  return mapping;
+}
+
+async function pickFromCatalog({ rl, catalog, options, promptLabel }) {
+  let workingCatalog = catalog;
+  if (options.search) {
+    workingCatalog = filterCatalogBySearch(catalog, options.search);
+  } else {
+    const searchQuery = (await rl.question("Filter models (optional, Enter for all): ")).trim();
+    workingCatalog = filterCatalogBySearch(catalog, searchQuery);
+  }
+
+  if (workingCatalog.length === 0) {
+    throw new Error("No serverless models matched your filter.");
+  }
+
+  const modelChoices = workingCatalog.map((entry) => ({
+    id: entry.id,
+    shortId: entry.shortId,
+    label: `${entry.shortId} — ${entry.displayName} (${entry.kind})`,
+  }));
+
+  const picked = await promptChoice(rl, promptLabel, modelChoices);
+  if (!picked) {
+    console.log("Cancelled.");
+    return null;
+  }
+
+  const confirm = (await rl.question(`Set model to ${picked.id}? [Y/n] `)).trim().toLowerCase();
+  if (confirm === "n" || confirm === "no") {
+    console.log("Cancelled.");
+    return null;
+  }
+
+  return picked;
+}
+
+async function runClaudeModelSelect({ options, settingsPath, dataDir, configPath }) {
+  const settings = await readJsonIfExists(settingsPath);
+  const env = settings.env ?? {};
+  if (providerStatusFromEnv(env) !== "fireworks") {
+    throw new Error("model select requires Fireworks to be enabled; run: fireconnect on");
+  }
+
+  const { catalog, keyType } = await loadServerlessCatalog({
+    apiKey: options.apiKey,
+    harness: HARNESS.CLAUDE,
+    settingsPath,
+    dataDir,
+    configPath,
+  });
+
+  const rl = readline.createInterface({ input, output });
+
+  try {
+    let slot = options.slot ? parseSlotChoice(options.slot) : null;
+    if (!slot) {
+      const slotChoices = CLAUDE_CODE_SLOTS.map((entry) => {
+        const current = mappingFromEnv(env)[entry.key];
+        const currentShort = current ? current.split("/").at(-1) : "(unset)";
+        return {
+          key: entry.key,
+          label: `${entry.label} — current: ${currentShort}`,
+        };
+      });
+      const slotChoice = await promptChoice(rl, "Which Claude Code alias do you want to update?", slotChoices);
+      if (!slotChoice) {
+        console.log("Cancelled.");
+        return;
+      }
+      slot = slotChoice.key;
+    }
+
+    const picked = await pickFromCatalog({
+      rl,
+      catalog,
+      options,
+      promptLabel: `Pick a serverless model for ${slot}:`,
+    });
+    if (!picked) {
+      return;
+    }
+
+    const resolvedKeyType = keyType || detectApiKeyType(
+      env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN || "",
+    );
+    const mapping = buildMappingForSlot({
+      env,
+      slot,
+      pickedId: picked.id,
+      keyType: resolvedKeyType,
+    });
+
+    await applyModelMapping({ settingsPath, mapping });
+    console.log(`Updated ${slot} -> ${mapping[slot]}`);
+    console.log("Restart Claude Code for full effect.");
+  } finally {
+    rl.close();
+  }
+}
+
+async function runOpencodeModelSelect({ options, configPath, dataDir, settingsPath }) {
+  if (options.slot) {
+    throw new Error("--slot is Claude Code only; OpenCode uses a single model (omit --slot)");
+  }
+
+  const config = await readJsonIfExists(configPath);
+  if (opencodeProviderStatus(config) !== "fireworks") {
+    throw new Error("model select requires Fireworks to be enabled; run: fireconnect on --harness opencode");
+  }
+
+  const existingKey = config.provider?.fireworks?.options?.apiKey ?? "";
+  const effectiveKey = effectiveOpencodeApiKey(existingKey) || options.apiKey;
+  const keyType = detectApiKeyType(effectiveKey);
+
+  const { catalog } = await loadServerlessCatalog({
+    apiKey: options.apiKey || effectiveKey,
+    harness: HARNESS.OPENCODE,
+    settingsPath,
+    dataDir: "",
+    configPath,
+    keyType,
+  });
+
+  const currentModel = typeof config.model === "string" && config.model.startsWith("fireworks/")
+    ? config.model.slice("fireworks/".length).split("/").at(-1)
+    : "(unset)";
+
+  const rl = readline.createInterface({ input, output });
+
+  try {
+    console.log(`Current OpenCode model: ${currentModel}`);
+
+    const picked = await pickFromCatalog({
+      rl,
+      catalog,
+      options,
+      promptLabel: "Pick a serverless model for OpenCode:",
+    });
+    if (!picked) {
+      return;
+    }
+
+    // Preserve the existing key mode: explicit --api-key or a literal key stored in
+    // config should be written back literally; an env reference (or no existing key)
+    // should keep using the env reference so the secret stays out of the file.
+    const apiKey = options.apiKeyFromFlag ? options.apiKey : (existingKey || options.apiKey);
+    const existingKeyIsLiteral = Boolean(existingKey) && existingKey !== OPENCODE_API_KEY_ENV_REF;
+
+    const result = await enableOpencodeFireworks({
+      configPath,
+      dataDir,
+      apiKey,
+      apiKeyFromFlag: options.apiKeyFromFlag || existingKeyIsLiteral,
+      modelId: picked.shortId,
+      keyType,
+    });
+
+    console.log(`Updated OpenCode model: ${result.model}`);
+    console.log("Restart OpenCode for full effect.");
+  } finally {
+    rl.close();
+  }
+}
+
+export async function runModelSelectCommand({
+  options,
+  harness = DEFAULT_HARNESS,
+  settingsPath = "",
+  dataDir = "",
+  configPath = "",
+  opencodeDataDir = "",
+}) {
+  ensureInteractiveTerminal(harness);
+
+  if (harness === HARNESS.OPENCODE) {
+    await runOpencodeModelSelect({
+      options,
+      configPath,
+      dataDir: opencodeDataDir,
+      settingsPath,
+    });
+    return;
+  }
+
+  await runClaudeModelSelect({
+    options,
+    settingsPath,
+    dataDir,
+    configPath,
+  });
+}

--- a/packages/setup-cli/lib/opencode-core.mjs
+++ b/packages/setup-cli/lib/opencode-core.mjs
@@ -3,6 +3,7 @@ import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import {
+  DEFAULT_FIREPASS_MAIN_MODEL,
   DEFAULT_MAIN_MODEL,
   detectApiKeyType,
   normalizeModelId,
@@ -119,7 +120,7 @@ export async function enableOpencodeFireworks({
   // default to that router so the user gets a working config out of the box.
   let effectiveModelId = modelId;
   if (resolvedKeyType === "firepass" && !modelId) {
-    effectiveModelId = DEFAULT_MAIN_MODEL;
+    effectiveModelId = DEFAULT_FIREPASS_MAIN_MODEL;
   }
 
   const resolvedModel = normalizeModelId(effectiveModelId || currentModelId || DEFAULT_MAIN_MODEL);


### PR DESCRIPTION
## Summary

Squashed release of all changes since the initial public release, synced from `fireconnect-internal/main`.

### What's included

- **Standalone FireConnect CLI** with `install.sh` and a PATH launcher (`fireconnect`)
- **Model commands**: `fireconnect model list` and `fireconnect model select`
- **OpenCode harness support** via `--harness opencode`
- **Default routing to Kimi K2.7 Code Fast**
- **Fire Pass key auto-detection** — Fire Pass keys now default to `kimi-k2p7-code-fast` for all aliases
- **Hardcoded routers**; removes the 403-prone model catalog fetch
- **1M Claude Code context** for `deepseek-v4-pro`
- **`fireconnect uninstall`** and restore/rollback safeguards
- CI hardening and daily smoke tests

### Bugbot follow-ups (fixed in internal #37)

- Correct Fire Pass model list message and user-facing default references
- OpenCode `list` now resolves the configured key type before picking defaults
- `fireconnect model list` without `--harness` now checks both Claude Code and OpenCode key sources

### Files changed

- `README.md`
- `packages/setup-cli/bin/fireconnect.mjs`
- `packages/setup-cli/lib/claude-code-context.mjs`
- `packages/setup-cli/lib/fireconnect-core.mjs`
- `packages/setup-cli/lib/fireworks-models.mjs`
- `packages/setup-cli/lib/harness.mjs`
- `packages/setup-cli/lib/model-list.mjs`
- `packages/setup-cli/lib/model-select.mjs`
- `packages/setup-cli/lib/opencode-core.mjs`

### Version bump

`packages/setup-cli/package.json` version should be bumped from `0.2.0` to `0.3.0` before or after merging.

### Test plan

- [ ] Run `fireconnect on`, `fireconnect status`, `fireconnect off` for Claude Code
- [ ] Run `fireconnect model list` and `fireconnect model select`
- [ ] Run `fireconnect on --harness opencode` and verify OpenCode config
- [ ] Verify Fire Pass key (`fpk_...`) auto-detects and defaults to `kimi-k2p7-code-fast`
- [ ] Verify `fireconnect model list` without `--harness` finds an OpenCode-stored key
- [ ] Bump version and tag release