### PR TITLE
fix: Fire Pass default, key resolution, and tests follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/fw-ai/fireconnect/main/install.sh |
 ```
 
 Fire Pass users can use a `fpk_...` key directly — FireConnect detects the key type and
-uses the correct defaults for Fire Pass (kimi-k2p6-turbo for all aliases).
+uses the correct defaults for Fire Pass (kimi-k2p7-code-fast for all aliases).
 
 If you prefer installing from an SSH checkout:
 
@@ -133,7 +133,7 @@ default both sources are checked, but non-Fireworks-shaped keys (for example, an
 `sk-ant-...` token) are skipped. Use `--harness opencode` to force the OpenCode key source, or
 `--harness claude` to force the Claude Code source.
 
-Fire Pass keys (`fpk_...`) only show the `kimi-k2p6-turbo` router.
+Fire Pass keys (`fpk_...`) only show the `kimi-k2p7-code-fast` router.
 
 ### `fireconnect model select`
 

--- a/packages/setup-cli/bin/fireconnect.mjs
+++ b/packages/setup-cli/bin/fireconnect.mjs
@@ -11,6 +11,8 @@ import {
   detectApiKeyType,
   disableFireworksProvider,
   enableFireworksProvider,
+  claudeFireworksKeyFrom,
+  resolveClaudeToken,
   isSafeDataDirRemoval,
   mappingFromEnv,
   providerStatePath,
@@ -40,9 +42,9 @@ function parseArgs(argv) {
     home: process.env.HOME ?? "",
     settingsPath: "",
     configPath: "",
-    harness: DEFAULT_HARNESS,
+    harness: "",
     dataDir: "",
-    apiKey: process.env.FIREWORKS_API_KEY ?? "",
+    apiKey: "",
     apiKeyFromFlag: false,
     baseUrl: FIREWORKS_BASE_URL,
     main: "",
@@ -288,11 +290,17 @@ async function opencodeListCommand(options) {
     ? config.model.slice("fireworks/".length)
     : null;
 
+  const existingKey = config.provider?.fireworks?.options?.apiKey ?? "";
+  const effectiveKey = existingKey === OPENCODE_API_KEY_ENV_REF
+    ? (process.env.FIREWORKS_API_KEY ?? "")
+    : existingKey;
+  const keyType = detectApiKeyType(effectiveKey || (options.apiKeyFromFlag ? options.apiKey : ""));
+
   // OpenCode routes a single default model (no opus/sonnet/haiku alias slots),
   // so the mapping has one entry — same defaults/current shape as Claude Code.
   const payload = {
     harness: HARNESS.OPENCODE,
-    defaults: { main: defaultModelIds().main },
+    defaults: { main: defaultModelIds(keyType).main },
     current: { main: model },
     provider: opencodeProviderStatus(config),
   };
@@ -321,7 +329,7 @@ async function listCommand(options) {
   const settings = await readJsonIfExists(settingsPath);
   const state = await readJsonIfExists(providerStatePath(dataDir));
   const env = settings.env ?? {};
-  const token = env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN || state.fireworksApiKey || "";
+  const token = claudeFireworksKeyFrom({ env, state });
   const keyType = detectApiKeyType(token);
 
   const payload = {
@@ -348,7 +356,7 @@ async function listCommand(options) {
 
   console.log(`Current provider: ${payload.provider}`);
   if (keyType === "firepass") {
-    console.log("Key type: Fire Pass (kimi-k2p6-turbo only)");
+    console.log("Key type: Fire Pass (kimi-k2p7-code-fast only)");
   }
   console.log("Current mapping:");
   console.log(`  main     -> ${payload.current.main ?? "(unset)"}`);
@@ -449,7 +457,7 @@ async function setCommand(options, commandName = "set") {
   const settings = await readJsonIfExists(settingsPath);
   const state = await readJsonIfExists(providerStatePath(dataDir));
   const env = settings.env ?? {};
-  const token = options.apiKey || env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN || state.fireworksApiKey || "";
+  const token = resolveClaudeToken(options, { env, state });
   const keyType = detectApiKeyType(token);
   await applyModelMapping({
     settingsPath,
@@ -477,6 +485,9 @@ async function onCommand(options) {
         reusedExistingKey = true;
       }
     }
+    if (!apiKey) {
+      apiKey = process.env.FIREWORKS_API_KEY ?? "";
+    }
     // Resolve env-ref placeholder to the real key before detecting type.
     const effectiveApiKey = apiKey === OPENCODE_API_KEY_ENV_REF
       ? (process.env.FIREWORKS_API_KEY ?? "")
@@ -499,7 +510,7 @@ async function onCommand(options) {
       console.log("API key written into opencode.json (passed via --api-key).");
     }
     if (result.keyType === "firepass") {
-      console.log("Fire Pass key detected: using kimi-k2p6-turbo for all aliases.");
+      console.log("Fire Pass key detected: using kimi-k2p7-code-fast for all aliases.");
     } else {
       console.log("Browse models: fireconnect model list");
       console.log("Pick a model:  fireconnect model select --harness opencode");
@@ -513,19 +524,19 @@ async function onCommand(options) {
   const settings = await readJsonIfExists(settingsPath);
   const state = await readJsonIfExists(providerStatePath(dataDir));
   const env = settings.env ?? {};
-  const token = options.apiKey || env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN || state.fireworksApiKey || "";
+  const token = resolveClaudeToken(options, { env, state });
   const keyType = detectApiKeyType(token);
   await enableFireworksProvider({
     settingsPath,
     dataDir,
-    apiKey: options.apiKey,
+    apiKey: options.apiKeyFromFlag ? options.apiKey : "",
     baseUrl: options.baseUrl,
     mapping: resolveModelMapping(modelOverridesFrom(options), keyType),
     keyType,
   });
   console.log("Fireworks provider enabled. Restart Claude Code for full effect.");
   if (keyType === "firepass") {
-    console.log("Fire Pass key detected: using kimi-k2p6-turbo for all aliases.");
+    console.log("Fire Pass key detected: using kimi-k2p7-code-fast for all aliases.");
   } else {
     console.log("Browse models: fireconnect model list");
     console.log("Pick a model:  fireconnect model select");

--- a/packages/setup-cli/lib/fireconnect-core.mjs
+++ b/packages/setup-cli/lib/fireconnect-core.mjs
@@ -12,7 +12,7 @@ export { CLAUDE_CODE_1M_CONTEXT_MODELS } from "./claude-code-context.mjs";
 
 export const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference";
 export const DEFAULT_OPUS_MODEL = "kimi-k2p7-code-fast";
-export const DEFAULT_FIREPASS_MAIN_MODEL = "kimi-k2p6-turbo";
+export const DEFAULT_FIREPASS_MAIN_MODEL = "kimi-k2p7-code-fast";
 export const DEFAULT_SONNET_MODEL = "glm-5p1";
 export const DEFAULT_HAIKU_MODEL = "minimax-m2p5";
 export const DEFAULT_MAIN_MODEL = DEFAULT_OPUS_MODEL;
@@ -62,13 +62,13 @@ export const DEFAULT_FIREWORKS_PRESET = {
 
 export const DEFAULT_FIREPASS_PRESET = {
   ...DEFAULT_FIREWORKS_PRESET,
-  ANTHROPIC_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
-  ANTHROPIC_DEFAULT_OPUS_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
-  ANTHROPIC_DEFAULT_SONNET_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
-  ANTHROPIC_DEFAULT_HAIKU_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
-  CLAUDE_CODE_SUBAGENT_MODEL: "accounts/fireworks/routers/kimi-k2p6-turbo",
-  ANTHROPIC_CUSTOM_MODEL_OPTION: "accounts/fireworks/routers/kimi-k2p6-turbo",
-  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "Kimi K2.6 Turbo via Fireworks",
+  ANTHROPIC_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  ANTHROPIC_DEFAULT_OPUS_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  ANTHROPIC_DEFAULT_SONNET_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  CLAUDE_CODE_SUBAGENT_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  ANTHROPIC_CUSTOM_MODEL_OPTION: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "Kimi K2.7 Code Fast via Fireworks",
 };
 
 export async function readJsonIfExists(filePath) {
@@ -258,6 +258,27 @@ export function isFireworksModelId(model) {
   return typeof model === "string" && model.startsWith("accounts/fireworks/");
 }
 
+export function isFireworksShapedKey(key) {
+  return typeof key === "string" && (key.startsWith("fw_") || key.startsWith("fpk_"));
+}
+
+export function fireworksKeyOrEmpty(key) {
+  return isFireworksShapedKey(key) ? key.trim() : "";
+}
+
+export function claudeFireworksKeyFrom({ env = {}, state = {} } = {}) {
+  return fireworksKeyOrEmpty(env.ANTHROPIC_API_KEY)
+    || fireworksKeyOrEmpty(env.ANTHROPIC_AUTH_TOKEN)
+    || fireworksKeyOrEmpty(state.fireworksApiKey);
+}
+
+export function resolveClaudeToken({ apiKeyFromFlag, apiKey }, { env, state }) {
+  if (apiKeyFromFlag) {
+    return apiKey;
+  }
+  return claudeFireworksKeyFrom({ env, state }) || process.env.FIREWORKS_API_KEY || "";
+}
+
 /** Detect whether a key is a Fire Pass subscription key (fpk_...) or a
  *  standard Fireworks API key (fw_...). Returns "firepass" or "fireworks". */
 export function detectApiKeyType(key) {
@@ -357,7 +378,7 @@ export async function enableFireworksProvider({
     }
   }
 
-  const token = apiKey || env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN || state.fireworksApiKey;
+  const token = apiKey || claudeFireworksKeyFrom({ env, state }) || process.env.FIREWORKS_API_KEY || "";
   if (!token) {
     throw new Error("No Fireworks API key found. Pass --api-key or set FIREWORKS_API_KEY.");
   }

--- a/packages/setup-cli/lib/fireworks-models.mjs
+++ b/packages/setup-cli/lib/fireworks-models.mjs
@@ -1,5 +1,7 @@
 import {
+  claudeFireworksKeyFrom,
   detectApiKeyType,
+  fireworksKeyOrEmpty,
   providerStatePath,
   readJsonIfExists,
 } from "./fireconnect-core.mjs";
@@ -9,7 +11,7 @@ import { OPENCODE_API_KEY_ENV_REF } from "./opencode-core.mjs";
 export const FIREWORKS_GATEWAY_URL = "https://api.fireworks.ai";
 export const PLATFORM_ACCOUNT_ID = "fireworks";
 export const KIND_SERVERLESS = "serverless";
-export const FIREPASS_ROUTER_ID = "accounts/fireworks/routers/kimi-k2p6-turbo";
+export const FIREPASS_ROUTER_ID = "accounts/fireworks/routers/kimi-k2p7-code-fast";
 
 const BUILTIN_ROUTERS = [
   {
@@ -50,24 +52,10 @@ export function effectiveOpencodeApiKey(storedKey) {
   return storedKey;
 }
 
-function isFireworksKey(key) {
-  return typeof key === "string" && (key.startsWith("fw_") || key.startsWith("fpk_"));
-}
-
 async function resolveClaudeFireworksKey({ settingsPath, dataDir }) {
   const settings = settingsPath ? await readJsonIfExists(settingsPath) : {};
   const state = dataDir ? await readJsonIfExists(providerStatePath(dataDir)) : {};
-  const env = settings.env ?? {};
-  if (isFireworksKey(env.ANTHROPIC_API_KEY)) {
-    return env.ANTHROPIC_API_KEY.trim();
-  }
-  if (isFireworksKey(env.ANTHROPIC_AUTH_TOKEN)) {
-    return env.ANTHROPIC_AUTH_TOKEN.trim();
-  }
-  if (isFireworksKey(state.fireworksApiKey)) {
-    return state.fireworksApiKey.trim();
-  }
-  return "";
+  return claudeFireworksKeyFrom({ env: settings.env ?? {}, state });
 }
 
 async function resolveOpencodeFireworksKey({ configPath }) {
@@ -76,10 +64,7 @@ async function resolveOpencodeFireworksKey({ configPath }) {
   }
   const config = await readJsonIfExists(configPath);
   const opencodeKey = effectiveOpencodeApiKey(config.provider?.fireworks?.options?.apiKey ?? "");
-  if (isFireworksKey(opencodeKey)) {
-    return opencodeKey.trim();
-  }
-  return "";
+  return fireworksKeyOrEmpty(opencodeKey);
 }
 
 const HARNESS_KEY_RESOLVERS = {
@@ -98,16 +83,30 @@ export async function resolveFireworksApiKey({
     return apiKey.trim();
   }
 
+  if (!harness) {
+    const claudeKey = await resolveClaudeFireworksKey({ settingsPath, dataDir });
+    if (claudeKey) {
+      return claudeKey;
+    }
+    const opencodeKey = await resolveOpencodeFireworksKey({ configPath });
+    if (opencodeKey) {
+      return opencodeKey;
+    }
+  } else {
+    const resolveKey = HARNESS_KEY_RESOLVERS[harness];
+    if (resolveKey) {
+      const harnessKey = await resolveKey({ settingsPath, dataDir, configPath });
+      if (harnessKey) {
+        return harnessKey;
+      }
+    }
+  }
+
   if (process.env.FIREWORKS_API_KEY) {
     return process.env.FIREWORKS_API_KEY.trim();
   }
 
-  const resolveKey = HARNESS_KEY_RESOLVERS[harness];
-  if (!resolveKey) {
-    return "";
-  }
-
-  return resolveKey({ settingsPath, dataDir, configPath });
+  return "";
 }
 
 async function fetchGatewayPage(path, apiKey) {

--- a/packages/setup-cli/lib/harness.mjs
+++ b/packages/setup-cli/lib/harness.mjs
@@ -1,4 +1,4 @@
-/** @typedef {"claude" | "opencode"} HarnessId */
+/** @typedef {"" | "claude" | "opencode"} HarnessArg */
 
 export const HARNESS = Object.freeze({
   CLAUDE: "claude",
@@ -7,6 +7,7 @@ export const HARNESS = Object.freeze({
 
 export const HARNESSES = Object.freeze(Object.values(HARNESS));
 
+/** Default harness for commands that require a single target (e.g. model select). */
 export const DEFAULT_HARNESS = HARNESS.CLAUDE;
 
 export function parseHarness(value) {

--- a/packages/setup-cli/lib/model-list.mjs
+++ b/packages/setup-cli/lib/model-list.mjs
@@ -17,7 +17,7 @@ function formatTable(catalog) {
 
 export async function runModelListCommand({ options, settingsPath, dataDir, configPath }) {
   const { catalog, keyType } = await loadServerlessCatalog({
-    apiKey: options.apiKey,
+    apiKey: options.apiKeyFromFlag ? options.apiKey : "",
     harness: options.harness,
     settingsPath,
     dataDir,

--- a/packages/setup-cli/lib/model-select.mjs
+++ b/packages/setup-cli/lib/model-select.mjs
@@ -127,7 +127,7 @@ async function runClaudeModelSelect({ options, settingsPath, dataDir, configPath
   }
 
   const { catalog, keyType } = await loadServerlessCatalog({
-    apiKey: options.apiKey,
+    apiKey: options.apiKeyFromFlag ? options.apiKey : "",
     harness: HARNESS.CLAUDE,
     settingsPath,
     dataDir,
@@ -194,11 +194,12 @@ async function runOpencodeModelSelect({ options, configPath, dataDir, settingsPa
   }
 
   const existingKey = config.provider?.fireworks?.options?.apiKey ?? "";
-  const effectiveKey = effectiveOpencodeApiKey(existingKey) || options.apiKey;
+  const effectiveKey = effectiveOpencodeApiKey(existingKey)
+    || (options.apiKeyFromFlag ? options.apiKey : "");
   const keyType = detectApiKeyType(effectiveKey);
 
   const { catalog } = await loadServerlessCatalog({
-    apiKey: options.apiKey || effectiveKey,
+    apiKey: options.apiKeyFromFlag ? options.apiKey : effectiveKey,
     harness: HARNESS.OPENCODE,
     settingsPath,
     dataDir: "",

--- a/packages/setup-cli/lib/opencode-core.mjs
+++ b/packages/setup-cli/lib/opencode-core.mjs
@@ -116,8 +116,8 @@ export async function enableOpencodeFireworks({
     ? config.model.slice("fireworks/".length)
     : "";
 
-  // Fire Pass only covers kimi-k2p6-turbo; when no explicit model is requested,
-  // default to that router so the user gets a working config out of the box.
+  // Fire Pass defaults to the K2.7 Code Fast router; when no explicit model is
+  // requested, use that so the user gets a working config out of the box.
   let effectiveModelId = modelId;
   if (resolvedKeyType === "firepass" && !modelId) {
     effectiveModelId = DEFAULT_FIREPASS_MAIN_MODEL;

--- a/packages/setup-cli/package.json
+++ b/packages/setup-cli/package.json
@@ -13,5 +13,8 @@
   "engines": {
     "node": ">=18"
   },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
   "license": "Apache-2.0"
 }

--- a/packages/setup-cli/test/cli-commands.test.mjs
+++ b/packages/setup-cli/test/cli-commands.test.mjs
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { OPENCODE_API_KEY_ENV_REF } from "../lib/opencode-core.mjs";
+import {
+  FIREPASS_ROUTER,
+  FIREWORKS_INFERENCE_URL,
+  FPK_KEY,
+  FW_CLAUDE_KEY,
+  K2P7_FAST,
+  NO_ENV_KEY,
+  readClaudeSettings,
+  readOpencodeConfig,
+  runCli,
+  runCliJson,
+  withTempHome,
+  writeClaudeSettings,
+  writeNativeAnthropicSettings,
+  writeOpencodeConfig,
+} from "./helpers.mjs";
+
+describe("fireconnect on", () => {
+  test("fpk_ routes Claude Code to kimi-k2p7-code-fast", async () => {
+    await withTempHome("on-fpk", async (home) => {
+      const result = await runCli(["on", "--api-key", FPK_KEY], { home });
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /kimi-k2p7-code-fast/);
+
+      const { env } = await readClaudeSettings(home);
+      for (const key of [
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        "CLAUDE_CODE_SUBAGENT_MODEL",
+      ]) {
+        assert.equal(env[key], FIREPASS_ROUTER);
+      }
+    });
+  });
+
+  test("fpk_ with --harness opencode uses kimi-k2p7-code-fast", async () => {
+    await withTempHome("on-fpk-oc", async (home) => {
+      const result = await runCli(
+        ["on", "--harness", "opencode", "--api-key", FPK_KEY],
+        { home },
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const config = await readOpencodeConfig(home);
+      assert.match(config.model, /kimi-k2p7-code-fast/);
+    });
+  });
+
+  test("uses FIREWORKS_API_KEY when settings only have native Anthropic key", async () => {
+    await withTempHome("on-skant", async (home) => {
+      await writeNativeAnthropicSettings(home);
+      const result = await runCli(["on"], {
+        home,
+        env: { FIREWORKS_API_KEY: FW_CLAUDE_KEY },
+      });
+      assert.equal(result.code, 0, result.stderr);
+
+      const { env } = await readClaudeSettings(home);
+      assert.equal(env.ANTHROPIC_API_KEY, FW_CLAUDE_KEY);
+      assert.equal(env.ANTHROPIC_BASE_URL, FIREWORKS_INFERENCE_URL);
+    });
+  });
+
+  test("re-run preserves stored Fire Pass key over FIREWORKS_API_KEY env", async () => {
+    await withTempHome("reon-fpk", async (home) => {
+      await runCli(["on", "--api-key", FPK_KEY], { home });
+      const result = await runCli(["on"], {
+        home,
+        env: { FIREWORKS_API_KEY: FW_CLAUDE_KEY },
+      });
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /kimi-k2p7-code-fast/);
+
+      const { env } = await readClaudeSettings(home);
+      assert.equal(env.ANTHROPIC_API_KEY, FPK_KEY);
+    });
+  });
+});
+
+describe("fireconnect model list", () => {
+  test("Fire Pass key shows kimi-k2p7-code-fast only", async () => {
+    await withTempHome("ml-fpk", async (home) => {
+      const { json } = await runCliJson(
+        ["model", "list", "--api-key", FPK_KEY, "--json"],
+        { home, env: NO_ENV_KEY },
+      );
+      assert.equal(json.keyType, "firepass");
+      assert.equal(json.count, 1);
+      assert.equal(json.models[0].shortId, K2P7_FAST);
+    });
+  });
+
+  test("without --harness finds OpenCode-stored key", async () => {
+    await withTempHome("ml-oc", async (home) => {
+      await writeOpencodeConfig(home, FPK_KEY);
+      const { code, stderr, json, stdout } = await runCliJson(
+        ["model", "list", "--json"],
+        { home, env: NO_ENV_KEY },
+      );
+      assert.equal(code, 0, stderr);
+      assert.equal(json.keyType, "firepass");
+      assert.equal(json.models[0].shortId, K2P7_FAST);
+      assert.match(stdout, /kimi-k2p7-code-fast/);
+    });
+  });
+
+  test("without --harness prefers Claude when both keys exist", async () => {
+    await withTempHome("ml-both", async (home) => {
+      await writeClaudeSettings(home, FPK_KEY);
+      await writeOpencodeConfig(home, FW_CLAUDE_KEY);
+      const { json } = await runCliJson(
+        ["model", "list", "--json"],
+        { home, env: NO_ENV_KEY },
+      );
+      assert.equal(json.keyType, "firepass");
+    });
+  });
+
+  test("without --harness prefers stored key over FIREWORKS_API_KEY env", async () => {
+    await withTempHome("ml-env", async (home) => {
+      await writeOpencodeConfig(home, FPK_KEY);
+      const { json } = await runCliJson(
+        ["model", "list", "--json"],
+        { home, env: { FIREWORKS_API_KEY: FW_CLAUDE_KEY } },
+      );
+      assert.equal(json.keyType, "firepass");
+    });
+  });
+
+  test("--harness claude uses only Claude key source", async () => {
+    await withTempHome("ml-harness-cc", async (home) => {
+      await writeOpencodeConfig(home, FPK_KEY);
+      const missing = await runCli(
+        ["model", "list", "--harness", "claude", "--json"],
+        { home, env: NO_ENV_KEY },
+      );
+      assert.notEqual(missing.code, 0);
+      assert.match(missing.stderr, /No Fireworks API key found/);
+
+      await writeClaudeSettings(home, FPK_KEY);
+      const { json } = await runCliJson(
+        ["model", "list", "--harness", "claude", "--json"],
+        { home, env: NO_ENV_KEY },
+      );
+      assert.equal(json.keyType, "firepass");
+    });
+  });
+
+  test("text banner mentions kimi-k2p7-code-fast for Fire Pass", async () => {
+    await withTempHome("ml-banner", async (home) => {
+      const result = await runCli(
+        ["model", "list", "--api-key", FPK_KEY],
+        { home, env: NO_ENV_KEY },
+      );
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /kimi-k2p7-code-fast/);
+      assert.doesNotMatch(result.stdout, /kimi-k2p6-turbo/);
+    });
+  });
+});
+
+describe("fireconnect list", () => {
+  test("Claude Fire Pass key shows correct defaults and message", async () => {
+    await withTempHome("list-cc-fpk", async (home) => {
+      await writeClaudeSettings(home, FPK_KEY);
+      const { json } = await runCliJson(["list", "--json"], { home, env: NO_ENV_KEY });
+      assert.equal(json.defaults.main, K2P7_FAST);
+      assert.equal(json.defaults.opus, K2P7_FAST);
+
+      const text = await runCli(["list"], { home, env: NO_ENV_KEY });
+      assert.equal(text.code, 0, text.stderr);
+      assert.match(text.stdout, /kimi-k2p7-code-fast only/);
+      assert.doesNotMatch(text.stdout, /kimi-k2p6-turbo/);
+    });
+  });
+
+  test("fw_ key gets non-Fire-Pass defaults", async () => {
+    await withTempHome("list-fw", async (home) => {
+      await writeClaudeSettings(home, FW_CLAUDE_KEY);
+      const { json } = await runCliJson(["list", "--json"], { home, env: NO_ENV_KEY });
+      assert.equal(json.defaults.main, K2P7_FAST);
+      assert.equal(json.defaults.sonnet, "glm-5p1");
+      assert.equal(json.defaults.haiku, "minimax-m2p5");
+    });
+  });
+
+  test("ignores sk-ant tokens in Claude settings", async () => {
+    await withTempHome("list-skant", async (home) => {
+      await writeNativeAnthropicSettings(home);
+      const { json } = await runCliJson(["list", "--json"], { home, env: NO_ENV_KEY });
+      assert.equal(json.provider, "default");
+      assert.equal(json.defaults.sonnet, "glm-5p1");
+    });
+  });
+
+  test("--harness opencode with Fire Pass key shows kimi-k2p7-code-fast default", async () => {
+    await withTempHome("list-oc-fpk", async (home) => {
+      await writeOpencodeConfig(home, FPK_KEY);
+      const { json } = await runCliJson(
+        ["list", "--harness", "opencode", "--json"],
+        { home, env: NO_ENV_KEY },
+      );
+      assert.equal(json.defaults.main, K2P7_FAST);
+    });
+  });
+
+  test("--harness opencode resolves env-ref Fire Pass key", async () => {
+    await withTempHome("list-envref", async (home) => {
+      await writeOpencodeConfig(home, OPENCODE_API_KEY_ENV_REF);
+      const { json } = await runCliJson(
+        ["list", "--harness", "opencode", "--json"],
+        { home, env: { FIREWORKS_API_KEY: FPK_KEY } },
+      );
+      assert.equal(json.defaults.main, K2P7_FAST);
+    });
+  });
+});
+
+describe("fireconnect reset", () => {
+  test("keeps Fire Pass defaults when FIREWORKS_API_KEY env differs", async () => {
+    await withTempHome("reset-fpk", async (home) => {
+      await runCli(["on", "--api-key", FPK_KEY], { home });
+      const result = await runCli(["reset"], {
+        home,
+        env: { FIREWORKS_API_KEY: FW_CLAUDE_KEY },
+      });
+      assert.equal(result.code, 0, result.stderr);
+
+      const { env } = await readClaudeSettings(home);
+      assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, FIREPASS_ROUTER);
+      assert.equal(env.ANTHROPIC_DEFAULT_HAIKU_MODEL, FIREPASS_ROUTER);
+      assert.equal(env.CLAUDE_CODE_SUBAGENT_MODEL, FIREPASS_ROUTER);
+      assert.equal(env.ANTHROPIC_API_KEY, FPK_KEY);
+    });
+  });
+});

--- a/packages/setup-cli/test/firepass-defaults.test.mjs
+++ b/packages/setup-cli/test/firepass-defaults.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { DEFAULT_FIREPASS_PRESET } from "../lib/fireconnect-core.mjs";
+import { FIREPASS_ROUTER_ID } from "../lib/fireworks-models.mjs";
+import { FIREPASS_ROUTER } from "./helpers.mjs";
+
+describe("Fire Pass defaults", () => {
+  test("FIREPASS_ROUTER_ID is kimi-k2p7-code-fast", () => {
+    assert.equal(FIREPASS_ROUTER_ID, FIREPASS_ROUTER);
+  });
+
+  test("DEFAULT_FIREPASS_PRESET routes all aliases to kimi-k2p7-code-fast", () => {
+    const aliasKeys = [
+      "ANTHROPIC_MODEL",
+      "ANTHROPIC_DEFAULT_OPUS_MODEL",
+      "ANTHROPIC_DEFAULT_SONNET_MODEL",
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+      "CLAUDE_CODE_SUBAGENT_MODEL",
+    ];
+    for (const key of aliasKeys) {
+      assert.equal(DEFAULT_FIREPASS_PRESET[key], FIREPASS_ROUTER);
+    }
+  });
+});

--- a/packages/setup-cli/test/helpers.mjs
+++ b/packages/setup-cli/test/helpers.mjs
@@ -1,0 +1,106 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { USER_SETTINGS_RELATIVE_PATH } from "../lib/fireconnect-core.mjs";
+import { OPENCODE_CONFIG_RELATIVE_PATH } from "../lib/opencode-core.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(__dirname, "../bin/fireconnect.mjs");
+
+export const FPK_KEY = "fpk_test_firepass_key_000000000000";
+export const FW_CLAUDE_KEY = "fw_test_claude_key_00000000000000";
+export const FW_OPENCODE_KEY = "fw_test_opencode_key_00000000000";
+export const SK_ANT_KEY = "sk-ant-test-non-fireworks-token";
+
+export const K2P7_FAST = "kimi-k2p7-code-fast";
+export const FIREPASS_ROUTER = "accounts/fireworks/routers/kimi-k2p7-code-fast";
+export const FIREWORKS_INFERENCE_URL = "https://api.fireworks.ai/inference";
+
+/** Clear FIREWORKS_API_KEY in the child process (overrides the parent shell). */
+export const NO_ENV_KEY = { FIREWORKS_API_KEY: "" };
+
+export function claudePaths(home) {
+  return {
+    settingsPath: path.join(home, USER_SETTINGS_RELATIVE_PATH),
+    dataDir: path.join(home, ".fireconnect/claude"),
+  };
+}
+
+export async function withTempHome(prefix, fn) {
+  const home = await mkdtemp(path.join(os.tmpdir(), `fireconnect-${prefix}-`));
+  try {
+    return await fn(home);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+export async function runCli(args, { home, env = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: {
+        ...process.env,
+        ...env,
+        HOME: home,
+        FIREWORKS_API_KEY: env.FIREWORKS_API_KEY ?? "",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+export async function runCliJson(args, options) {
+  const result = await runCli(args, options);
+  return {
+    ...result,
+    json: result.stdout ? JSON.parse(result.stdout) : null,
+  };
+}
+
+async function writeJson(filePath, data) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(data, null, 2));
+}
+
+export async function writeClaudeSettings(home, apiKey, { fireworks = true } = {}) {
+  const settingsPath = path.join(home, USER_SETTINGS_RELATIVE_PATH);
+  const env = fireworks
+    ? { ANTHROPIC_BASE_URL: FIREWORKS_INFERENCE_URL, ANTHROPIC_API_KEY: apiKey }
+    : { ANTHROPIC_API_KEY: apiKey };
+  await writeJson(settingsPath, { env });
+  return settingsPath;
+}
+
+export async function writeNativeAnthropicSettings(home) {
+  return writeClaudeSettings(home, SK_ANT_KEY, { fireworks: false });
+}
+
+export async function writeOpencodeConfig(home, apiKey) {
+  const configPath = path.join(home, OPENCODE_CONFIG_RELATIVE_PATH);
+  await writeJson(configPath, {
+    provider: { fireworks: { options: { apiKey } } },
+    model: `fireworks/${K2P7_FAST}`,
+  });
+  return configPath;
+}
+
+export async function readClaudeSettings(home) {
+  return JSON.parse(await readFile(path.join(home, USER_SETTINGS_RELATIVE_PATH), "utf8"));
+}
+
+export async function readOpencodeConfig(home) {
+  return JSON.parse(await readFile(path.join(home, OPENCODE_CONFIG_RELATIVE_PATH), "utf8"));
+}

--- a/packages/setup-cli/test/key-resolution.test.mjs
+++ b/packages/setup-cli/test/key-resolution.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { resolveFireworksApiKey } from "../lib/fireworks-models.mjs";
+import {
+  FW_CLAUDE_KEY,
+  FW_OPENCODE_KEY,
+  claudePaths,
+  withTempHome,
+  writeClaudeSettings,
+  writeNativeAnthropicSettings,
+  writeOpencodeConfig,
+} from "./helpers.mjs";
+
+describe("resolveFireworksApiKey", () => {
+  test("without harness prefers Claude over OpenCode", async () => {
+    await withTempHome("both-keys", async (home) => {
+      const { settingsPath, dataDir } = claudePaths(home);
+      await writeClaudeSettings(home, FW_CLAUDE_KEY);
+      const configPath = await writeOpencodeConfig(home, FW_OPENCODE_KEY);
+
+      const resolved = await resolveFireworksApiKey({
+        harness: "",
+        settingsPath,
+        dataDir,
+        configPath,
+      });
+      assert.equal(resolved, FW_CLAUDE_KEY);
+    });
+  });
+
+  test("without harness falls back to OpenCode", async () => {
+    await withTempHome("oc-only", async (home) => {
+      const { settingsPath, dataDir } = claudePaths(home);
+      const configPath = await writeOpencodeConfig(home, FW_OPENCODE_KEY);
+
+      const resolved = await resolveFireworksApiKey({
+        harness: "",
+        settingsPath,
+        dataDir,
+        configPath,
+      });
+      assert.equal(resolved, FW_OPENCODE_KEY);
+    });
+  });
+
+  test("skips non-Fireworks-shaped Claude tokens", async () => {
+    await withTempHome("skip-ant", async (home) => {
+      const { settingsPath, dataDir } = claudePaths(home);
+      await writeNativeAnthropicSettings(home);
+      const configPath = await writeOpencodeConfig(home, FW_OPENCODE_KEY);
+
+      const resolved = await resolveFireworksApiKey({
+        harness: "",
+        settingsPath,
+        dataDir,
+        configPath,
+      });
+      assert.equal(resolved, FW_OPENCODE_KEY);
+    });
+  });
+
+  test("with harness opencode ignores Claude", async () => {
+    await withTempHome("harness-oc", async (home) => {
+      const { settingsPath, dataDir } = claudePaths(home);
+      await writeClaudeSettings(home, FW_CLAUDE_KEY);
+      const configPath = await writeOpencodeConfig(home, FW_OPENCODE_KEY);
+
+      const resolved = await resolveFireworksApiKey({
+        harness: "opencode",
+        settingsPath,
+        dataDir,
+        configPath,
+      });
+      assert.equal(resolved, FW_OPENCODE_KEY);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Syncs the public repo with the two commits from `fireconnect-internal/main` that were not included in the v0.3.0 release PR (#2):

- `e0ef793` — fix: correct Fire Pass model list message and key resolution for OpenCode (#37)

## What's included

- **Fire Pass default switched to `kimi-k2p7-code-fast`** for all aliases and messages
- **Stale Anthropic token fix**: Claude Code key resolution now prefers Fireworks-shaped keys (`fw_...` / `fpk_...`) over leftover Anthropic tokens before falling back to `FIREWORKS_API_KEY`
- **`fireconnect model list` without `--harness`** now checks both Claude Code and OpenCode key sources
- **OpenCode `list`** resolves the configured key type before picking defaults
- **Tests** for CLI commands, Fire Pass defaults, and key resolution
- Removed the public release workflow section from README

## Files changed

- `README.md`
- `packages/setup-cli/bin/fireconnect.mjs`
- `packages/setup-cli/lib/fireconnect-core.mjs`
- `packages/setup-cli/lib/fireworks-models.mjs`
- `packages/setup-cli/lib/harness.mjs`
- `packages/setup-cli/lib/model-list.mjs`
- `packages/setup-cli/lib/model-select.mjs`
- `packages/setup-cli/lib/opencode-core.mjs`
- `packages/setup-cli/package.json`
- `packages/setup-cli/test/cli-commands.test.mjs`
- `packages/setup-cli/test/firepass-defaults.test.mjs`
- `packages/setup-cli/test/helpers.mjs`
- `packages/setup-cli/test/key-resolution.test.mjs`

## Test plan

- [ ] `fireconnect on` with a stale Anthropic token and `FIREWORKS_API_KEY` set uses the Fireworks key
- [ ] `fireconnect model list` with a Fire Pass key shows `kimi-k2p7-code-fast`
- [ ] `fireconnect list --harness opencode` with a Fire Pass key shows `kimi-k2p7-code-fast`
- [ ] `fireconnect model list` without `--harness` finds an OpenCode-stored key
- [ ] Run `npm test` (or equivalent) in `packages/setup-cli`