### PR TITLE
release: v0.5.0 — Codex & Pi harnesses, background update notifications, GLM-latest defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/fw-ai/fireconnect/blob/main/LICENSE)
 
-> Use [Fireworks AI](https://fireworks.ai) models in Claude Code and OpenCode.
+> Use [Fireworks AI](https://fireworks.ai) models in Claude Code, OpenCode, Codex, and Pi.
 
 **Install in one line:**
 
@@ -16,7 +16,7 @@ Or with `bash` directly:
 curl -fsSL https://raw.githubusercontent.com/fw-ai/fireconnect/main/install.sh | bash
 ```
 
-Install the `fireconnect` CLI once, then use it to manage Fireworks routing for Claude Code and OpenCode. Run `fireconnect help` to see what it can do.
+Install the `fireconnect` CLI once, then use it to manage Fireworks routing for Claude Code, OpenCode, Codex, and Pi. Run `fireconnect help` to see what it can do.
 
 ## Quick Setup
 
@@ -33,7 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/fw-ai/fireconnect/main/install.sh |
 ```
 
 Fire Pass users can use a `fpk_...` key directly — FireConnect detects the key type and
-uses the correct defaults for Fire Pass (kimi-k2p7-code-fast for all aliases).
+uses the correct defaults for Fire Pass (glm-latest for all aliases).
 
 If you prefer installing from an SSH checkout:
 
@@ -57,7 +57,8 @@ hi
 Default models:
 
 ```text
-opus     -> kimi-k2p7-code-fast
+main     -> glm-latest
+opus     -> glm-latest
 sonnet   -> glm-5p1
 haiku    -> minimax-m2p5
 subagent -> minimax-m2p5
@@ -89,8 +90,8 @@ The setup writes these Claude Code settings:
     "ANTHROPIC_BASE_URL": "https://api.fireworks.ai/inference",
     "ANTHROPIC_API_KEY": "fw_YOUR_FIREWORKS_API_KEY",
     "ANTHROPIC_AUTH_TOKEN": "fw_YOUR_FIREWORKS_API_KEY",
-    "ANTHROPIC_MODEL": "accounts/fireworks/routers/kimi-k2p7-code-fast",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "accounts/fireworks/routers/kimi-k2p7-code-fast",
+    "ANTHROPIC_MODEL": "accounts/fireworks/routers/glm-latest[1m]",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "accounts/fireworks/routers/glm-latest[1m]",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "accounts/fireworks/models/glm-5p1",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "accounts/fireworks/models/minimax-m2p5",
     "CLAUDE_CODE_SUBAGENT_MODEL": "accounts/fireworks/models/minimax-m2p5"
@@ -100,7 +101,7 @@ The setup writes these Claude Code settings:
 
 The setup writes both `ANTHROPIC_API_KEY` (preferred) and `ANTHROPIC_AUTH_TOKEN` (compatibility alias) with the same Fireworks key. It saves a backup of your previous provider settings so `fireconnect claude off` can restore them.
 
-Short model IDs are accepted everywhere. For example, `kimi-k2p7-code-fast` is written to Claude Code settings as `accounts/fireworks/routers/kimi-k2p7-code-fast`.
+Short model IDs are accepted everywhere. For example, `glm-latest` is written to Claude Code settings as `accounts/fireworks/routers/glm-latest[1m]`.
 
 ## Browsing and Picking Models
 
@@ -112,13 +113,14 @@ fireconnect claude model list                 # browse callable serverless endpo
 fireconnect claude model select               # pick a model for Claude Code
 fireconnect claude model select --slot sonnet # update one Claude Code alias
 fireconnect opencode model select             # pick OpenCode's default model
+fireconnect codex model select                # pick Codex's default model
 ```
 
 ### `fireconnect <harness> model list`
 
 Harness-scoped: lists the Fireworks serverless catalog using the API key resolved from that
 harness. Fetches serverless models from the Fireworks API (`supports_serverless=true`) and merges
-the two known public platform routers (`kimi-k2p6-turbo` and `kimi-k2p7-code-fast`). Every row is
+the known public platform routers (`glm-latest`, `kimi-fast-latest`, `kimi-latest`, `kimi-k2p6-turbo`, and `kimi-k2p7-code-fast`). Every row is
 tagged `serverless` (on-demand endpoints will be added later).
 
 ```bash
@@ -131,7 +133,7 @@ Resolves the key in documented order: `--api-key`, then the harness's stored key
 `~/.fireconnect/config.json`, then `FIREWORKS_API_KEY`. Non-Fireworks-shaped keys (for example
 Anthropic `sk-ant-...`) are skipped when resolving harness-local keys.
 
-Fire Pass keys (`fpk_...`) only show the `kimi-k2p7-code-fast` router.
+Fire Pass keys (`fpk_...`) show Fire Pass-supported routers: `glm-latest`, `kimi-fast-latest`, and `kimi-k2p7-code-fast`.
 
 ### `fireconnect <harness> model select`
 
@@ -159,9 +161,31 @@ fireconnect opencode model select --search glm
 | `fireconnect claude status` | Your current provider, auth, and configured alias mapping |
 | `fireconnect claude model list` | Available serverless endpoints from the Fireworks API |
 
-After `fireconnect claude on`, `model select`, or `model reset`, model routing updates in
-`settings.json` immediately. Claude Code's `/model` picker may still show the previous model
-until you restart the app — use `fireconnect claude status` to confirm the active mapping.
+After `fireconnect claude on`, `model select`, or `model reset`, `settings.json` is updated
+immediately. To use the new model in Claude Code, run `/model` to activate it in the same
+session, start a new session, or `/exit` and resume the conversation with `claude --resume <id>`.
+
+### Recommended model slugs
+
+Short IDs are accepted everywhere and are normalized to their full paths automatically.
+
+| Short ID | Best for | Notes |
+|----------|----------|-------|
+| `glm-latest` | All-around use, agentic tasks | Default for `main` and `opus` slots. Strong reasoning, 1M context. |
+| `glm-5p1` | General use (lighter) | Default `sonnet` slot. Good balance of speed and quality. |
+| `minimax-m2p5` | Background / fast tasks | Default `haiku` and `subagent` slots. Lowest latency. |
+
+**Fire Pass keys** (`fpk_...`): all slots default to `glm-latest`.
+
+**Switching a single slot** (Claude Code only):
+
+```bash
+fireconnect claude model select --slot opus    # pick a model interactively
+fireconnect claude model select --slot sonnet  # pick general model interactively
+fireconnect claude on --sonnet glm-5p1 --haiku minimax-m2p5  # set non-interactively
+```
+
+**OpenCode and Pi** use a single default model; use `fireconnect <harness> model select` or pass `--main <slug>` to `on`.
 
 ## FireConnect CLI
 
@@ -176,7 +200,7 @@ fireconnect uninstall              Disable + restore all harnesses, then remove 
 fireconnect help                   Show help.
 ```
 
-**Per harness** (`claude`, `opencode`)
+**Per harness** (`claude`, `opencode`, `codex`, `pi`)
 
 ```text
 fireconnect <harness> on           Route the harness through Fireworks (default if no command).
@@ -188,8 +212,37 @@ fireconnect <harness> model reset  Reset models to defaults.
 fireconnect <harness> help         Show help for that harness.
 ```
 
-Run `fireconnect help` for the overview, or `fireconnect claude help` / `fireconnect opencode help`
-for everything available at the harness level.
+Run `fireconnect help` for the overview, or `fireconnect claude help` / `fireconnect opencode help` /
+`fireconnect codex help` / `fireconnect pi help` for everything available at the harness level.
+
+## Codex Harness
+
+FireConnect routes [OpenAI Codex CLI](https://developers.openai.com/codex) through Fireworks via the Responses API:
+
+```bash
+export FIREWORKS_API_KEY=fw_...
+fireconnect codex on                  # route Codex through Fireworks (~/.codex/config.toml)
+fireconnect codex on --api-key fw_... # pass key once; later model commands reuse it
+fireconnect codex status              # check current provider and model
+fireconnect codex on --main glm-5p1   # switch model (non-interactive)
+fireconnect codex model select        # switch model (interactive)
+fireconnect codex off                 # restore your original config
+```
+
+What it does:
+
+- Sets root `model_provider` / `model` for Codex 0.134+ and adds a
+  `[model_providers.fireworks-ai]` block with `wire_api = "responses"`. With `--api-key` or a
+  key from `~/.fireconnect/config.json`, FireConnect writes `experimental_bearer_token` so later
+  `model list` / `select` / `reset` work without passing the key again. With only
+  `FIREWORKS_API_KEY` in the environment, it writes `env_key = "FIREWORKS_API_KEY"` instead.
+- Snapshots your original `~/.codex/config.toml` before the first change. `fireconnect codex off`
+  restores it byte-for-byte. The snapshot lives in `~/.fireconnect/codex/`.
+- Preserves unrelated Codex settings (for example `[[mcp_servers]]`) via surgical TOML edits.
+
+After `fireconnect codex on`, `off`, `model select`, or `model reset`, `config.toml` is updated
+immediately. To use the updated routing in Codex, run `/model` to activate it in the same
+session, start a new session, or `/exit` and resume the conversation with `codex resume <id>`.
 
 ## OpenCode Harness
 
@@ -219,4 +272,29 @@ What it does:
 
 Use `--config-path <path>` to target a non-default config file (also handy for testing
 without touching your real config). See `docs/cli-design.md` for the full CLI spec.
+
+## Pi Harness
+
+FireConnect routes [Pi](https://pi.dev) through Fireworks with harness-first commands:
+
+```bash
+export FIREWORKS_API_KEY=fw_...
+fireconnect pi on                        # route Pi through Fireworks
+fireconnect pi status                    # check current provider
+fireconnect pi on --main glm-5p1         # switch model (non-interactive)
+fireconnect pi model select              # switch model (interactive)
+fireconnect pi off                     # restore your original settings and auth
+```
+
+What it does:
+
+- Sets `defaultProvider` / `defaultModel` in `~/.pi/agent/settings.json` and stores the API
+  key in `~/.pi/agent/auth.json` (`$FIREWORKS_API_KEY` when from env, literal with
+  `--api-key`). `on` applies the default model (`glm-latest`) unless you pass
+  `--main`.
+- Snapshots both files under `~/.fireconnect/pi/` before the first change. `fireconnect pi off`
+  restores them **byte-for-byte**. `auth.json` is written at mode `0600`.
+- Restart Pi after `on`, `model select`, `model reset`, or `off` when Pi is already running.
+
+Use `--settings-path <path>` to target a non-default settings file.
 

--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -10,13 +10,13 @@ fireconnect <harness> <noun> <verb>
 
 **Harness first**, then resource, then action.
 
-### Per harness (`claude`, `opencode`)
+### Per harness (`claude`, `opencode`, `codex`, `pi`)
 
 ```bash
 fireconnect claude on
 fireconnect claude off
 fireconnect claude status
-fireconnect claude on --main kimi-k2p7-code-fast
+fireconnect claude on --main glm-latest
 fireconnect claude model list
 fireconnect claude model select --slot sonnet
 fireconnect claude model reset
@@ -26,6 +26,20 @@ fireconnect opencode off
 fireconnect opencode model list
 fireconnect opencode model select
 fireconnect opencode model reset
+
+fireconnect codex on
+fireconnect codex off
+fireconnect codex model list
+fireconnect codex model select
+fireconnect codex model reset
+
+fireconnect pi on
+fireconnect pi off
+fireconnect pi status
+fireconnect pi on --main glm-latest
+fireconnect pi model list
+fireconnect pi model select
+fireconnect pi model reset
 ```
 
 Bare harness runs `on` (e.g. `fireconnect claude`).
@@ -52,6 +66,7 @@ Fireworks key is resolved from that harness's settings.
 | `fireconnect set` | `fireconnect claude on --main <id>` |
 | `fireconnect reset` | `fireconnect claude model reset` |
 | `fireconnect on --harness opencode` | `fireconnect opencode on` |
+| `fireconnect on --harness pi` | `fireconnect pi on` |
 | `fireconnect model list` | `fireconnect claude model list` / `fireconnect opencode model list` |
 | `fireconnect model select --harness opencode` | `fireconnect opencode model select` |
 | `fireconnect uninstall` (Claude only) | Off all configured harnesses, then uninstall |
@@ -72,13 +87,17 @@ Shared config at `~/.fireconnect/config.json`:
   "apiKey": "{env:FIREWORKS_API_KEY}",
   "harnesses": {
     "claude": { "enabled": true },
-    "opencode": { "enabled": false }
+    "opencode": { "enabled": false },
+    "codex": { "enabled": false },
+    "pi": { "enabled": false }
   }
 }
 ```
 
-Per-harness data dirs (`~/.fireconnect/claude`, `~/.fireconnect/opencode`) hold
-backups and harness-local metadata; on/off state lives in `config.json`.
+Per-harness data dirs (`~/.fireconnect/claude`, `~/.fireconnect/opencode`,
+`~/.fireconnect/codex`, `~/.fireconnect/pi`) hold backups and harness-local metadata; on/off state lives
+in `config.json`. Pi also writes `~/.pi/agent/settings.json` and
+`~/.pi/agent/auth.json`.
 
 ## API key resolution
 

--- a/install.sh
+++ b/install.sh
@@ -160,15 +160,15 @@ main() {
   ensure_durable_source
 
   read_api_key
-  node "${CLI}" claude on --api-key "${FIREWORKS_API_KEY}" --base-url "${BASE_URL}" >/dev/null
+  node "${CLI}" configure --api-key "${FIREWORKS_API_KEY}" --harnesses claude,opencode
   install_cli_launcher
 
   echo
-  echo "FireConnect is installed and Claude Code is routed through Fireworks."
+  echo "FireConnect is installed."
   echo
   node "${CLI}" help
   echo
-  echo "Restart Claude Code, then test with: hi"
+  echo "Enable a harness to get started: fireconnect claude on"
 }
 
 main "$@"

--- a/packages/setup-cli/bin/fireconnect.mjs
+++ b/packages/setup-cli/bin/fireconnect.mjs
@@ -3,17 +3,20 @@
 import { parseCli } from "../lib/parse-args.mjs";
 import { runGlobalCommand } from "../lib/commands/global.mjs";
 import { runHarnessCommand } from "../lib/commands/harness.mjs";
+import { checkForUpdates } from "../lib/update-notify.mjs";
 
 async function run() {
   const parsed = parseCli(process.argv.slice(2));
 
   if (parsed.kind === "global") {
     await runGlobalCommand(parsed);
+    checkForUpdates(parsed.command, parsed.ctx.home);
     return;
   }
 
   if (parsed.kind === "harness") {
     await runHarnessCommand(parsed.route, parsed.ctx);
+    checkForUpdates("harness", parsed.ctx.home);
     return;
   }
 

--- a/packages/setup-cli/lib/claude-code-context.mjs
+++ b/packages/setup-cli/lib/claude-code-context.mjs
@@ -1,5 +1,7 @@
 export const CLAUDE_CODE_1M_CONTEXT_MODELS = new Set([
   "deepseek-v4-pro",
+  "glm-5p2",
+  "glm-latest",
 ]);
 
 const CLAUDE_CODE_1M_SUFFIX = "[1m]";

--- a/packages/setup-cli/lib/claude-hints.mjs
+++ b/packages/setup-cli/lib/claude-hints.mjs
@@ -1,4 +1,6 @@
-export function printClaudeModelRoutingHint() {
-  console.log("Model routing updated in settings.json (effective immediately).");
-  console.log("Restart Claude Code to refresh the /model picker.");
+export function printClaudeModelActivationHint() {
+  console.log(
+    "To use the new model, run /model in Claude Code to activate it in the same session, "
+    + "start a new session, or /exit and resume the conversation with claude --resume <id>.",
+  );
 }

--- a/packages/setup-cli/lib/codex-core.mjs
+++ b/packages/setup-cli/lib/codex-core.mjs
@@ -1,0 +1,350 @@
+import { createHash } from "node:crypto";
+import { chmod, mkdir, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import {
+  DEFAULT_FIREPASS_MAIN_MODEL,
+  DEFAULT_MAIN_MODEL,
+  detectApiKeyType,
+  normalizeModelId,
+  readJsonIfExists,
+  writeJson,
+} from "./fireconnect-core.mjs";
+import { readRawIfExists } from "./opencode-core.mjs";
+import { parseToml } from "./codex-toml.mjs";
+import {
+  patchCodexModelRaw,
+  patchCodexProviderAuthRaw,
+  patchFireconnectRoutingRaw,
+  stripFireconnectRoutingRaw,
+} from "./codex-toml-patch.mjs";
+
+export const CODEX_CONFIG_RELATIVE_PATH = ".codex/config.toml";
+export const CODEX_DATA_RELATIVE_DIR = ".fireconnect/codex";
+export const CODEX_FIREWORKS_PROVIDER_ID = "fireworks-ai";
+export const CODEX_FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
+export const CODEX_API_KEY_ENV_REF = "{env:FIREWORKS_API_KEY}";
+export const CODEX_PROVIDER_TABLE = `model_providers.${CODEX_FIREWORKS_PROVIDER_ID}`;
+
+export function printCodexRestartHint() {
+  console.log(
+    "To use the updated routing, run /model in Codex to activate it in the same session, "
+    + "start a new session, or /exit and resume the conversation with codex resume <id>.",
+  );
+}
+
+export function codexConfigPath(home, configPath = "") {
+  return configPath || path.join(home, CODEX_CONFIG_RELATIVE_PATH);
+}
+
+export function codexDataDir(home, dataDir = "") {
+  return dataDir || path.join(home, CODEX_DATA_RELATIVE_DIR);
+}
+
+export function codexBackupPath(dataDir, configPath) {
+  const key = createHash("sha256").update(path.resolve(configPath)).digest("hex").slice(0, 16);
+  return path.join(dataDir, `config-backup.${key}.json`);
+}
+
+function emptyTomlDoc() {
+  return { root: {}, tables: {} };
+}
+
+function readTomlDoc(raw) {
+  if (!raw.trim()) {
+    return emptyTomlDoc();
+  }
+  return parseToml(raw);
+}
+
+function isFireworksModelId(model) {
+  return typeof model === "string" && model.startsWith("accounts/fireworks/");
+}
+
+function isManagedProviderTable(table) {
+  return table
+    && table.base_url === CODEX_FIREWORKS_BASE_URL
+    && (table.env_key === "FIREWORKS_API_KEY"
+      || typeof table.experimental_bearer_token === "string");
+}
+
+/**
+ * FireConnect owns routing when root model_provider/model point at our managed
+ * Fireworks provider table.
+ * @param {{ root: Record<string, unknown>, tables: Record<string, Record<string, unknown>> }} doc
+ */
+export function fireconnectManaged(doc) {
+  const providerTable = doc.tables[CODEX_PROVIDER_TABLE];
+  return doc.root.model_provider === CODEX_FIREWORKS_PROVIDER_ID
+    && isFireworksModelId(doc.root.model)
+    && isManagedProviderTable(providerTable);
+}
+
+/**
+ * @param {{ root: Record<string, unknown>, tables: Record<string, Record<string, unknown>> }} doc
+ */
+export function codexCurrentModelId(doc) {
+  if (!fireconnectManaged(doc)) {
+    return null;
+  }
+  const model = doc.root.model;
+  if (typeof model !== "string") {
+    return null;
+  }
+  if (model.startsWith("accounts/fireworks/models/")) {
+    return model.slice("accounts/fireworks/models/".length);
+  }
+  if (model.startsWith("accounts/fireworks/routers/")) {
+    return model.slice("accounts/fireworks/routers/".length);
+  }
+  return model;
+}
+
+/**
+ * @param {{ root: Record<string, unknown>, tables: Record<string, Record<string, unknown>> }} doc
+ */
+export function codexStoredAuthRef(doc) {
+  const provider = doc.tables[CODEX_PROVIDER_TABLE];
+  if (!provider || !isManagedProviderTable(provider)) {
+    return "";
+  }
+  const bearer = provider.experimental_bearer_token;
+  if (typeof bearer === "string" && bearer.trim()) {
+    return bearer.trim();
+  }
+  if (provider.env_key === "FIREWORKS_API_KEY") {
+    return CODEX_API_KEY_ENV_REF;
+  }
+  return "";
+}
+
+/**
+ * @param {string} storedRef
+ */
+export function effectiveCodexApiKey(storedRef) {
+  if (!storedRef) {
+    return "";
+  }
+  if (storedRef === CODEX_API_KEY_ENV_REF) {
+    return process.env.FIREWORKS_API_KEY?.trim() ?? "";
+  }
+  return storedRef;
+}
+
+/**
+ * @param {{ root: Record<string, unknown>, tables: Record<string, Record<string, unknown>> }} doc
+ */
+export function codexLiteralAuthFromDoc(doc) {
+  const provider = doc.tables[CODEX_PROVIDER_TABLE];
+  return typeof provider?.experimental_bearer_token === "string"
+    && provider.experimental_bearer_token.trim().length > 0;
+}
+
+/**
+ * @param {{ root: Record<string, unknown>, tables: Record<string, Record<string, unknown>> }} doc
+ */
+export function codexProviderStatus(doc) {
+  if (fireconnectManaged(doc)) {
+    return "fireworks";
+  }
+  if (doc.tables[CODEX_PROVIDER_TABLE] || doc.root.model_provider === CODEX_FIREWORKS_PROVIDER_ID) {
+    return "custom";
+  }
+  return "default";
+}
+
+/**
+ * @param {{ snapshot?: { existed: boolean, raw: string }, configPath?: string }} backup
+ * @param {string} configPath
+ * @param {string} backupPath
+ */
+function assertBackupMatchesConfig(backup, configPath, backupPath) {
+  if (backup.snapshot !== undefined
+    && backup.configPath !== undefined
+    && backup.configPath !== path.resolve(configPath)) {
+    throw new Error(
+      `Backup at ${backupPath} was taken for ${backup.configPath}, not ${configPath}; refusing to restore.`,
+    );
+  }
+}
+
+/**
+ * @param {{ snapshot?: { existed: boolean, raw: string } }} backup
+ */
+function backupContainsManagedRouting(backup) {
+  return backup.snapshot !== undefined
+    && backup.snapshot.existed
+    && backup.snapshot.raw.trim()
+    && fireconnectManaged(readTomlDoc(backup.snapshot.raw));
+}
+
+/**
+ * @param {{ snapshot: { existed: boolean, raw: string } }} backup
+ * @param {string} configPath
+ * @param {string} backupPath
+ */
+async function restoreConfigFromBackup(backup, configPath, backupPath) {
+  if (backup.snapshot.existed) {
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(configPath, backup.snapshot.raw, "utf8");
+  } else {
+    try {
+      await unlink(configPath);
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  await unlink(backupPath);
+}
+
+/**
+ * @param {string} configPath
+ * @param {string} raw
+ */
+async function stripManagedRoutingFromConfig(configPath, raw) {
+  const stripped = stripFireconnectRoutingRaw(raw, { stripRootRouting: true });
+  if (stripped !== raw) {
+    await writeFile(configPath, stripped, "utf8");
+    return true;
+  }
+  return false;
+}
+
+export async function enableCodexFireworks({
+  configPath,
+  dataDir,
+  apiKey,
+  apiKeyFromFlag = false,
+  modelId,
+  keyType = "fireworks",
+}) {
+  const effectiveApiKey = apiKey === CODEX_API_KEY_ENV_REF
+    ? (process.env.FIREWORKS_API_KEY ?? "")
+    : apiKey;
+  if (!effectiveApiKey) {
+    throw new Error("No Fireworks API key found. Pass --api-key or set FIREWORKS_API_KEY.");
+  }
+
+  const snapshot = await readRawIfExists(configPath);
+  const doc = snapshot.existed && snapshot.raw.trim()
+    ? readTomlDoc(snapshot.raw)
+    : emptyTomlDoc();
+
+  const resolvedKeyType = keyType === "fireworks" ? detectApiKeyType(effectiveApiKey) : keyType;
+
+  let effectiveModelId = modelId;
+  if (resolvedKeyType === "firepass" && !modelId) {
+    effectiveModelId = DEFAULT_FIREPASS_MAIN_MODEL;
+  }
+
+  const resolvedModel = normalizeModelId(
+    effectiveModelId || codexCurrentModelId(doc) || DEFAULT_MAIN_MODEL,
+  );
+
+  const backupPath = codexBackupPath(dataDir, configPath);
+  const hasBackup = (await readJsonIfExists(backupPath)).snapshot !== undefined;
+  // Only snapshot pre-Fireconnect config. If routing is already active but the
+  // backup file is gone, the original cannot be recovered — re-on must not
+  // snapshot the Fireworks config or off would restore routing.
+  const shouldSnapshot = !hasBackup && !fireconnectManaged(doc);
+
+  if (shouldSnapshot) {
+    await mkdir(path.dirname(backupPath), { recursive: true, mode: 0o700 });
+    await writeJson(backupPath, { configPath: path.resolve(configPath), snapshot });
+    await chmod(backupPath, 0o600);
+  }
+
+  const nextRaw = patchFireconnectRoutingRaw(snapshot.raw, {
+    providerId: CODEX_FIREWORKS_PROVIDER_ID,
+    baseUrl: CODEX_FIREWORKS_BASE_URL,
+    modelId: resolvedModel,
+    apiKey: effectiveApiKey,
+    literalAuth: apiKeyFromFlag,
+  });
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, nextRaw, "utf8");
+  // A literal bearer token can end up in config.toml when --api-key is passed.
+  // Restrict to owner-only so a permissive umask can't leak the key to other users.
+  if (apiKeyFromFlag) {
+    await chmod(configPath, 0o600);
+  }
+
+  return {
+    model: resolvedModel,
+    keyType: resolvedKeyType,
+    apiKeyMode: apiKeyFromFlag ? "literal" : "env-reference",
+  };
+}
+
+export async function disableCodexFireworks({ configPath, dataDir, wasEnabled = false }) {
+  const backupPath = codexBackupPath(dataDir, configPath);
+  const backup = await readJsonIfExists(backupPath);
+  const snapshot = await readRawIfExists(configPath);
+  const doc = snapshot.existed && snapshot.raw.trim()
+    ? readTomlDoc(snapshot.raw)
+    : emptyTomlDoc();
+  const hasBackup = backup.snapshot !== undefined;
+
+  if (!wasEnabled && !hasBackup && codexProviderStatus(doc) !== "fireworks") {
+    return "noop";
+  }
+
+  assertBackupMatchesConfig(backup, configPath, backupPath);
+
+  if (hasBackup) {
+    if (backupContainsManagedRouting(backup)) {
+      await unlink(backupPath);
+    } else {
+      await restoreConfigFromBackup(backup, configPath, backupPath);
+      return "restored";
+    }
+  }
+
+  if (!snapshot.existed) {
+    return "noop";
+  }
+
+  return (await stripManagedRoutingFromConfig(configPath, snapshot.raw))
+    ? "stripped"
+    : "noop";
+}
+
+export async function readCodexTomlIfExists(configPath) {
+  const snapshot = await readRawIfExists(configPath);
+  if (!snapshot.existed || !snapshot.raw.trim()) {
+    return { existed: false, doc: emptyTomlDoc() };
+  }
+  return { existed: true, doc: readTomlDoc(snapshot.raw) };
+}
+
+export async function updateCodexModel({
+  configPath,
+  modelId,
+  apiKey = "",
+  literalAuth = false,
+}) {
+  const snapshot = await readRawIfExists(configPath);
+  if (!snapshot.existed) {
+    throw new Error(`${configPath} does not exist; run: fireconnect codex on`);
+  }
+  const doc = readTomlDoc(snapshot.raw);
+  if (codexProviderStatus(doc) !== "fireworks") {
+    throw new Error("Codex Fireworks routing is not active; run: fireconnect codex on");
+  }
+  const resolvedModel = normalizeModelId(modelId);
+  let nextRaw = patchCodexModelRaw(snapshot.raw, resolvedModel);
+  const authKey = apiKey === CODEX_API_KEY_ENV_REF
+    ? (process.env.FIREWORKS_API_KEY ?? "")
+    : apiKey;
+  if (authKey) {
+    nextRaw = patchCodexProviderAuthRaw(nextRaw, { apiKey: authKey, literalAuth });
+  }
+  await writeFile(configPath, nextRaw, "utf8");
+  // If we just wrote a literal bearer token, restrict the file to owner-only.
+  if (authKey && literalAuth) {
+    await chmod(configPath, 0o600);
+  }
+  return { model: resolvedModel };
+}

--- a/packages/setup-cli/lib/codex-toml-patch.mjs
+++ b/packages/setup-cli/lib/codex-toml-patch.mjs
@@ -1,0 +1,187 @@
+/**
+ * Surgical edits to Codex config.toml — only touches FireConnect-owned keys/tables
+ * so array-of-tables and other non-flat TOML is preserved.
+ */
+
+const CODEX_PROVIDER_TABLE_HEADER = "[model_providers.fireworks-ai]";
+const LEGACY_PROFILE_TABLE_HEADER = "[profiles.fireconnect]";
+const LEGACY_FIRECONNECT_PROFILE_LINE = /^profile\s*=\s*["']fireconnect["']\s*$/;
+
+const ROOT_PROFILE_LINE = /^profile\s*=.+$/;
+const ROOT_MODEL_PROVIDER_LINE = /^model_provider\s*=.+$/;
+const ROOT_MODEL_LINE = /^model\s*=.+$/;
+const CODEX_BEARER_AUTH_LINE = /^experimental_bearer_token\s*=.+$/;
+const CODEX_ENV_AUTH_LINE = /^env_key\s*=.+$/;
+
+function providerAuthLines({ literal, apiKey }) {
+  if (literal && apiKey) {
+    return [
+      `experimental_bearer_token = "${apiKey}"`,
+      "requires_openai_auth = false",
+    ];
+  }
+  return [
+    'env_key = "FIREWORKS_API_KEY"',
+    "requires_openai_auth = false",
+  ];
+}
+
+function isAnyTableHeader(trimmed) {
+  return trimmed.startsWith("[") && trimmed.endsWith("]");
+}
+
+function isManagedTableHeader(trimmed) {
+  return trimmed === CODEX_PROVIDER_TABLE_HEADER || trimmed === LEGACY_PROFILE_TABLE_HEADER;
+}
+
+function ensureTrailingNewline(text) {
+  if (!text) {
+    return "";
+  }
+  return text.endsWith("\n") ? text : `${text}\n`;
+}
+
+/**
+ * @param {string} raw
+ * @param {{ stripRootRouting?: boolean }} [options]
+ */
+export function stripFireconnectRoutingRaw(raw, { stripRootRouting = false } = {}) {
+  const lines = raw.split("\n");
+  const out = [];
+  let skippingTable = false;
+  let atRoot = true;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (LEGACY_FIRECONNECT_PROFILE_LINE.test(trimmed)) {
+      continue;
+    }
+    if (atRoot && stripRootRouting) {
+      if (ROOT_PROFILE_LINE.test(trimmed)
+        || ROOT_MODEL_PROVIDER_LINE.test(trimmed)
+        || ROOT_MODEL_LINE.test(trimmed)) {
+        continue;
+      }
+    }
+    if (isAnyTableHeader(trimmed)) {
+      atRoot = false;
+    }
+    if (isManagedTableHeader(trimmed)) {
+      skippingTable = true;
+      continue;
+    }
+    if (skippingTable) {
+      if (isAnyTableHeader(trimmed)) {
+        skippingTable = false;
+        out.push(line);
+      }
+      continue;
+    }
+    out.push(line);
+  }
+
+  return ensureTrailingNewline(out.join("\n").replace(/\n+$/, "\n"));
+}
+
+/**
+ * @param {string} raw
+ * @param {{ providerId: string, baseUrl: string, modelId: string, apiKey?: string, literalAuth?: boolean }} routing
+ */
+export function patchFireconnectRoutingRaw(raw, {
+  providerId,
+  baseUrl,
+  modelId,
+  apiKey = "",
+  literalAuth = false,
+}) {
+  const base = stripFireconnectRoutingRaw(raw, { stripRootRouting: true });
+  const routingBlock = [
+    `model_provider = "${providerId}"`,
+    `model = "${modelId}"`,
+  ].join("\n");
+  const tablesBlock = [
+    CODEX_PROVIDER_TABLE_HEADER,
+    'name = "Fireworks"',
+    `base_url = "${baseUrl}"`,
+    'wire_api = "responses"',
+    ...providerAuthLines({ literal: literalAuth, apiKey }),
+  ].join("\n");
+
+  if (!base.trim()) {
+    return `${routingBlock}\n\n${tablesBlock}\n`;
+  }
+
+  const separator = base.endsWith("\n") ? "" : "\n";
+  return `${routingBlock}\n\n${base}${separator}\n${tablesBlock}\n`;
+}
+
+/**
+ * @param {string} raw
+ * @param {string} modelId
+ */
+export function patchCodexModelRaw(raw, modelId) {
+  const lines = raw.split("\n");
+  const out = [];
+  let atRoot = true;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (atRoot && /^model\s*=/.test(trimmed)) {
+      out.push(`model = "${modelId}"`);
+      continue;
+    }
+    if (isAnyTableHeader(trimmed)) {
+      atRoot = false;
+    }
+    out.push(line);
+  }
+
+  return ensureTrailingNewline(out.join("\n"));
+}
+
+/**
+ * @param {string} raw
+ * @param {{ apiKey: string, literalAuth: boolean }} auth
+ */
+export function patchCodexProviderAuthRaw(raw, { apiKey, literalAuth }) {
+  const lines = raw.split("\n");
+  const out = [];
+  let inProviderTable = false;
+  let authPatched = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === CODEX_PROVIDER_TABLE_HEADER) {
+      inProviderTable = true;
+      out.push(line);
+      continue;
+    }
+    if (inProviderTable) {
+      if (isAnyTableHeader(trimmed)) {
+        if (!authPatched) {
+          for (const authLine of providerAuthLines({ literal: literalAuth, apiKey })) {
+            out.push(authLine);
+          }
+          authPatched = true;
+        }
+        inProviderTable = false;
+        out.push(line);
+        continue;
+      }
+      if (CODEX_BEARER_AUTH_LINE.test(trimmed)
+        || CODEX_ENV_AUTH_LINE.test(trimmed)
+        || /^requires_openai_auth\s*=/.test(trimmed)) {
+        continue;
+      }
+    }
+    out.push(line);
+  }
+
+  if (inProviderTable && !authPatched) {
+    for (const authLine of providerAuthLines({ literal: literalAuth, apiKey })) {
+      out.push(authLine);
+    }
+  }
+
+  return ensureTrailingNewline(out.join("\n"));
+}

--- a/packages/setup-cli/lib/codex-toml.mjs
+++ b/packages/setup-cli/lib/codex-toml.mjs
@@ -1,0 +1,65 @@
+/**
+ * Minimal TOML parse for Codex config.toml (flat tables only).
+ * Writes use codex-toml-patch.mjs; this covers the subset FireConnect reads.
+ */
+
+function parseTomlValue(raw) {
+  const value = raw.trim();
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  if ((value.startsWith("\"") && value.endsWith("\""))
+    || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  if (/^-?\d+(\.\d+)?$/.test(value)) {
+    return Number(value);
+  }
+  return value;
+}
+
+/**
+ * @param {string} text
+ * @returns {{ root: Record<string, unknown>, tables: Record<string, Record<string, unknown>> }}
+ */
+export function parseToml(text) {
+  /** @type {Record<string, unknown>} */
+  const root = {};
+  /** @type {Record<string, Record<string, unknown>>} */
+  const tables = {};
+  let currentTable = "";
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const tableMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (tableMatch) {
+      currentTable = tableMatch[1];
+      if (!tables[currentTable]) {
+        tables[currentTable] = {};
+      }
+      continue;
+    }
+
+    const kvMatch = trimmed.match(/^([A-Za-z0-9_.-]+)\s*=\s*(.+)$/);
+    if (!kvMatch) {
+      continue;
+    }
+
+    const key = kvMatch[1];
+    const value = parseTomlValue(kvMatch[2]);
+    if (currentTable) {
+      tables[currentTable][key] = value;
+    } else {
+      root[key] = value;
+    }
+  }
+
+  return { root, tables };
+}

--- a/packages/setup-cli/lib/commands/configure.mjs
+++ b/packages/setup-cli/lib/commands/configure.mjs
@@ -63,7 +63,7 @@ export async function runConfigureCommand(ctx) {
       rl.close();
     }
   } else if (harnessIds.length === 0) {
-    throw new Error("Pass --harnesses claude,opencode or run configure in an interactive terminal");
+    throw new Error("Pass --harnesses claude,opencode,codex,pi or run configure in an interactive terminal");
   }
 
   if (apiKey) {

--- a/packages/setup-cli/lib/commands/global.mjs
+++ b/packages/setup-cli/lib/commands/global.mjs
@@ -10,6 +10,12 @@ import {
   OPENCODE_DATA_RELATIVE_DIR,
 } from "../opencode-core.mjs";
 import {
+  CODEX_DATA_RELATIVE_DIR,
+} from "../codex-core.mjs";
+import {
+  PI_DATA_RELATIVE_DIR,
+} from "../pi-core.mjs";
+import {
   discoverHarnessesForUninstall,
   globalConfigPath,
 } from "../global-config.mjs";
@@ -70,13 +76,57 @@ Options:
   --home <path>             Override HOME for config resolution.
   --config-path <path>      Explicit opencode.json path.
   --data-dir <path>         Override backup/state directory.`,
+    codex: `Usage:
+  ${CLI_NAME} codex [command] [options]
+
+Manage Fireworks routing for OpenAI Codex CLI. Bare "${CLI_NAME} codex" runs on.
+
+Commands:
+  on              Route Codex through Fireworks (default).
+  off             Restore your previous config.
+  status          Show the provider, auth, and model.
+  model list      Browse callable Fireworks serverless models.
+  model select    Interactively pick the default model.
+  model reset     Reset the model to the default.
+  help            Show this help.
+
+Options:
+  --api-key <key>           Fireworks API key (validates setup; Codex reads FIREWORKS_API_KEY).
+  --main, --model <id>      Default model (on).
+  --search <query>          Filter models (model list, model select).
+  --json                    Machine-readable output (model list, status).
+  --home <path>             Override HOME for config resolution.
+  --config-path <path>      Explicit ~/.codex/config.toml path.
+  --data-dir <path>         Override backup/state directory.`,
+    pi: `Usage:
+  ${CLI_NAME} pi [command] [options]
+
+Manage Fireworks routing for Pi. Bare "${CLI_NAME} pi" runs on.
+
+Commands:
+  on              Route Pi through Fireworks (default).
+  off             Restore your previous settings and auth.
+  status          Show the provider, auth, and model.
+  model list      Browse callable Fireworks serverless models.
+  model select    Interactively pick the default model.
+  model reset     Reset the model to the default.
+  help            Show this help.
+
+Options:
+  --api-key <key>           Fireworks API key. Defaults to FIREWORKS_API_KEY.
+  --main, --model <id>      Default model (on).
+  --search <query>          Filter models (model list, model select).
+  --json                    Machine-readable output (model list, status).
+  --home <path>             Override HOME for settings resolution.
+  --settings-path <path>    Explicit Pi settings.json path.
+  --data-dir <path>         Override backup/state directory.`,
     configure: `Usage:
   ${CLI_NAME} configure [options]
 
 Register which harnesses you use and store API key preferences.
 
 Options:
-  --harnesses <ids>         Comma-separated harness ids (e.g. claude,opencode).
+  --harnesses <ids>         Comma-separated harness ids (e.g. claude,opencode,codex,pi).
   --api-key <key>           Fireworks API key.
   --api-key-mode <mode>     env or literal.
   --home <path>             Override HOME.`,
@@ -97,7 +147,7 @@ Only works when installed via the curl installer (requires git).`,
     return;
   }
 
-  console.log(`FireConnect — use Fireworks models in Claude Code and OpenCode.
+  console.log(`FireConnect — use Fireworks models in Claude Code, OpenCode, Codex, and Pi.
 
 Usage:
   ${CLI_NAME} <command> [options]
@@ -112,6 +162,8 @@ Global commands:
 Harnesses:
   claude      Claude Code (${CLI_NAME} claude on|off|...)
   opencode    OpenCode (${CLI_NAME} opencode on|off|...)
+  codex       OpenAI Codex CLI (${CLI_NAME} codex on|off|...)
+  pi          Pi (${CLI_NAME} pi on|off|...)
 
 Examples:
   # Global
@@ -129,6 +181,16 @@ Examples:
   ${CLI_NAME} opencode on
   ${CLI_NAME} opencode model list
   ${CLI_NAME} opencode model select
+
+  # Codex
+  ${CLI_NAME} codex on
+  ${CLI_NAME} codex model list
+  ${CLI_NAME} codex model select
+
+  # Pi
+  ${CLI_NAME} pi on
+  ${CLI_NAME} pi on --main glm-5p1
+  ${CLI_NAME} pi model select
 
 Run "${CLI_NAME} help <topic>" or "${CLI_NAME} <harness> help" for details.
 `);
@@ -166,6 +228,7 @@ export async function runUpgradeCommand() {
   try {
     beforeHash = execFileSync("git", ["-C", installDir, "rev-parse", "HEAD"], { stdio: "pipe", encoding: "utf8" }).trim();
   } catch { /* non-fatal */ }
+
 
   console.log("Checking for updates...");
   try {
@@ -246,6 +309,8 @@ export async function runUninstallCommand(ctx) {
   const pathsToRemove = [
     path.join(home, DEFAULT_DATA_DIR),
     path.join(home, OPENCODE_DATA_RELATIVE_DIR),
+    path.join(home, CODEX_DATA_RELATIVE_DIR),
+    path.join(home, PI_DATA_RELATIVE_DIR),
     globalConfigPath(home),
     path.join(home, ".fireconnect/cli"),
     path.join(home, ".local/bin/fireconnect"),
@@ -261,7 +326,7 @@ export async function runUninstallCommand(ctx) {
 
   const hasErrors = offErrors.length > 0 || removalFailures.length > 0;
   if (!hasErrors) {
-    console.log("FireConnect has been uninstalled. Restart any running harnesses (Claude Code, OpenCode) to fully apply.");
+    console.log("FireConnect has been uninstalled. Restart any running harnesses (Claude Code, OpenCode, Codex, Pi) to fully apply.");
   } else {
     if (removalFailures.length > 0) {
       console.error("FireConnect uninstall completed with file removal errors:");

--- a/packages/setup-cli/lib/fireconnect-core.mjs
+++ b/packages/setup-cli/lib/fireconnect-core.mjs
@@ -11,12 +11,21 @@ import {
 export { CLAUDE_CODE_1M_CONTEXT_MODELS } from "./claude-code-context.mjs";
 
 export const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference";
-export const DEFAULT_OPUS_MODEL = "kimi-k2p7-code-fast";
-export const DEFAULT_FIREPASS_MAIN_MODEL = "kimi-k2p7-code-fast";
+export const GLM_LATEST_ROUTER_ID = "accounts/fireworks/routers/glm-latest";
+export const DEFAULT_OPUS_MODEL = "glm-latest";
+export const DEFAULT_FIREPASS_MAIN_MODEL = "glm-latest";
+export const DEFAULT_MAIN_MODEL = "glm-latest";
 export const DEFAULT_SONNET_MODEL = "glm-5p1";
 export const DEFAULT_HAIKU_MODEL = "minimax-m2p5";
-export const DEFAULT_MAIN_MODEL = DEFAULT_OPUS_MODEL;
 export const DEFAULT_SUBAGENT_MODEL = DEFAULT_HAIKU_MODEL;
+
+const FIREWORKS_ROUTER_SHORT_IDS = new Set([
+  "glm-latest",
+  "kimi-fast-latest",
+  "kimi-k2p6-turbo",
+  "kimi-k2p7-code-fast",
+  "kimi-latest",
+]);
 
 export const DEFAULT_DATA_DIR = ".fireconnect/claude";
 export const USER_SETTINGS_RELATIVE_PATH = ".claude/settings.json";
@@ -47,13 +56,13 @@ export const FIREWORKS_TOP_LEVEL_KEYS = [
 ];
 
 export const DEFAULT_FIREWORKS_PRESET = {
-  ANTHROPIC_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
-  ANTHROPIC_DEFAULT_OPUS_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
+  ANTHROPIC_MODEL: GLM_LATEST_ROUTER_ID,
+  ANTHROPIC_DEFAULT_OPUS_MODEL: GLM_LATEST_ROUTER_ID,
   ANTHROPIC_DEFAULT_SONNET_MODEL: "accounts/fireworks/models/glm-5p1",
   ANTHROPIC_DEFAULT_HAIKU_MODEL: "accounts/fireworks/models/minimax-m2p5",
   CLAUDE_CODE_SUBAGENT_MODEL: "accounts/fireworks/models/minimax-m2p5",
-  ANTHROPIC_CUSTOM_MODEL_OPTION: "accounts/fireworks/routers/kimi-k2p7-code-fast",
-  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "Kimi K2.7 Code Fast via Fireworks",
+  ANTHROPIC_CUSTOM_MODEL_OPTION: GLM_LATEST_ROUTER_ID,
+  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "glm-latest via Fireworks",
   ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION: "Fireworks Anthropic-compatible open model",
   CLAUDE_CODE_DISABLE_1M_CONTEXT: "1",
   CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1",
@@ -62,13 +71,13 @@ export const DEFAULT_FIREWORKS_PRESET = {
 
 export const DEFAULT_FIREPASS_PRESET = {
   ...DEFAULT_FIREWORKS_PRESET,
-  ANTHROPIC_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
-  ANTHROPIC_DEFAULT_OPUS_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
-  ANTHROPIC_DEFAULT_SONNET_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
-  ANTHROPIC_DEFAULT_HAIKU_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
-  CLAUDE_CODE_SUBAGENT_MODEL: "accounts/fireworks/routers/kimi-k2p7-code-fast",
-  ANTHROPIC_CUSTOM_MODEL_OPTION: "accounts/fireworks/routers/kimi-k2p7-code-fast",
-  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "Kimi K2.7 Code Fast via Fireworks",
+  ANTHROPIC_MODEL: GLM_LATEST_ROUTER_ID,
+  ANTHROPIC_DEFAULT_OPUS_MODEL: GLM_LATEST_ROUTER_ID,
+  ANTHROPIC_DEFAULT_SONNET_MODEL: GLM_LATEST_ROUTER_ID,
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: GLM_LATEST_ROUTER_ID,
+  CLAUDE_CODE_SUBAGENT_MODEL: GLM_LATEST_ROUTER_ID,
+  ANTHROPIC_CUSTOM_MODEL_OPTION: GLM_LATEST_ROUTER_ID,
+  ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "glm-latest via Fireworks",
 };
 
 export async function readJsonIfExists(filePath) {
@@ -150,18 +159,15 @@ export function normalizeModelId(model) {
   if (model.includes("/")) {
     return model;
   }
-  if (model === "kimi-k2p6-turbo") {
-    return "accounts/fireworks/routers/kimi-k2p6-turbo";
-  }
-  if (model === "kimi-k2p7-code-fast") {
-    return "accounts/fireworks/routers/kimi-k2p7-code-fast";
+  if (FIREWORKS_ROUTER_SHORT_IDS.has(model)) {
+    return `accounts/fireworks/routers/${model}`;
   }
   return `accounts/fireworks/models/${model}`;
 }
 
 export function validateModelId(model, flag) {
   if (!model.startsWith("accounts/") && model.includes("/")) {
-    throw new Error(`${flag} must be a Fireworks model or router ID like kimi-k2p7-code-fast or accounts/fireworks/routers/kimi-k2p7-code-fast`);
+    throw new Error(`${flag} must be a Fireworks model ID like deepseek-v4-flash or a router ID like glm-latest`);
   }
 }
 

--- a/packages/setup-cli/lib/fireworks-models.mjs
+++ b/packages/setup-cli/lib/fireworks-models.mjs
@@ -5,9 +5,26 @@ import { OPENCODE_API_KEY_ENV_REF } from "./opencode-core.mjs";
 export const FIREWORKS_GATEWAY_URL = "https://api.fireworks.ai";
 export const PLATFORM_ACCOUNT_ID = "fireworks";
 export const KIND_SERVERLESS = "serverless";
-export const FIREPASS_ROUTER_ID = "accounts/fireworks/routers/kimi-k2p7-code-fast";
+export const FIREPASS_ROUTER_ID = "accounts/fireworks/routers/glm-latest";
+export const FIREPASS_ROUTER_IDS = new Set([
+  FIREPASS_ROUTER_ID,
+  "accounts/fireworks/routers/kimi-fast-latest",
+  "accounts/fireworks/routers/kimi-k2p7-code-fast",
+]);
 
 const BUILTIN_ROUTERS = [
+  {
+    id: "accounts/fireworks/routers/glm-latest",
+    shortId: "glm-latest",
+    displayName: "GLM Latest via Fireworks",
+    kind: KIND_SERVERLESS,
+  },
+  {
+    id: "accounts/fireworks/routers/kimi-fast-latest",
+    shortId: "kimi-fast-latest",
+    displayName: "Kimi Fast Latest via Fireworks",
+    kind: KIND_SERVERLESS,
+  },
   {
     id: "accounts/fireworks/routers/kimi-k2p6-turbo",
     shortId: "kimi-k2p6-turbo",
@@ -18,6 +35,12 @@ const BUILTIN_ROUTERS = [
     id: "accounts/fireworks/routers/kimi-k2p7-code-fast",
     shortId: "kimi-k2p7-code-fast",
     displayName: "Kimi K2.7 Code Fast via Fireworks",
+    kind: KIND_SERVERLESS,
+  },
+  {
+    id: "accounts/fireworks/routers/kimi-latest",
+    shortId: "kimi-latest",
+    displayName: "Kimi Latest via Fireworks",
     kind: KIND_SERVERLESS,
   },
 ];
@@ -177,7 +200,7 @@ export function filterCatalogForKeyType(catalog, keyType) {
   if (keyType !== "firepass") {
     return catalog;
   }
-  return catalog.filter((entry) => entry.id === FIREPASS_ROUTER_ID);
+  return catalog.filter((entry) => FIREPASS_ROUTER_IDS.has(entry.id));
 }
 
 export function filterCatalogBySearch(catalog, search = "") {

--- a/packages/setup-cli/lib/harness-context.mjs
+++ b/packages/setup-cli/lib/harness-context.mjs
@@ -3,9 +3,18 @@ import {
   userSettingsPath,
 } from "./fireconnect-core.mjs";
 import {
+  codexConfigPath,
+  codexDataDir,
+} from "./codex-core.mjs";
+import {
   opencodeConfigPath,
   opencodeDataDir,
 } from "./opencode-core.mjs";
+import {
+  piAuthPath,
+  piDataDir,
+  piSettingsPath,
+} from "./pi-core.mjs";
 
 /** @typedef {import("./harness-types.mjs").HarnessContext} HarnessContext */
 
@@ -32,6 +41,28 @@ export function opencodePathsFor(ctx) {
 /**
  * @param {HarnessContext} ctx
  */
+export function codexPathsFor(ctx) {
+  return {
+    configPath: codexConfigPath(ctx.home, ctx.configPath),
+    dataDir: codexDataDir(ctx.home, ctx.dataDir),
+  };
+}
+
+/**
+ * @param {HarnessContext} ctx
+ */
+export function piPathsFor(ctx) {
+  const settingsPath = piSettingsPath(ctx.home, ctx.settingsPath || ctx.configPath);
+  return {
+    settingsPath,
+    authPath: piAuthPath(ctx.home, "", settingsPath),
+    dataDir: piDataDir(ctx.home, ctx.dataDir),
+  };
+}
+
+/**
+ * @param {HarnessContext} ctx
+ */
 export function modelOverridesFrom(ctx) {
   return {
     main: ctx.main,
@@ -44,12 +75,18 @@ export function modelOverridesFrom(ctx) {
 
 /**
  * @param {HarnessContext} ctx
- * @param {"claude" | "opencode"} harnessId
+ * @param {"claude" | "opencode" | "codex" | "pi"} harnessId
  */
 export function ensureHomeForHarness(ctx, harnessId) {
-  if (harnessId === "opencode") {
+  if (harnessId === "opencode" || harnessId === "codex") {
     if (!ctx.configPath && !ctx.home) {
       throw new Error("HOME is not set; pass --home or --config-path");
+    }
+    return;
+  }
+  if (harnessId === "pi") {
+    if (!ctx.settingsPath && !ctx.configPath && !ctx.home) {
+      throw new Error("HOME is not set; pass --home or --settings-path");
     }
     return;
   }

--- a/packages/setup-cli/lib/harness-registry.mjs
+++ b/packages/setup-cli/lib/harness-registry.mjs
@@ -1,11 +1,13 @@
 import claude from "./harnesses/claude.mjs";
+import codex from "./harnesses/codex.mjs";
 import opencode from "./harnesses/opencode.mjs";
+import pi from "./harnesses/pi.mjs";
 import { HARNESSES } from "./harness.mjs";
 
 /** @typedef {import("./harness-types.mjs").HarnessAdapter} HarnessAdapter */
 
 const REGISTRY = new Map(
-  [claude, opencode].map((adapter) => [adapter.id, adapter]),
+  [claude, opencode, codex, pi].map((adapter) => [adapter.id, adapter]),
 );
 
 /**

--- a/packages/setup-cli/lib/harness.mjs
+++ b/packages/setup-cli/lib/harness.mjs
@@ -1,8 +1,10 @@
-/** @typedef {"" | "claude" | "opencode"} HarnessArg */
+/** @typedef {"" | "claude" | "opencode" | "codex" | "pi"} HarnessArg */
 
 export const HARNESS = Object.freeze({
   CLAUDE: "claude",
   OPENCODE: "opencode",
+  CODEX: "codex",
+  PI: "pi",
 });
 
 export const HARNESSES = Object.freeze(Object.values(HARNESS));

--- a/packages/setup-cli/lib/harnesses/claude.mjs
+++ b/packages/setup-cli/lib/harnesses/claude.mjs
@@ -14,7 +14,7 @@ import {
 import { isFireworksKey, resolveFireworksApiKey } from "../fireworks-models.mjs";
 import { runModelListCommand } from "../model-list.mjs";
 import { runClaudeModelSelect } from "../model-select.mjs";
-import { printClaudeModelRoutingHint } from "../claude-hints.mjs";
+import { printClaudeModelActivationHint } from "../claude-hints.mjs";
 import { defineHarness } from "../harness-types.mjs";
 import {
   claudePathsFor,
@@ -78,9 +78,9 @@ export default defineHarness({
     });
     await setHarnessEnabled(ctx.home, HARNESS.CLAUDE, true);
     console.log("Fireworks provider enabled.");
-    printClaudeModelRoutingHint();
+    printClaudeModelActivationHint();
     if (keyType === "firepass") {
-      console.log("Fire Pass key detected: using kimi-k2p7-code-fast for all aliases.");
+      console.log("Fire Pass key detected: using glm-latest for all aliases.");
     } else {
       console.log("Browse models: fireconnect claude model list");
       console.log("Pick a model:  fireconnect claude model select");
@@ -124,7 +124,7 @@ export default defineHarness({
     console.log(`Base URL: ${payload.baseUrl ?? "(unset)"}`);
     console.log(`Auth token present: ${payload.hasAuthToken ? "yes" : "no"}`);
     if (keyType === "firepass") {
-      console.log("Key type: Fire Pass (kimi-k2p7-code-fast only)");
+      console.log("Key type: Fire Pass (default: glm-latest)");
     }
     console.log("");
 
@@ -166,7 +166,7 @@ export default defineHarness({
     const keyType = detectApiKeyType(token);
     await applyModelMapping({ settingsPath, mapping: resolveModelMapping({}, keyType) });
     console.log("Reset Claude Code model aliases to defaults.");
-    printClaudeModelRoutingHint();
+    printClaudeModelActivationHint();
   },
 
   async modelSelect(ctx) {

--- a/packages/setup-cli/lib/harnesses/codex.mjs
+++ b/packages/setup-cli/lib/harnesses/codex.mjs
@@ -1,0 +1,249 @@
+import process from "node:process";
+import {
+  defaultModelIds,
+  detectApiKeyType,
+} from "../fireconnect-core.mjs";
+import {
+  CODEX_API_KEY_ENV_REF,
+  CODEX_FIREWORKS_BASE_URL,
+  CODEX_FIREWORKS_PROVIDER_ID,
+  codexCurrentModelId,
+  codexLiteralAuthFromDoc,
+  codexProviderStatus,
+  codexStoredAuthRef,
+  disableCodexFireworks,
+  effectiveCodexApiKey,
+  enableCodexFireworks,
+  printCodexRestartHint,
+  readCodexTomlIfExists,
+  updateCodexModel,
+} from "../codex-core.mjs";
+import {
+  FIREWORKS_API_KEY_ENV_REF,
+  isHarnessEnabled,
+  readGlobalConfig,
+  resolveStoredApiKey,
+  setHarnessEnabled,
+} from "../global-config.mjs";
+import {
+  isFireworksKey,
+} from "../fireworks-models.mjs";
+import { runModelListCommand } from "../model-list.mjs";
+import { runCodexModelSelect } from "../model-select.mjs";
+import { defineHarness } from "../harness-types.mjs";
+import {
+  codexPathsFor,
+  ensureHomeForHarness,
+} from "../harness-context.mjs";
+import { HARNESS } from "../harness.mjs";
+
+/**
+ * Harness-local Fireworks key for Codex: bearer token or env_key reference in
+ * ~/.codex/config.toml. Returns "" when none.
+ * @param {import("../harness-types.mjs").HarnessContext} ctx
+ */
+async function codexResolveKey(ctx) {
+  const { configPath } = codexPathsFor(ctx);
+  const { doc } = await readCodexTomlIfExists(configPath);
+  if (codexProviderStatus(doc) !== "fireworks") {
+    return "";
+  }
+  const key = effectiveCodexApiKey(codexStoredAuthRef(doc));
+  return isFireworksKey(key) ? key.trim() : "";
+}
+
+/**
+ * Full resolution chain for Codex model commands (flag > harness-local > global > env).
+ * Unlike `resolveFireworksApiKey`, harness-local auth in config.toml wins over env so
+ * `codex on --api-key` keeps working after FIREWORKS_API_KEY is set elsewhere.
+ * @param {import("../harness-types.mjs").HarnessContext} ctx
+ */
+async function codexApiKey(ctx) {
+  if (ctx.apiKey?.trim()) {
+    return ctx.apiKey.trim();
+  }
+
+  const harnessKey = await codexResolveKey(ctx);
+  if (harnessKey) {
+    return harnessKey;
+  }
+
+  if (ctx.home) {
+    const globalKey = resolveStoredApiKey((await readGlobalConfig(ctx.home)).apiKey);
+    if (globalKey && isFireworksKey(globalKey)) {
+      return globalKey;
+    }
+  }
+
+  return process.env.FIREWORKS_API_KEY?.trim() ?? "";
+}
+
+export default defineHarness({
+  id: HARNESS.CODEX,
+  label: "Codex",
+  resolveKey: codexResolveKey,
+
+  async on(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.CODEX);
+    const { configPath, dataDir } = codexPathsFor(ctx);
+
+    let apiKey = ctx.apiKey;
+    let apiKeyFromFlag = ctx.apiKeyFromFlag;
+    let reusedExistingKey = false;
+    if (!apiKey) {
+      const { doc } = await readCodexTomlIfExists(configPath);
+      const existingAuth = codexStoredAuthRef(doc);
+      if (existingAuth) {
+        apiKey = existingAuth;
+        apiKeyFromFlag = existingAuth !== CODEX_API_KEY_ENV_REF;
+        reusedExistingKey = true;
+      }
+    }
+
+    if (!apiKey && ctx.home) {
+      const globalConfig = await readGlobalConfig(ctx.home);
+      const storedKey = globalConfig.apiKey;
+      if (storedKey && storedKey !== FIREWORKS_API_KEY_ENV_REF) {
+        apiKey = storedKey;
+        apiKeyFromFlag = true;
+      }
+    }
+
+    if (!apiKey && process.env.FIREWORKS_API_KEY) {
+      apiKey = CODEX_API_KEY_ENV_REF;
+      apiKeyFromFlag = false;
+    }
+
+    const effectiveApiKey = apiKey === CODEX_API_KEY_ENV_REF
+      ? (process.env.FIREWORKS_API_KEY ?? "")
+      : apiKey;
+    const keyType = detectApiKeyType(effectiveApiKey);
+    if (keyType === "firepass") {
+      throw new Error(
+        "The /responses endpoint is not supported for Fire Pass keys yet. " +
+        "Use a standard Fireworks API key (fw_...).",
+      );
+    }
+    const result = await enableCodexFireworks({
+      configPath,
+      dataDir,
+      apiKey,
+      apiKeyFromFlag,
+      modelId: ctx.main,
+      keyType,
+    });
+    await setHarnessEnabled(ctx.home, HARNESS.CODEX, true);
+    console.log(`Fireworks provider enabled for Codex (model: ${result.model}).`);
+    if (reusedExistingKey) {
+      console.log("Reused the API key already configured in ~/.codex/config.toml.");
+    } else if (result.apiKeyMode === "env-reference") {
+      console.log("API key written as env_key FIREWORKS_API_KEY — keep FIREWORKS_API_KEY set in your shell.");
+    } else {
+      console.log("API key written into ~/.codex/config.toml (passed via --api-key).");
+    }
+    if (result.keyType === "firepass") {
+      console.log("Fire Pass key detected: using kimi-k2p7-code-fast for the default model.");
+    } else {
+      console.log("Browse models: fireconnect codex model list");
+      console.log("Pick a model:  fireconnect codex model select");
+    }
+    printCodexRestartHint();
+  },
+
+  async off(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.CODEX);
+    const { configPath, dataDir } = codexPathsFor(ctx);
+    const wasEnabled = await isHarnessEnabled(ctx.home, HARNESS.CODEX);
+    const outcome = await disableCodexFireworks({ configPath, dataDir, wasEnabled });
+    await setHarnessEnabled(ctx.home, HARNESS.CODEX, false);
+    if (outcome === "restored") {
+      console.log("Fireworks provider disabled for Codex; original config restored.");
+    } else if (outcome === "stripped") {
+      console.log("Fireworks provider disabled for Codex; FireConnect routing removed from config.toml.");
+    } else {
+      console.log("Fireworks provider is not active for Codex.");
+    }
+    printCodexRestartHint();
+  },
+
+  async status(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.CODEX);
+    const { configPath } = codexPathsFor(ctx);
+    const { doc } = await readCodexTomlIfExists(configPath);
+    const model = codexCurrentModelId(doc);
+    const storedAuth = codexStoredAuthRef(doc);
+    const payload = {
+      harness: HARNESS.CODEX,
+      provider: codexProviderStatus(doc),
+      baseUrl: CODEX_FIREWORKS_BASE_URL,
+      modelProvider: CODEX_FIREWORKS_PROVIDER_ID,
+      hasAuthToken: Boolean(storedAuth || process.env.FIREWORKS_API_KEY),
+      defaults: { main: defaultModelIds().main },
+      current: { main: model },
+    };
+
+    if (ctx.json) {
+      console.log(JSON.stringify(payload, null, 2));
+      return;
+    }
+
+    console.log(`Harness: ${HARNESS.CODEX}`);
+    console.log(`Provider: ${payload.provider}`);
+    console.log(`Base URL: ${payload.baseUrl}`);
+    console.log(`Model provider id: ${payload.modelProvider}`);
+    console.log(`API key configured: ${payload.hasAuthToken ? "yes" : "no"}`);
+    console.log("");
+    console.log("Default mapping:");
+    console.log(`  main -> ${payload.defaults.main}`);
+    console.log("");
+    console.log("Current mapping:");
+    console.log(`  main -> ${payload.current.main ?? "(unset)"}`);
+  },
+
+  async modelList(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.CODEX);
+    const apiKey = await codexApiKey(ctx);
+    await runModelListCommand({
+      options: ctx,
+      harness: HARNESS.CODEX,
+      apiKey,
+    });
+  },
+
+  async modelReset(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.CODEX);
+    const { configPath } = codexPathsFor(ctx);
+    const { doc } = await readCodexTomlIfExists(configPath);
+    if (codexProviderStatus(doc) !== "fireworks") {
+      throw new Error(
+        "model reset for codex requires Fireworks to be enabled; run: fireconnect codex on",
+      );
+    }
+
+    const storedAuth = codexStoredAuthRef(doc);
+    const catalogKey = await codexApiKey(ctx);
+    const keyType = detectApiKeyType(catalogKey || effectiveCodexApiKey(storedAuth));
+    const writeAuth = ctx.apiKeyFromFlag ? ctx.apiKey : storedAuth;
+    const result = await updateCodexModel({
+      configPath,
+      modelId: defaultModelIds(keyType).main,
+      apiKey: writeAuth || catalogKey,
+      literalAuth: ctx.apiKeyFromFlag || codexLiteralAuthFromDoc(doc),
+    });
+    console.log(`Reset Codex model to default: ${result.model}`);
+    printCodexRestartHint();
+  },
+
+  async modelSelect(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.CODEX);
+    const { configPath } = codexPathsFor(ctx);
+    const { doc } = await readCodexTomlIfExists(configPath);
+    const apiKey = await codexApiKey(ctx);
+    await runCodexModelSelect({
+      options: ctx,
+      configPath,
+      apiKey,
+      literalAuth: codexLiteralAuthFromDoc(doc),
+    });
+  },
+});

--- a/packages/setup-cli/lib/harnesses/opencode.mjs
+++ b/packages/setup-cli/lib/harnesses/opencode.mjs
@@ -124,7 +124,7 @@ export default defineHarness({
       console.log("API key written into opencode.json (passed via --api-key).");
     }
     if (result.keyType === "firepass") {
-      console.log("Fire Pass key detected: using kimi-k2p7-code-fast for all aliases.");
+      console.log("Fire Pass key detected: using glm-latest for all aliases.");
     } else {
       console.log("Browse models: fireconnect opencode model list");
       console.log("Pick a model:  fireconnect opencode model select");
@@ -147,12 +147,15 @@ export default defineHarness({
     const config = await readJsonIfExists(configPath);
     const fireworksAi = config.provider?.[OPENCODE_FIREWORKS_PROVIDER_ID] ?? null;
     const model = opencodeCurrentModelId(config);
+    const storedRef = opencodeStoredApiKeyRef(config);
+    const effectiveKey = effectiveOpencodeApiKey(storedRef) || process.env.FIREWORKS_API_KEY || "";
+    const keyType = detectApiKeyType(effectiveKey);
     const payload = {
       harness: HARNESS.OPENCODE,
       provider: opencodeProviderStatus(config),
       baseUrl: fireworksAi?.options?.baseURL ?? null,
-      hasAuthToken: Boolean(opencodeStoredApiKeyRef(config) || process.env.FIREWORKS_API_KEY),
-      defaults: { main: defaultModelIds().main },
+      hasAuthToken: Boolean(storedRef || process.env.FIREWORKS_API_KEY),
+      defaults: defaultModelIds(keyType),
       current: { main: model },
     };
 

--- a/packages/setup-cli/lib/harnesses/pi.mjs
+++ b/packages/setup-cli/lib/harnesses/pi.mjs
@@ -1,0 +1,221 @@
+import process from "node:process";
+import {
+  defaultModelIds,
+  detectApiKeyType,
+  readJsonIfExists,
+} from "../fireconnect-core.mjs";
+import {
+  PI_API_KEY_ENV_REF,
+  disablePiFireworks,
+  enablePiFireworks,
+  piAuthKeyMode,
+  piProviderStatus,
+  resolvePiApiKeyValue,
+} from "../pi-core.mjs";
+import {
+  FIREWORKS_API_KEY_ENV_REF,
+  readGlobalConfig,
+  setHarnessEnabled,
+} from "../global-config.mjs";
+import { isFireworksKey, resolveFireworksApiKey } from "../fireworks-models.mjs";
+import { runModelListCommand } from "../model-list.mjs";
+import { runPiModelSelect } from "../model-select.mjs";
+import { printPiRestartHint } from "../pi-hints.mjs";
+import { defineHarness } from "../harness-types.mjs";
+import {
+  ensureHomeForHarness,
+  piPathsFor,
+} from "../harness-context.mjs";
+import { HARNESS } from "../harness.mjs";
+
+function piStoredApiKeyRef(auth) {
+  return auth.fireworks?.key ?? "";
+}
+
+/**
+ * Harness-local Fireworks key for Pi: the key stored in auth.json
+ * (resolving the $FIREWORKS_API_KEY reference). Returns "" when none.
+ * @param {import("../harness-types.mjs").HarnessContext} ctx
+ */
+async function piResolveKey(ctx) {
+  const { authPath } = piPathsFor(ctx);
+  const auth = await readJsonIfExists(authPath);
+  const key = resolvePiApiKeyValue(piStoredApiKeyRef(auth));
+  return isFireworksKey(key) ? key.trim() : "";
+}
+
+/**
+ * Full resolution chain for Pi (flag > harness-local > global > env).
+ * @param {import("../harness-types.mjs").HarnessContext} ctx
+ */
+function piApiKey(ctx) {
+  return resolveFireworksApiKey({
+    apiKey: ctx.apiKey,
+    resolveKey: () => piResolveKey(ctx),
+    home: ctx.home,
+  });
+}
+
+export default defineHarness({
+  id: HARNESS.PI,
+  label: "Pi",
+  resolveKey: piResolveKey,
+
+  async on(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.PI);
+    const paths = piPathsFor(ctx);
+
+    let apiKey = ctx.apiKey;
+    let apiKeyFromFlag = ctx.apiKeyFromFlag;
+    let reusedExistingKey = false;
+    if (!apiKey) {
+      const auth = await readJsonIfExists(paths.authPath);
+      const existingKey = piStoredApiKeyRef(auth);
+      if (existingKey) {
+        apiKey = existingKey;
+        apiKeyFromFlag = true;
+        reusedExistingKey = true;
+      }
+    }
+
+    if (!apiKey && ctx.home) {
+      const globalConfig = await readGlobalConfig(ctx.home);
+      const storedKey = globalConfig.apiKey;
+      if (storedKey && storedKey !== FIREWORKS_API_KEY_ENV_REF) {
+        apiKey = storedKey;
+        apiKeyFromFlag = true;
+      }
+    }
+
+    if (!apiKey && process.env.FIREWORKS_API_KEY) {
+      apiKey = PI_API_KEY_ENV_REF;
+      apiKeyFromFlag = false;
+    }
+
+    const effectiveApiKey = apiKey === PI_API_KEY_ENV_REF
+      ? (process.env.FIREWORKS_API_KEY ?? "")
+      : apiKey;
+    const keyType = detectApiKeyType(effectiveApiKey);
+    const result = await enablePiFireworks({
+      ...paths,
+      apiKey,
+      apiKeyFromFlag,
+      modelId: ctx.main,
+      keyType,
+    });
+    await setHarnessEnabled(ctx.home, HARNESS.PI, true);
+    console.log(`Fireworks provider enabled for Pi (model: ${result.model}).`);
+    if (reusedExistingKey) {
+      console.log("Reused the API key already configured in auth.json.");
+    } else if (result.apiKeyMode === "env-reference") {
+      console.log("API key written as $FIREWORKS_API_KEY — keep FIREWORKS_API_KEY set in your shell.");
+    } else {
+      console.log("API key written into auth.json (passed via --api-key).");
+    }
+    if (result.keyType === "firepass") {
+      console.log("Fire Pass key detected: using glm-latest for all aliases.");
+    } else {
+      console.log("Browse models: fireconnect pi model list");
+      console.log("Pick a model:  fireconnect pi model select");
+    }
+    printPiRestartHint();
+  },
+
+  async off(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.PI);
+    const paths = piPathsFor(ctx);
+    const { changed } = await disablePiFireworks(paths);
+    await setHarnessEnabled(ctx.home, HARNESS.PI, false);
+    if (changed) {
+      console.log("Fireworks provider disabled for Pi; original settings and auth restored.");
+      printPiRestartHint();
+    } else {
+      console.log("FireConnect is not enabled for Pi; no changes made.");
+    }
+  },
+
+  async status(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.PI);
+    const { settingsPath, authPath } = piPathsFor(ctx);
+    const settings = await readJsonIfExists(settingsPath);
+    const auth = await readJsonIfExists(authPath);
+    const authKey = piStoredApiKeyRef(auth);
+    const keyType = detectApiKeyType(resolvePiApiKeyValue(authKey));
+    const model = typeof settings.defaultModel === "string" ? settings.defaultModel : null;
+    const currentModel = model?.startsWith("accounts/fireworks/") ? model : null;
+    const payload = {
+      harness: HARNESS.PI,
+      provider: piProviderStatus(settings),
+      hasAuthToken: Boolean(authKey || process.env.FIREWORKS_API_KEY),
+      apiKeyMode: piAuthKeyMode(authKey),
+      defaults: { main: defaultModelIds(keyType).main },
+      current: { main: currentModel },
+      defaultProvider: settings.defaultProvider ?? null,
+      model,
+    };
+
+    if (ctx.json) {
+      console.log(JSON.stringify(payload, null, 2));
+      return;
+    }
+
+    console.log(`Harness: ${HARNESS.PI}`);
+    console.log(`Provider: ${payload.provider}`);
+    console.log(`Default provider: ${payload.defaultProvider ?? "(unset)"}`);
+    console.log(`API key configured: ${payload.hasAuthToken ? "yes" : "no"}`);
+    console.log(`API key mode: ${payload.apiKeyMode}`);
+    console.log("");
+    console.log("Default mapping:");
+    console.log(`  main -> ${payload.defaults.main}`);
+    console.log("");
+    console.log("Current mapping:");
+    console.log(`  main -> ${payload.current.main ?? "(unset)"}`);
+  },
+
+  async modelList(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.PI);
+    const apiKey = await piApiKey(ctx);
+    await runModelListCommand({
+      options: ctx,
+      harness: HARNESS.PI,
+      apiKey,
+    });
+  },
+
+  async modelReset(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.PI);
+    const paths = piPathsFor(ctx);
+    const settings = await readJsonIfExists(paths.settingsPath);
+    if (piProviderStatus(settings) !== "fireworks") {
+      throw new Error(
+        "model reset for pi requires Fireworks to be enabled; run: fireconnect pi on",
+      );
+    }
+
+    const auth = await readJsonIfExists(paths.authPath);
+    const existingKey = piStoredApiKeyRef(auth);
+    const effectiveKey = resolvePiApiKeyValue(existingKey);
+    const keyType = detectApiKeyType(effectiveKey);
+
+    const result = await enablePiFireworks({
+      ...paths,
+      apiKey: existingKey,
+      apiKeyFromFlag: Boolean(existingKey),
+      modelId: defaultModelIds(keyType).main,
+      keyType,
+    });
+    console.log(`Reset Pi model to default: ${result.model}`);
+    printPiRestartHint();
+  },
+
+  async modelSelect(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.PI);
+    const paths = piPathsFor(ctx);
+    const apiKey = await piApiKey(ctx);
+    await runPiModelSelect({
+      options: ctx,
+      ...paths,
+      apiKey,
+    });
+  },
+});

--- a/packages/setup-cli/lib/model-list.mjs
+++ b/packages/setup-cli/lib/model-list.mjs
@@ -30,7 +30,7 @@ export async function runModelListCommand({ options, harness = "", apiKey }) {
   }
 
   if (keyType === "firepass") {
-    console.log("Fire Pass key: showing the kimi-k2p7-code-fast serverless router only.");
+    console.log("Fire Pass key: showing Fire Pass-supported serverless routers.");
     console.log("");
   }
 

--- a/packages/setup-cli/lib/model-select.mjs
+++ b/packages/setup-cli/lib/model-select.mjs
@@ -17,11 +17,25 @@ import {
   opencodeProviderStatus,
 } from "./opencode-core.mjs";
 import {
+  PI_API_KEY_ENV_REF,
+  enablePiFireworks,
+  piProviderStatus,
+} from "./pi-core.mjs";
+import {
   filterCatalogBySearch,
   loadServerlessCatalog,
 } from "./fireworks-models.mjs";
 import { HARNESS } from "./harness.mjs";
-import { printClaudeModelRoutingHint } from "./claude-hints.mjs";
+import { printClaudeModelActivationHint } from "./claude-hints.mjs";
+import {
+  codexCurrentModelId,
+  codexProviderStatus,
+  codexStoredAuthRef,
+  printCodexRestartHint,
+  readCodexTomlIfExists,
+  updateCodexModel,
+} from "./codex-core.mjs";
+import { printPiRestartHint } from "./pi-hints.mjs";
 
 export const CLAUDE_CODE_SLOTS = [
   { key: "main", label: "main (primary conversation model)" },
@@ -35,6 +49,12 @@ function ensureInteractiveTerminal(harness) {
   if (!input.isTTY || !output.isTTY) {
     if (harness === HARNESS.OPENCODE) {
       throw new Error("model select requires an interactive terminal. Use: fireconnect opencode on --main <id>");
+    }
+    if (harness === HARNESS.CODEX) {
+      throw new Error("model select requires an interactive terminal. Use: fireconnect codex on --main <id>");
+    }
+    if (harness === HARNESS.PI) {
+      throw new Error("model select requires an interactive terminal. Use: fireconnect pi on --main <id>");
     }
     throw new Error("model select requires an interactive terminal. Use: fireconnect claude on --<slot> <id>");
   }
@@ -175,7 +195,7 @@ export async function runClaudeModelSelect({ options, settingsPath, apiKey }) {
 
     await applyModelMapping({ settingsPath, mapping });
     console.log(`Updated ${slot} -> ${mapping[slot]}`);
-    printClaudeModelRoutingHint();
+    printClaudeModelActivationHint();
   } finally {
     rl.close();
   }
@@ -233,6 +253,112 @@ export async function runOpencodeModelSelect({ options, configPath, dataDir, api
 
     console.log(`Updated OpenCode model: ${result.model}`);
     console.log("Restart OpenCode for full effect.");
+  } finally {
+    rl.close();
+  }
+}
+
+export async function runCodexModelSelect({ options, configPath, apiKey, literalAuth = false }) {
+  ensureInteractiveTerminal(HARNESS.CODEX);
+
+  if (options.slot) {
+    throw new Error("--slot is Claude Code only; Codex uses a single model (omit --slot)");
+  }
+
+  const { doc } = await readCodexTomlIfExists(configPath);
+  if (codexProviderStatus(doc) !== "fireworks") {
+    throw new Error("model select requires Fireworks to be enabled; run: fireconnect codex on");
+  }
+
+  const storedAuth = codexStoredAuthRef(doc);
+  const keyType = detectApiKeyType(apiKey);
+  const { catalog } = await loadServerlessCatalog({ apiKey, keyType });
+  const currentModel = codexCurrentModelId(doc)?.split("/").at(-1) ?? "(unset)";
+
+  const rl = readline.createInterface({ input, output });
+
+  try {
+    console.log(`Current Codex model: ${currentModel}`);
+
+    const picked = await pickFromCatalog({
+      rl,
+      catalog,
+      options,
+      promptLabel: "Pick a serverless model for Codex:",
+    });
+    if (!picked) {
+      return;
+    }
+
+    const writeAuth = options.apiKeyFromFlag ? options.apiKey : (storedAuth || apiKey);
+    const result = await updateCodexModel({
+      configPath,
+      modelId: picked.shortId,
+      apiKey: writeAuth,
+      literalAuth: options.apiKeyFromFlag || literalAuth,
+    });
+
+    console.log(`Updated Codex model: ${result.model}`);
+    printCodexRestartHint();
+  } finally {
+    rl.close();
+  }
+}
+
+export async function runPiModelSelect({ options, settingsPath, authPath, dataDir, apiKey }) {
+  ensureInteractiveTerminal(HARNESS.PI);
+
+  if (options.slot) {
+    throw new Error("--slot is Claude Code only; Pi uses a single model (omit --slot)");
+  }
+
+  const settings = await readJsonIfExists(settingsPath);
+  if (piProviderStatus(settings) !== "fireworks") {
+    throw new Error("model select requires Fireworks to be enabled; run: fireconnect pi on");
+  }
+
+  const auth = await readJsonIfExists(authPath);
+  const existingKey = auth.fireworks?.key ?? "";
+  const keyType = detectApiKeyType(apiKey);
+
+  const { catalog } = await loadServerlessCatalog({ apiKey, keyType });
+
+  const currentModel = typeof settings.defaultModel === "string"
+    ? settings.defaultModel.split("/").at(-1)
+    : "(unset)";
+
+  const rl = readline.createInterface({ input, output });
+
+  try {
+    console.log(`Current Pi model: ${currentModel}`);
+
+    const picked = await pickFromCatalog({
+      rl,
+      catalog,
+      options,
+      promptLabel: "Pick a serverless model for Pi:",
+    });
+    if (!picked) {
+      return;
+    }
+
+    const writeKey = options.apiKeyFromFlag ? options.apiKey : (existingKey || options.apiKey);
+    const existingKeyIsLiteral = Boolean(existingKey)
+      && existingKey !== PI_API_KEY_ENV_REF
+      && existingKey !== "${FIREWORKS_API_KEY}";
+
+    const result = await enablePiFireworks({
+      settingsPath,
+      authPath,
+      dataDir,
+      apiKey: writeKey,
+      apiKeyFromFlag: options.apiKeyFromFlag || existingKeyIsLiteral,
+      modelId: picked.shortId,
+      keyType,
+    });
+
+    console.log(`Updated Pi model: ${result.model}`);
+    printPiRestartHint();
   } finally {
     rl.close();
   }

--- a/packages/setup-cli/lib/opencode-core.mjs
+++ b/packages/setup-cli/lib/opencode-core.mjs
@@ -127,7 +127,7 @@ export async function enableOpencodeFireworks({
       ? modelRef.slice("fireworks/".length)
       : "";
 
-  // Fire Pass defaults to the K2.7 Code Fast router; when no explicit model is
+  // Fire Pass defaults to the GLM Latest router; when no explicit model is
   // requested, use that so the user gets a working config out of the box.
   let effectiveModelId = modelId;
   if (resolvedKeyType === "firepass" && !modelId) {
@@ -154,7 +154,6 @@ export async function enableOpencodeFireworks({
     await chmod(backupPath, 0o600);
   }
 
-  const shortName = resolvedModel.split("/").at(-1) ?? resolvedModel;
   const provider = { ...(config.provider ?? {}) };
   delete provider.fireworks;
 
@@ -165,14 +164,14 @@ export async function enableOpencodeFireworks({
     options: { ...(existing.options ?? {}), apiKey: apiKeyValue },
     models: {
       ...(existing.models ?? {}),
-      [shortName]: { name: shortName },
+      [resolvedModel]: { name: resolvedModel },
     },
   };
 
   const next = {
     ...config,
     provider,
-    model: `${prefix}${shortName}`,
+    model: `${prefix}${resolvedModel}`,
   };
 
   await writeJson(configPath, next);

--- a/packages/setup-cli/lib/pi-core.mjs
+++ b/packages/setup-cli/lib/pi-core.mjs
@@ -1,0 +1,301 @@
+import { createHash } from "node:crypto";
+import { chmod, mkdir, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import {
+  DEFAULT_FIREPASS_MAIN_MODEL,
+  DEFAULT_MAIN_MODEL,
+  detectApiKeyType,
+  normalizeModelId,
+  readJsonIfExists,
+  writeJson,
+} from "./fireconnect-core.mjs";
+import { readRawIfExists } from "./opencode-core.mjs";
+
+export const PI_SETTINGS_RELATIVE_PATH = ".pi/agent/settings.json";
+export const PI_DATA_RELATIVE_DIR = ".fireconnect/pi";
+export const PI_API_KEY_ENV_REF = "$FIREWORKS_API_KEY";
+const PI_PROVIDER = "fireworks";
+const PI_MANAGED_BY = "fireconnect";
+
+function isFireconnectActive(settings) {
+  return settings.defaultProvider === PI_PROVIDER
+    && typeof settings.defaultModel === "string"
+    && settings.defaultModel.startsWith("accounts/fireworks/");
+}
+
+function isFireconnectManagedAuth(auth) {
+  return auth[PI_PROVIDER]?.managedBy === PI_MANAGED_BY;
+}
+
+export function piSettingsPath(home, settingsPath = "") {
+  return settingsPath || path.join(home, PI_SETTINGS_RELATIVE_PATH);
+}
+
+export function piAuthPath(home, authPath = "", settingsPath = "") {
+  if (authPath) {
+    return authPath;
+  }
+  if (settingsPath) {
+    return path.join(path.dirname(settingsPath), "auth.json");
+  }
+  return path.join(home, ".pi/agent/auth.json");
+}
+
+export function piDataDir(home, dataDir = "") {
+  return dataDir || path.join(home, PI_DATA_RELATIVE_DIR);
+}
+
+function backupPath(dataDir, filePath, label) {
+  const key = createHash("sha256").update(path.resolve(filePath)).digest("hex").slice(0, 16);
+  return path.join(dataDir, `${label}-backup.${key}.json`);
+}
+
+function statePath(dataDir) {
+  return path.join(dataDir, "state.json");
+}
+
+async function writeState(dataDir, enabled) {
+  await mkdir(dataDir, { recursive: true, mode: 0o700 });
+  await writeJson(statePath(dataDir), { enabled });
+  await chmod(statePath(dataDir), 0o600);
+}
+
+export function resolvePiApiKeyValue(key) {
+  return key === PI_API_KEY_ENV_REF || key === "${FIREWORKS_API_KEY}"
+    ? (process.env.FIREWORKS_API_KEY ?? "")
+    : key;
+}
+
+export function piAuthKeyMode(key) {
+  if (!key) {
+    return "missing";
+  }
+  return key === PI_API_KEY_ENV_REF || key === "${FIREWORKS_API_KEY}" ? "env-reference" : "literal";
+}
+
+export function piProviderStatus(settings) {
+  const model = typeof settings.defaultModel === "string" ? settings.defaultModel : "";
+  const fireworksModel = model.startsWith("accounts/fireworks/");
+  if (settings.defaultProvider === PI_PROVIDER && fireworksModel) {
+    return "fireworks";
+  }
+  if (settings.defaultProvider === PI_PROVIDER || fireworksModel) {
+    return "custom";
+  }
+  return "default";
+}
+
+async function writePrivateBackup(dataDir, dest, filePath, snapshot) {
+  await mkdir(dataDir, { recursive: true, mode: 0o700 });
+  await writeJson(dest, { filePath: path.resolve(filePath), snapshot });
+  await chmod(dest, 0o600);
+}
+
+async function writeAuthFile(authPath, auth) {
+  await mkdir(path.dirname(authPath), { recursive: true });
+  await writeFile(authPath, `${JSON.stringify(auth, null, 2)}\n`, "utf8");
+  await chmod(authPath, 0o600);
+}
+
+async function restoreSnapshot(filePath, snapshot) {
+  if (snapshot.existed) {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, snapshot.raw, "utf8");
+    if (filePath.endsWith("auth.json")) {
+      await chmod(filePath, 0o600);
+    }
+    return;
+  }
+  await unlink(filePath).catch((error) => {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  });
+}
+
+async function parseJsonFile(filePath, snapshot) {
+  if (!snapshot.existed || !snapshot.raw.trim()) {
+    return {};
+  }
+  try {
+    return JSON.parse(snapshot.raw);
+  } catch {
+    throw new Error(`${filePath} is not valid JSON`);
+  }
+}
+
+export async function enablePiFireworks({
+  settingsPath,
+  authPath,
+  dataDir,
+  apiKey,
+  apiKeyFromFlag = false,
+  modelId,
+  keyType = "fireworks",
+}) {
+  if (!apiKey) {
+    throw new Error("No Fireworks API key found. Pass --api-key or set FIREWORKS_API_KEY.");
+  }
+
+  const settingsSnapshot = await readRawIfExists(settingsPath);
+  const authSnapshot = await readRawIfExists(authPath);
+  const settings = await parseJsonFile(settingsPath, settingsSnapshot);
+  const auth = await parseJsonFile(authPath, authSnapshot);
+
+  const resolvedKeyType = keyType === "fireworks"
+    ? detectApiKeyType(resolvePiApiKeyValue(apiKey))
+    : keyType;
+  let effectiveModelId = modelId;
+  if (resolvedKeyType === "firepass" && !modelId) {
+    effectiveModelId = DEFAULT_FIREPASS_MAIN_MODEL;
+  }
+  const resolvedModel = normalizeModelId(
+    effectiveModelId || DEFAULT_MAIN_MODEL,
+  );
+
+  const settingsBackup = backupPath(dataDir, settingsPath, "settings");
+  const hasActiveBackup = (await readJsonIfExists(settingsBackup)).snapshot !== undefined;
+  const hasFireworksModel = typeof settings.defaultModel === "string"
+    && settings.defaultModel.startsWith("accounts/fireworks/");
+
+  if (!hasActiveBackup) {
+    await writePrivateBackup(dataDir, settingsBackup, settingsPath, settingsSnapshot);
+    if (authSnapshot.existed) {
+      await writePrivateBackup(dataDir, backupPath(dataDir, authPath, "auth"), authPath, authSnapshot);
+    }
+  } else if (settings.defaultProvider !== PI_PROVIDER && !hasFireworksModel) {
+    await writePrivateBackup(dataDir, settingsBackup, settingsPath, settingsSnapshot);
+    if (authSnapshot.existed) {
+      await writePrivateBackup(dataDir, backupPath(dataDir, authPath, "auth"), authPath, authSnapshot);
+    }
+  }
+
+  const apiKeyValue = apiKeyFromFlag ? apiKey : PI_API_KEY_ENV_REF;
+  await writeJson(settingsPath, {
+    ...settings,
+    defaultProvider: PI_PROVIDER,
+    defaultModel: resolvedModel,
+  });
+  await writeAuthFile(authPath, {
+    ...auth,
+    [PI_PROVIDER]: { type: "api_key", key: apiKeyValue, managedBy: PI_MANAGED_BY },
+  });
+  await writeState(dataDir, true);
+
+  return {
+    model: resolvedModel,
+    apiKeyMode: piAuthKeyMode(apiKeyValue),
+    keyType: resolvedKeyType,
+  };
+}
+
+async function restoreBackedUpFile(filePath, backupPath, label) {
+  const backup = await readJsonIfExists(backupPath);
+  if (backup.snapshot !== undefined
+    && backup.filePath !== undefined
+    && backup.filePath !== path.resolve(filePath)) {
+    throw new Error(`Backup was taken for ${backup.filePath}, not ${filePath}; refusing to restore ${label}.`);
+  }
+  if (backup.snapshot !== undefined) {
+    if (label === "auth" && !backup.snapshot.existed) {
+      await unlink(backupPath).catch(() => {});
+      return false;
+    }
+    await restoreSnapshot(filePath, backup.snapshot);
+    await unlink(backupPath).catch(() => {});
+    return true;
+  }
+  return false;
+}
+
+async function stripManagedSettings(settingsPath) {
+  if (!(await readRawIfExists(settingsPath)).existed) {
+    return false;
+  }
+  const settings = await readJsonIfExists(settingsPath);
+  const next = { ...settings };
+  let changed = false;
+  if (next.defaultProvider === PI_PROVIDER) {
+    delete next.defaultProvider;
+    changed = true;
+  }
+  if (typeof next.defaultModel === "string" && next.defaultModel.startsWith("accounts/fireworks/")) {
+    delete next.defaultModel;
+    changed = true;
+  }
+  if (changed) {
+    await writeJson(settingsPath, next);
+  }
+  return changed;
+}
+
+async function stripManagedAuth(authPath) {
+  if (!(await readRawIfExists(authPath)).existed) {
+    return false;
+  }
+  const auth = await readJsonIfExists(authPath);
+  if (!isFireconnectManagedAuth(auth)) {
+    return false;
+  }
+  const next = { ...auth };
+  delete next[PI_PROVIDER];
+  if (Object.keys(next).length === 0) {
+    await unlink(authPath).catch((error) => {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    });
+  } else {
+    await writeAuthFile(authPath, next);
+  }
+  return true;
+}
+
+export async function disablePiFireworks({ settingsPath, authPath, dataDir }) {
+  const state = await readJsonIfExists(statePath(dataDir));
+  const wasEnabled = state.enabled === true;
+  const settingsBackup = backupPath(dataDir, settingsPath, "settings");
+  const hasBackup = (await readJsonIfExists(settingsBackup)).snapshot !== undefined;
+
+  if (!wasEnabled && !hasBackup) {
+    const auth = await readJsonIfExists(authPath);
+    const settings = await readJsonIfExists(settingsPath);
+    const hasFireconnectState = (await readRawIfExists(statePath(dataDir))).existed;
+    if (!isFireconnectManagedAuth(auth)) {
+      if (!hasFireconnectState || !isFireconnectActive(settings)) {
+        return { changed: false };
+      }
+    }
+    let changed = false;
+    changed = (await stripManagedSettings(settingsPath)) || changed;
+    if (isFireconnectManagedAuth(auth)) {
+      changed = (await stripManagedAuth(authPath)) || changed;
+    }
+    if (!changed) {
+      return { changed: false };
+    }
+    await writeState(dataDir, false);
+    return { changed: true };
+  }
+
+  const restoredSettings = await restoreBackedUpFile(settingsPath, settingsBackup, "settings");
+  let changed = restoredSettings;
+  if (!restoredSettings && wasEnabled) {
+    changed = (await stripManagedSettings(settingsPath)) || changed;
+  }
+
+  const restoredAuth = await restoreBackedUpFile(
+    authPath,
+    backupPath(dataDir, authPath, "auth"),
+    "auth",
+  );
+  if (restoredAuth) {
+    changed = true;
+  } else {
+    changed = (await stripManagedAuth(authPath)) || changed;
+  }
+
+  await writeState(dataDir, false);
+  return { changed };
+}

--- a/packages/setup-cli/lib/pi-hints.mjs
+++ b/packages/setup-cli/lib/pi-hints.mjs
@@ -1,0 +1,3 @@
+export function printPiRestartHint() {
+  console.log("Restart Pi for full effect.");
+}

--- a/packages/setup-cli/lib/update-checker.mjs
+++ b/packages/setup-cli/lib/update-checker.mjs
@@ -1,0 +1,66 @@
+import { readFile, mkdir, writeFile, unlink } from "node:fs/promises";
+import path from "node:path";
+
+const REMOTE_URL =
+  "https://raw.githubusercontent.com/fw-ai/fireconnect/main/packages/setup-cli/package.json";
+
+function cachePath(home) {
+  return path.join(home, ".fireconnect", "update-check.json");
+}
+
+function lockPath(home) {
+  return path.join(home, ".fireconnect", "update-check.lock");
+}
+
+async function readExistingCache(home) {
+  try {
+    const raw = await readFile(cachePath(home), "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(home, payload) {
+  const filePath = cachePath(home);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(payload), "utf8");
+}
+
+async function releaseLock(home) {
+  try {
+    await unlink(lockPath(home));
+  } catch {
+    // Lock may already be gone.
+  }
+}
+
+async function main() {
+  const home = process.env.HOME ?? "";
+  if (!home) return;
+
+  const existing = await readExistingCache(home);
+  const checkedAt = Date.now();
+  const latestVersion = existing?.latestVersion ?? null;
+
+  try {
+    const res = await fetch(REMOTE_URL, { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) throw new Error("fetch failed");
+    const { version } = await res.json();
+    if (!version) throw new Error("missing version");
+    await writeCache(home, { checkedAt, latestVersion: version });
+  } catch {
+    if (!latestVersion) {
+      try {
+        await writeCache(home, { checkedAt, latestVersion: null, fetchFailed: true });
+      } catch {
+        // Silent — main CLI must never be affected.
+      }
+    }
+    // Keep existing cache when we already know a version but fetch failed.
+  } finally {
+    await releaseLock(home);
+  }
+}
+
+main().catch(() => {});

--- a/packages/setup-cli/lib/update-notify.mjs
+++ b/packages/setup-cli/lib/update-notify.mjs
@@ -1,0 +1,149 @@
+import {
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+  statSync,
+} from "node:fs";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import process from "node:process";
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FAILURE_RETRY_MS = 60 * 60 * 1000;
+const PENDING_TTL_MS = 5 * 60 * 1000;
+
+function cacheFilePath(home) {
+  return path.join(home, ".fireconnect", "update-check.json");
+}
+
+function lockFilePath(home) {
+  return path.join(home, ".fireconnect", "update-check.lock");
+}
+
+function readLocalVersion() {
+  try {
+    const pkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+    return JSON.parse(readFileSync(pkgPath, "utf8")).version ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function readCache(home) {
+  try {
+    const raw = readFileSync(cacheFilePath(home), "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function semverGt(a, b) {
+  const pa = String(a).split(".").map(Number);
+  const pb = String(b).split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
+  }
+  return false;
+}
+
+export function shouldSpawnChecker(cache, now = Date.now()) {
+  if (!cache) return true;
+
+  const age = now - (cache.checkedAt ?? 0);
+  if (cache.pending) {
+    return age >= PENDING_TTL_MS;
+  }
+
+  // Distinguish a failed fetch (short retry) from a successful one (full TTL).
+  if (cache.fetchFailed) {
+    return age >= FAILURE_RETRY_MS;
+  }
+
+  if (cache.latestVersion) {
+    return age >= CACHE_TTL_MS;
+  }
+
+  return age >= FAILURE_RETRY_MS;
+}
+
+function lockAgeMs(home, now = Date.now()) {
+  try {
+    const stat = statSync(lockFilePath(home));
+    return now - stat.mtimeMs;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+export function hasActiveUpdateLock(home, now = Date.now()) {
+  return lockAgeMs(home, now) < PENDING_TTL_MS;
+}
+
+export function tryAcquireUpdateLock(home, now = Date.now()) {
+  const lockPath = lockFilePath(home);
+  try {
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    if (hasActiveUpdateLock(home, now)) {
+      return false;
+    }
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // No stale lock to remove.
+    }
+    const fd = openSync(lockPath, "wx");
+    closeSync(fd);
+    return true;
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      return false;
+    }
+    return false;
+  }
+}
+
+function spawnChecker(home) {
+  try {
+    const workerPath = fileURLToPath(new URL("./update-checker.mjs", import.meta.url));
+    const child = spawn(process.execPath, [workerPath], {
+      detached: true,
+      stdio: "ignore",
+      env: { ...process.env, HOME: home },
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Never fail the main process for a background check.
+  }
+}
+
+export function checkForUpdates(command, homeOverride) {
+  if (command === "upgrade" || command === "uninstall") return;
+
+  const home = homeOverride || process.env.HOME || "";
+  if (!home) return;
+
+  const localVersion = readLocalVersion();
+  const cache = readCache(home);
+
+  if (localVersion && cache?.latestVersion && semverGt(cache.latestVersion, localVersion)) {
+    const isGitInstall = existsSync(path.join(home, ".fireconnect", "cli", ".git"));
+    const upgradeInstruction = isGitInstall
+      ? "Run: fireconnect upgrade"
+      : "Run: curl -fsSL https://raw.githubusercontent.com/fw-ai/fireconnect/main/install.sh | bash";
+    process.stderr.write(
+      `\nFireConnect update available: v${localVersion} → v${cache.latestVersion}\n` +
+        `${upgradeInstruction}\n\n`,
+    );
+  }
+
+  if (shouldSpawnChecker(cache) && tryAcquireUpdateLock(home)) {
+    spawnChecker(home);
+  }
+}

--- a/packages/setup-cli/package.json
+++ b/packages/setup-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireconnect/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "FireConnect CLIs for using Fireworks models with Claude Code",
   "type": "module",
   "bin": {

--- a/packages/setup-cli/test/cli-commands.test.mjs
+++ b/packages/setup-cli/test/cli-commands.test.mjs
@@ -3,11 +3,14 @@ import { describe, test } from "node:test";
 
 import { OPENCODE_API_KEY_ENV_REF } from "../lib/opencode-core.mjs";
 import {
-  FIREPASS_ROUTER,
   FIREWORKS_INFERENCE_URL,
   FPK_KEY,
   FW_CLAUDE_KEY,
+  FIREPASS_ROUTER,
+  FIREPASS_ROUTER_1M,
+  GLM_LATEST,
   K2P7_FAST,
+  KIMI_FAST_LATEST,
   NO_ENV_KEY,
   readClaudeSettings,
   readOpencodeConfig,
@@ -20,11 +23,25 @@ import {
 } from "./helpers.mjs";
 
 describe("fireconnect claude on", () => {
-  test("fpk_ routes Claude Code to kimi-k2p7-code-fast", async () => {
+  test("fw_ uses glm-latest as default main router", async () => {
+    await withTempHome("on-fw", async (home) => {
+      const result = await runCli(["claude", "on", "--api-key", FW_CLAUDE_KEY], { home });
+      assert.equal(result.code, 0, result.stderr);
+
+      const settings = await readClaudeSettings(home);
+      assert.match(settings.model, /glm-latest/);
+      assert.equal(settings.env.ANTHROPIC_MODEL, FIREPASS_ROUTER_1M);
+      assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, FIREPASS_ROUTER_1M);
+      assert.equal(settings.env.ANTHROPIC_CUSTOM_MODEL_OPTION, FIREPASS_ROUTER_1M);
+      assert.equal(Object.hasOwn(settings.env, "CLAUDE_CODE_DISABLE_1M_CONTEXT"), false);
+    });
+  });
+
+  test("fpk_ routes Claude Code to glm-latest", async () => {
     await withTempHome("on-fpk", async (home) => {
       const result = await runCli(["claude", "on", "--api-key", FPK_KEY], { home });
       assert.equal(result.code, 0, result.stderr);
-      assert.match(result.stdout, /kimi-k2p7-code-fast/);
+      assert.match(result.stdout, /glm-latest/);
 
       const { env } = await readClaudeSettings(home);
       for (const key of [
@@ -34,8 +51,9 @@ describe("fireconnect claude on", () => {
         "ANTHROPIC_DEFAULT_HAIKU_MODEL",
         "CLAUDE_CODE_SUBAGENT_MODEL",
       ]) {
-        assert.equal(env[key], FIREPASS_ROUTER);
+        assert.equal(env[key], FIREPASS_ROUTER_1M);
       }
+      assert.equal(Object.hasOwn(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT"), false);
     });
   });
 
@@ -72,7 +90,23 @@ describe("fireconnect claude on", () => {
 });
 
 describe("fireconnect opencode on", () => {
-  test("fpk_ uses kimi-k2p7-code-fast", async () => {
+  test("fw_ uses glm-latest as default model", async () => {
+    await withTempHome("on-fw-oc", async (home) => {
+      const result = await runCli(
+        ["opencode", "on", "--api-key", FW_CLAUDE_KEY],
+        { home },
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const config = await readOpencodeConfig(home);
+      assert.equal(config.model, `fireworks-ai/${FIREPASS_ROUTER}`);
+      assert.deepEqual(config.provider["fireworks-ai"].models[FIREPASS_ROUTER], {
+        name: FIREPASS_ROUTER,
+      });
+    });
+  });
+
+  test("fpk_ uses glm-latest", async () => {
     await withTempHome("on-fpk-oc", async (home) => {
       const result = await runCli(
         ["opencode", "on", "--api-key", FPK_KEY],
@@ -81,21 +115,27 @@ describe("fireconnect opencode on", () => {
       assert.equal(result.code, 0, result.stderr);
 
       const config = await readOpencodeConfig(home);
-      assert.match(config.model, /kimi-k2p7-code-fast/);
+      assert.equal(config.model, `fireworks-ai/${FIREPASS_ROUTER}`);
+      assert.deepEqual(config.provider["fireworks-ai"].models[FIREPASS_ROUTER], {
+        name: FIREPASS_ROUTER,
+      });
     });
   });
 });
 
 describe("fireconnect <harness> model list", () => {
-  test("Fire Pass key shows kimi-k2p7-code-fast only", async () => {
+  test("Fire Pass key shows supported routers", async () => {
     await withTempHome("ml-fpk", async (home) => {
       const { json } = await runCliJson(
         ["claude", "model", "list", "--api-key", FPK_KEY, "--json"],
         { home, env: NO_ENV_KEY },
       );
       assert.equal(json.keyType, "firepass");
-      assert.equal(json.count, 1);
-      assert.equal(json.models[0].shortId, K2P7_FAST);
+      assert.equal(json.count, 3);
+      assert.deepEqual(
+        json.models.map((entry) => entry.shortId),
+        [GLM_LATEST, KIMI_FAST_LATEST, K2P7_FAST],
+      );
     });
   });
 
@@ -108,7 +148,9 @@ describe("fireconnect <harness> model list", () => {
       );
       assert.equal(code, 0, stderr);
       assert.equal(json.keyType, "firepass");
-      assert.equal(json.models[0].shortId, K2P7_FAST);
+      assert.equal(json.models[0].shortId, GLM_LATEST);
+      assert.match(stdout, /glm-latest/);
+      assert.match(stdout, /kimi-fast-latest/);
       assert.match(stdout, /kimi-k2p7-code-fast/);
     });
   });
@@ -156,15 +198,18 @@ describe("fireconnect <harness> model list", () => {
     });
   });
 
-  test("text banner mentions kimi-k2p7-code-fast for Fire Pass", async () => {
+  test("text banner mentions Fire Pass-supported routers", async () => {
     await withTempHome("ml-banner", async (home) => {
       const result = await runCli(
         ["claude", "model", "list", "--api-key", FPK_KEY],
         { home, env: NO_ENV_KEY },
       );
       assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /glm-latest/);
+      assert.match(result.stdout, /kimi-fast-latest/);
       assert.match(result.stdout, /kimi-k2p7-code-fast/);
       assert.doesNotMatch(result.stdout, /kimi-k2p6-turbo/);
+      assert.doesNotMatch(result.stdout, /kimi-latest/);
     });
   });
 
@@ -182,12 +227,12 @@ describe("fireconnect <harness> status", () => {
     await withTempHome("status-cc-fpk", async (home) => {
       await writeClaudeSettings(home, FPK_KEY);
       const { json } = await runCliJson(["claude", "status", "--json"], { home, env: NO_ENV_KEY });
-      assert.equal(json.defaults.main, K2P7_FAST);
-      assert.equal(json.defaults.opus, K2P7_FAST);
+      assert.equal(json.defaults.main, GLM_LATEST);
+      assert.equal(json.defaults.opus, GLM_LATEST);
 
       const text = await runCli(["claude", "status"], { home, env: NO_ENV_KEY });
       assert.equal(text.code, 0, text.stderr);
-      assert.match(text.stdout, /kimi-k2p7-code-fast only/);
+      assert.match(text.stdout, /default: glm-latest/);
       assert.doesNotMatch(text.stdout, /kimi-k2p6-turbo/);
     });
   });
@@ -196,7 +241,8 @@ describe("fireconnect <harness> status", () => {
     await withTempHome("status-fw", async (home) => {
       await writeClaudeSettings(home, FW_CLAUDE_KEY);
       const { json } = await runCliJson(["claude", "status", "--json"], { home, env: NO_ENV_KEY });
-      assert.equal(json.defaults.main, K2P7_FAST);
+      assert.equal(json.defaults.main, GLM_LATEST);
+      assert.equal(json.defaults.opus, GLM_LATEST);
       assert.equal(json.defaults.sonnet, "glm-5p1");
       assert.equal(json.defaults.haiku, "minimax-m2p5");
     });
@@ -211,14 +257,14 @@ describe("fireconnect <harness> status", () => {
     });
   });
 
-  test("opencode with Fire Pass key shows kimi-k2p7-code-fast default", async () => {
+  test("opencode with Fire Pass key shows glm-latest default", async () => {
     await withTempHome("status-oc-fpk", async (home) => {
       await writeOpencodeConfig(home, FPK_KEY);
       const { json } = await runCliJson(
         ["opencode", "status", "--json"],
         { home, env: NO_ENV_KEY },
       );
-      assert.equal(json.defaults.main, K2P7_FAST);
+      assert.equal(json.defaults.main, GLM_LATEST);
     });
   });
 
@@ -229,7 +275,7 @@ describe("fireconnect <harness> status", () => {
         ["opencode", "status", "--json"],
         { home, env: { FIREWORKS_API_KEY: FPK_KEY } },
       );
-      assert.equal(json.defaults.main, K2P7_FAST);
+      assert.equal(json.defaults.main, GLM_LATEST);
     });
   });
 });
@@ -245,9 +291,9 @@ describe("fireconnect claude model reset", () => {
       assert.equal(result.code, 0, result.stderr);
 
       const { env } = await readClaudeSettings(home);
-      assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, FIREPASS_ROUTER);
-      assert.equal(env.ANTHROPIC_DEFAULT_HAIKU_MODEL, FIREPASS_ROUTER);
-      assert.equal(env.CLAUDE_CODE_SUBAGENT_MODEL, FIREPASS_ROUTER);
+      assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, FIREPASS_ROUTER_1M);
+      assert.equal(env.ANTHROPIC_DEFAULT_HAIKU_MODEL, FIREPASS_ROUTER_1M);
+      assert.equal(env.CLAUDE_CODE_SUBAGENT_MODEL, FIREPASS_ROUTER_1M);
       assert.equal(env.ANTHROPIC_API_KEY, FPK_KEY);
     });
   });

--- a/packages/setup-cli/test/codex-harness.test.mjs
+++ b/packages/setup-cli/test/codex-harness.test.mjs
@@ -1,0 +1,267 @@
+import { mkdtemp, readFile, writeFile, mkdir, unlink, access, stat } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { spawn } from "node:child_process";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { codexBackupPath, codexConfigPath, codexDataDir } from "../lib/codex-core.mjs";
+import { writeJson } from "../lib/fireconnect-core.mjs";
+import { writeGlobalConfig } from "../lib/global-config.mjs";
+import { FPK_KEY, withoutEnvFireworksKey } from "./helpers.mjs";
+
+const CLI = path.join(import.meta.dirname, "..", "bin", "fireconnect.mjs");
+
+function runFireconnect(args, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.on("error", reject);
+  });
+}
+
+describe("codex harness integration", () => {
+  it("on/off round-trip restores config.toml", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-"));
+    const configDir = path.join(home, ".codex");
+    await mkdir(configDir, { recursive: true });
+    const configPath = codexConfigPath(home);
+    const original = [
+      'model_provider = "openai"',
+      'model = "gpt-4.1"',
+      "",
+      "[[mcp_servers]]",
+      'name = "test"',
+      'command = "echo"',
+      "",
+    ].join("\n");
+    await writeFile(configPath, original);
+
+    const onResult = await runFireconnect(
+      ["codex", "on", "--api-key", "fw_test_key_12345"],
+      { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" },
+    );
+    assert.equal(onResult.code, 0);
+
+    const enabled = await readFile(configPath, "utf8");
+    assert.match(enabled, /model_provider = "fireworks-ai"/);
+    assert.match(enabled, /\[model_providers\.fireworks-ai\]/);
+    assert.doesNotMatch(enabled, /profile = "fireconnect"/);
+    assert.doesNotMatch(enabled, /\[profiles\.fireconnect\]/);
+    assert.match(enabled, /experimental_bearer_token = "fw_test_key_12345"/);
+    assert.match(enabled, /wire_api = "responses"/);
+    assert.match(enabled, /\[\[mcp_servers\]\]/);
+
+    const offResult = await runFireconnect(["codex", "off"], { HOME: home });
+    assert.equal(offResult.code, 0);
+    assert.match(offResult.stdout, /original config restored/);
+
+    const restored = await readFile(configPath, "utf8");
+    assert.equal(restored, original);
+  });
+
+  it("on resolves API key from global config when env is unset", async () => {
+    await withoutEnvFireworksKey(async () => {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-global-"));
+      await mkdir(path.join(home, ".codex"), { recursive: true });
+      await writeGlobalConfig(home, {
+        apiKey: "fw_test_key_12345",
+        harnesses: { codex: { enabled: false } },
+      });
+
+      const onResult = await runFireconnect(["codex", "on"], { HOME: home });
+      assert.equal(onResult.code, 0);
+      assert.match(onResult.stdout, /API key written into ~\/\.codex\/config\.toml \(passed via --api-key\)/);
+
+      const configPath = codexConfigPath(home);
+      const enabled = await readFile(configPath, "utf8");
+      assert.match(enabled, /model_provider = "fireworks-ai"/);
+      assert.doesNotMatch(enabled, /profile = "fireconnect"/);
+    });
+  });
+
+  it("on with env only writes env_key reference", async () => {
+    await withoutEnvFireworksKey(async () => {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-env-on-"));
+      await mkdir(path.join(home, ".codex"), { recursive: true });
+
+      const env = { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" };
+      const onResult = await runFireconnect(["codex", "on"], env);
+      assert.equal(onResult.code, 0);
+      assert.match(onResult.stdout, /env_key FIREWORKS_API_KEY/);
+
+      const config = await readFile(codexConfigPath(home), "utf8");
+      assert.match(config, /env_key = "FIREWORKS_API_KEY"/);
+      assert.doesNotMatch(config, /experimental_bearer_token/);
+    });
+  });
+
+  it("on with --api-key restricts config.toml to owner-only (0o600)", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-perms-"));
+    await mkdir(path.join(home, ".codex"), { recursive: true });
+    const configPath = codexConfigPath(home);
+
+    const env = { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" };
+    const onResult = await runFireconnect(["codex", "on", "--api-key", "fw_test_key_12345"], env);
+    assert.equal(onResult.code, 0);
+
+    const enabled = await readFile(configPath, "utf8");
+    assert.match(enabled, /experimental_bearer_token = "fw_test_key_12345"/);
+
+    const st = await stat(configPath);
+    // Mask off file-type bits; expect owner-only read/write (0o600).
+    assert.equal(st.mode & 0o777, 0o600, "config.toml should be 0o600 when a literal key is written");
+  });
+
+  it("on with env reference does not tighten config.toml permissions", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-env-perms-"));
+    await mkdir(path.join(home, ".codex"), { recursive: true });
+    const configPath = codexConfigPath(home);
+
+    const env = { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" };
+    const onResult = await runFireconnect(["codex", "on"], env);
+    assert.equal(onResult.code, 0);
+
+    const enabled = await readFile(configPath, "utf8");
+    assert.match(enabled, /env_key = "FIREWORKS_API_KEY"/);
+    assert.doesNotMatch(enabled, /experimental_bearer_token/);
+
+    // No literal key, so the mode should NOT be forced to 0o600. We only assert
+    // it is writable+readable by owner (the 0o600 bit is not required here).
+    const st = await stat(configPath);
+    assert.equal(st.mode & 0o700, 0o600, "config.toml should remain owner-readable/writable");
+  });
+
+  it("off strips routing when backup is missing or contains Fireworks config", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-backup-"));
+    await mkdir(path.join(home, ".codex"), { recursive: true });
+    const configPath = codexConfigPath(home);
+    const original = [
+      'model_provider = "openai"',
+      'model = "gpt-4.1"',
+    ].join("\n") + "\n";
+    await writeFile(configPath, original);
+
+    const env = { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" };
+    assert.equal((await runFireconnect(["codex", "on", "--api-key", "fw_test_key_12345"], env)).code, 0);
+
+    const backupPath = codexBackupPath(codexDataDir(home), configPath);
+    await unlink(backupPath);
+
+    assert.equal((await runFireconnect(["codex", "on", "--api-key", "fw_test_key_12345"], env)).code, 0);
+    await assert.rejects(access(backupPath));
+
+    let offResult = await runFireconnect(["codex", "off"], { HOME: home });
+    assert.equal(offResult.code, 0);
+    assert.match(offResult.stdout, /FireConnect routing removed from config\.toml/);
+
+    let restored = await readFile(configPath, "utf8");
+    assert.doesNotMatch(restored, /model_provider = "fireworks-ai"/);
+    assert.doesNotMatch(restored, /\[model_providers\.fireworks-ai\]/);
+
+    assert.equal((await runFireconnect(["codex", "on", "--api-key", "fw_test_key_12345"], env)).code, 0);
+    const fireworksConfig = await readFile(configPath, "utf8");
+    await writeJson(backupPath, {
+      configPath: path.resolve(configPath),
+      snapshot: { existed: true, raw: fireworksConfig },
+    });
+
+    offResult = await runFireconnect(["codex", "off"], { HOME: home });
+    assert.equal(offResult.code, 0);
+    assert.match(offResult.stdout, /FireConnect routing removed from config\.toml/);
+
+    restored = await readFile(configPath, "utf8");
+    assert.doesNotMatch(restored, /model_provider = "fireworks-ai"/);
+    await assert.rejects(access(backupPath));
+  });
+
+  it("on snapshots and off restores when user already has fireworks-ai provider", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-existing-provider-"));
+    await mkdir(path.join(home, ".codex"), { recursive: true });
+    const configPath = codexConfigPath(home);
+    const original = [
+      'model_provider = "fireworks-ai"',
+      'model = "accounts/fireworks/models/custom-model"',
+      "",
+      "[model_providers.fireworks-ai]",
+      'name = "My Fireworks"',
+      'base_url = "https://custom.example/v1"',
+      'env_key = "FIREWORKS_API_KEY"',
+      "",
+    ].join("\n");
+    await writeFile(configPath, original);
+
+    const env = { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" };
+    assert.equal((await runFireconnect(["codex", "on", "--api-key", "fw_test_key_12345"], env)).code, 0);
+
+    const enabled = await readFile(configPath, "utf8");
+    assert.match(enabled, /model_provider = "fireworks-ai"/);
+    assert.doesNotMatch(enabled, /profile = "fireconnect"/);
+    assert.match(enabled, /base_url = "https:\/\/api\.fireworks\.ai\/inference\/v1"/);
+
+    const offResult = await runFireconnect(["codex", "off"], { HOME: home });
+    assert.equal(offResult.code, 0);
+    assert.match(offResult.stdout, /original config restored/);
+
+    const restored = await readFile(configPath, "utf8");
+    assert.equal(restored, original);
+  });
+
+  it("codex on rejects Fire Pass key with helpful error", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-fpk-env-"));
+    await mkdir(path.join(home, ".codex"), { recursive: true });
+
+    const env = {
+      HOME: home,
+      FIREWORKS_API_KEY: "fw_test_key_different_000000",
+    };
+    const result = await runFireconnect(["codex", "on", "--api-key", FPK_KEY], env);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /\/responses endpoint is not supported for Fire Pass keys yet/);
+    assert.match(result.stderr, /standard Fireworks API key/);
+  });
+
+  it("model reset keeps stored bearer when FIREWORKS_API_KEY env differs", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-reset-env-"));
+    await mkdir(path.join(home, ".codex"), { recursive: true });
+
+    const env = {
+      HOME: home,
+      FIREWORKS_API_KEY: "fw_test_key_different_000000",
+    };
+    assert.equal(
+      (await runFireconnect(["codex", "on", "--api-key", "fw_test_key_12345"], env)).code,
+      0,
+    );
+
+    const resetResult = await runFireconnect(["codex", "model", "reset"], env);
+    assert.equal(resetResult.code, 0);
+
+    const config = await readFile(codexConfigPath(home), "utf8");
+    assert.match(config, /experimental_bearer_token = "fw_test_key_12345"/);
+    assert.doesNotMatch(config, /fw_test_key_different/);
+  });
+
+  it("codex on rejects Fire Pass key sourced from global config", async () => {
+    await withoutEnvFireworksKey(async () => {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-codex-reset-"));
+      await mkdir(path.join(home, ".codex"), { recursive: true });
+      await writeGlobalConfig(home, {
+        apiKey: FPK_KEY,
+        harnesses: { codex: { enabled: false } },
+      });
+
+      const env = { HOME: home };
+      const result = await runFireconnect(["codex", "on"], env);
+      assert.notEqual(result.code, 0);
+      assert.match(result.stderr, /\/responses endpoint is not supported for Fire Pass keys yet/);
+      assert.match(result.stderr, /standard Fireworks API key/);
+    });
+  });
+});

--- a/packages/setup-cli/test/codex-toml-patch.test.mjs
+++ b/packages/setup-cli/test/codex-toml-patch.test.mjs
@@ -1,0 +1,134 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  patchCodexModelRaw,
+  patchCodexProviderAuthRaw,
+  patchFireconnectRoutingRaw,
+  stripFireconnectRoutingRaw,
+} from "../lib/codex-toml-patch.mjs";
+import { parseToml } from "../lib/codex-toml.mjs";
+import { fireconnectManaged } from "../lib/codex-core.mjs";
+
+const ROUTING = {
+  providerId: "fireworks-ai",
+  baseUrl: "https://api.fireworks.ai/inference/v1",
+  modelId: "accounts/fireworks/routers/glm-5p1",
+};
+
+describe("codex-toml-patch", () => {
+  it("preserves array-of-tables through patch and strip", () => {
+    const input = [
+      'model_provider = "openai"',
+      'model = "gpt-4.1"',
+      "",
+      "[[mcp_servers]]",
+      'name = "test"',
+      'command = "echo"',
+      "",
+    ].join("\n");
+
+    const patched = patchFireconnectRoutingRaw(input, ROUTING);
+    assert.match(patched, /\[\[mcp_servers\]\]/);
+    assert.match(patched, /model_provider = "fireworks-ai"/);
+    assert.doesNotMatch(patched, /profile = "fireconnect"/);
+    assert.doesNotMatch(patched, /\[profiles\.fireconnect\]/);
+
+    const stripped = stripFireconnectRoutingRaw(patched, { stripRootRouting: true });
+    assert.match(stripped, /\[\[mcp_servers\]\]/);
+    assert.doesNotMatch(stripped, /model_provider = "fireworks-ai"/);
+    assert.doesNotMatch(stripped, /\[model_providers\.fireworks-ai\]/);
+  });
+
+  it("patches the root model for Codex 0.134+ routing", () => {
+    const input = patchFireconnectRoutingRaw("", ROUTING);
+    const updated = patchCodexModelRaw(
+      input,
+      "accounts/fireworks/routers/kimi-k2p7-code-fast",
+    );
+    assert.match(updated, /model = "accounts\/fireworks\/routers\/kimi-k2p7-code-fast"/);
+    assert.match(updated, /model_provider = "fireworks-ai"/);
+    assert.equal(parseToml(updated).root.model, "accounts/fireworks/routers/kimi-k2p7-code-fast");
+  });
+
+  it("replaces existing root routing keys when enabling", () => {
+    const input = [
+      'profile = "default"',
+      'model_provider = "openai"',
+      'model = "gpt-4.1"',
+      "",
+      "[tui]",
+      "show_tooltips = true",
+      "",
+    ].join("\n");
+
+    const patched = patchFireconnectRoutingRaw(input, ROUTING);
+    const doc = parseToml(patched);
+    assert.equal(doc.root.model_provider, "fireworks-ai");
+    assert.equal(doc.root.model, ROUTING.modelId);
+    assert.equal(doc.root.profile, undefined);
+    assert.match(patched, /\[tui\]/);
+    assert.ok(fireconnectManaged(doc));
+  });
+
+  it("keeps routing keys at document root when user config ends in [tui] tables", () => {
+    const input = [
+      "[tui]",
+      "show_tooltips = true",
+      "",
+      "[tui.model_availability_nux]",
+      "gpt-4.1 = 2",
+      "",
+    ].join("\n");
+
+    const patched = patchFireconnectRoutingRaw(input, ROUTING);
+    const lines = patched.split("\n");
+    assert.equal(lines[0], 'model_provider = "fireworks-ai"');
+    assert.equal(lines[1], `model = "${ROUTING.modelId}"`);
+    assert.match(patched, /\[tui\.model_availability_nux\]/);
+    assert.match(patched, /^gpt-4\.1 = 2$/m);
+    assert.doesNotMatch(patched, /\[tui\.model_availability_nux\]\nmodel_provider = /);
+  });
+
+  it("migrates legacy profile config to root routing", () => {
+    const legacy = [
+      'profile = "fireconnect"',
+      "",
+      "[model_providers.fireworks-ai]",
+      'name = "Fireworks"',
+      'base_url = "https://api.fireworks.ai/inference/v1"',
+      'env_key = "FIREWORKS_API_KEY"',
+      "requires_openai_auth = false",
+      "",
+      "[profiles.fireconnect]",
+      'model_provider = "fireworks-ai"',
+      'model = "accounts/fireworks/models/old-model"',
+      "",
+    ].join("\n");
+
+    const patched = patchFireconnectRoutingRaw(legacy, ROUTING);
+    assert.doesNotMatch(patched, /profile = "fireconnect"/);
+    assert.doesNotMatch(patched, /\[profiles\.fireconnect\]/);
+    const doc = parseToml(patched);
+    assert.equal(doc.root.model_provider, "fireworks-ai");
+    assert.equal(doc.root.model, ROUTING.modelId);
+    assert.ok(fireconnectManaged(doc));
+  });
+
+  it("writes bearer token auth when literalAuth is enabled", () => {
+    const patched = patchFireconnectRoutingRaw("", {
+      ...ROUTING,
+      apiKey: "fw_test_key_12345",
+      literalAuth: true,
+    });
+    assert.match(patched, /experimental_bearer_token = "fw_test_key_12345"/);
+    assert.doesNotMatch(patched, /env_key = "FIREWORKS_API_KEY"/);
+
+    const updated = patchCodexModelRaw(patched, "accounts/fireworks/models/glm-5p2");
+    const withAuth = patchCodexProviderAuthRaw(updated, {
+      apiKey: "fw_test_key_12345",
+      literalAuth: true,
+    });
+    assert.match(withAuth, /model = "accounts\/fireworks\/models\/glm-5p2"/);
+    assert.match(withAuth, /experimental_bearer_token = "fw_test_key_12345"/);
+  });
+});

--- a/packages/setup-cli/test/firepass-defaults.test.mjs
+++ b/packages/setup-cli/test/firepass-defaults.test.mjs
@@ -1,16 +1,33 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 
-import { DEFAULT_FIREPASS_PRESET } from "../lib/fireconnect-core.mjs";
-import { FIREPASS_ROUTER_ID } from "../lib/fireworks-models.mjs";
-import { FIREPASS_ROUTER } from "./helpers.mjs";
+import {
+  DEFAULT_FIREPASS_PRESET,
+  normalizeModelId,
+  validateModelId,
+} from "../lib/fireconnect-core.mjs";
+import {
+  claudeCodeModelId,
+  applyClaudeCodeContextPolicy,
+} from "../lib/claude-code-context.mjs";
+import {
+  fetchServerlessCatalog,
+  filterCatalogForKeyType,
+  FIREPASS_ROUTER_ID,
+} from "../lib/fireworks-models.mjs";
+import {
+  FIREPASS_ROUTER,
+  GLM_LATEST,
+  K2P7_FAST,
+  KIMI_FAST_LATEST,
+} from "./helpers.mjs";
 
 describe("Fire Pass defaults", () => {
-  test("FIREPASS_ROUTER_ID is kimi-k2p7-code-fast", () => {
+  test("FIREPASS_ROUTER_ID is glm-latest", () => {
     assert.equal(FIREPASS_ROUTER_ID, FIREPASS_ROUTER);
   });
 
-  test("DEFAULT_FIREPASS_PRESET routes all aliases to kimi-k2p7-code-fast", () => {
+  test("DEFAULT_FIREPASS_PRESET routes all aliases to glm-latest", () => {
     const aliasKeys = [
       "ANTHROPIC_MODEL",
       "ANTHROPIC_DEFAULT_OPUS_MODEL",
@@ -21,5 +38,62 @@ describe("Fire Pass defaults", () => {
     for (const key of aliasKeys) {
       assert.equal(DEFAULT_FIREPASS_PRESET[key], FIREPASS_ROUTER);
     }
+  });
+
+  test("built-in router catalog includes latest GLM and Kimi routers", async () => {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ models: [] }),
+    });
+
+    try {
+      const { catalog } = await fetchServerlessCatalog("fw_test_key");
+      const ids = catalog.map((entry) => entry.id);
+      assert.ok(ids.includes("accounts/fireworks/routers/glm-latest"));
+      assert.ok(ids.includes("accounts/fireworks/routers/kimi-fast-latest"));
+      assert.ok(ids.includes("accounts/fireworks/routers/kimi-latest"));
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test("latest router short IDs normalize as routers", () => {
+    assert.equal(normalizeModelId("glm-latest"), "accounts/fireworks/routers/glm-latest");
+    assert.equal(normalizeModelId("kimi-fast-latest"), "accounts/fireworks/routers/kimi-fast-latest");
+    assert.equal(normalizeModelId("kimi-latest"), "accounts/fireworks/routers/kimi-latest");
+  });
+
+  test("Fire Pass catalog includes all supported routers", () => {
+    const catalog = [
+      { id: "accounts/fireworks/routers/glm-latest", shortId: GLM_LATEST },
+      { id: "accounts/fireworks/routers/kimi-fast-latest", shortId: KIMI_FAST_LATEST },
+      { id: "accounts/fireworks/routers/kimi-k2p6-turbo", shortId: "kimi-k2p6-turbo" },
+      { id: "accounts/fireworks/routers/kimi-k2p7-code-fast", shortId: K2P7_FAST },
+      { id: "accounts/fireworks/routers/kimi-latest", shortId: "kimi-latest" },
+    ];
+
+    assert.deepEqual(
+      filterCatalogForKeyType(catalog, "firepass").map((entry) => entry.shortId),
+      [GLM_LATEST, KIMI_FAST_LATEST, K2P7_FAST],
+    );
+  });
+
+  test("model ID validation shows model and router examples", () => {
+    assert.throws(
+      () => validateModelId("bad/provider/path", "--main"),
+      /--main must be a Fireworks model ID like deepseek-v4-flash or a router ID like glm-latest/,
+    );
+  });
+
+  test("GLM latest and GLM 5P2 use Claude Code 1m context", () => {
+    assert.equal(claudeCodeModelId("accounts/fireworks/routers/glm-latest"), "accounts/fireworks/routers/glm-latest[1m]");
+    assert.equal(claudeCodeModelId("accounts/fireworks/models/glm-5p2"), "accounts/fireworks/models/glm-5p2[1m]");
+
+    const env = applyClaudeCodeContextPolicy(
+      { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" },
+      { main: "accounts/fireworks/routers/glm-latest" },
+    );
+    assert.equal(Object.hasOwn(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT"), false);
   });
 });

--- a/packages/setup-cli/test/harness-types.test.mjs
+++ b/packages/setup-cli/test/harness-types.test.mjs
@@ -33,7 +33,7 @@ describe("defineHarness", () => {
   it("rejects unknown harness id", () => {
     assert.throws(
       () => defineHarness({
-        id: "pi",
+        id: "unknown",
         label: "Pi",
         on: async () => {},
         off: async () => {},

--- a/packages/setup-cli/test/helpers.mjs
+++ b/packages/setup-cli/test/helpers.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import { USER_SETTINGS_RELATIVE_PATH } from "../lib/fireconnect-core.mjs";
 import { OPENCODE_CONFIG_RELATIVE_PATH } from "../lib/opencode-core.mjs";
+import { CODEX_CONFIG_RELATIVE_PATH } from "../lib/codex-core.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI = path.join(__dirname, "../bin/fireconnect.mjs");
@@ -13,14 +14,32 @@ const CLI = path.join(__dirname, "../bin/fireconnect.mjs");
 export const FPK_KEY = "fpk_test_firepass_key_000000000000";
 export const FW_CLAUDE_KEY = "fw_test_claude_key_00000000000000";
 export const FW_OPENCODE_KEY = "fw_test_opencode_key_00000000000";
+export const FW_CODEX_KEY = "fw_test_codex_key_00000000000000";
 export const SK_ANT_KEY = "sk-ant-test-non-fireworks-token";
 
+export const NO_ENV_KEY = { FIREWORKS_API_KEY: "" };
+
+export async function withoutEnvFireworksKey(fn) {
+  const prev = process.env.FIREWORKS_API_KEY;
+  delete process.env.FIREWORKS_API_KEY;
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.FIREWORKS_API_KEY;
+    } else {
+      process.env.FIREWORKS_API_KEY = prev;
+    }
+  }
+}
+
+export const GLM_LATEST = "glm-latest";
+export const KIMI_FAST_LATEST = "kimi-fast-latest";
 export const K2P7_FAST = "kimi-k2p7-code-fast";
-export const FIREPASS_ROUTER = "accounts/fireworks/routers/kimi-k2p7-code-fast";
+export const FIREPASS_ROUTER = "accounts/fireworks/routers/glm-latest";
+export const FIREPASS_ROUTER_1M = `${FIREPASS_ROUTER}[1m]`;
 export const FIREWORKS_INFERENCE_URL = "https://api.fireworks.ai/inference";
 
-/** Clear FIREWORKS_API_KEY in the child process (overrides the parent shell). */
-export const NO_ENV_KEY = { FIREWORKS_API_KEY: "" };
 
 export function claudePaths(home) {
   return {
@@ -94,8 +113,30 @@ export async function writeOpencodeConfig(home, apiKey) {
     provider: {
       "fireworks-ai": { options: { apiKey } },
     },
-    model: `fireworks-ai/accounts/fireworks/routers/${K2P7_FAST}`,
+    model: `fireworks-ai/accounts/fireworks/routers/${GLM_LATEST}`,
   });
+  return configPath;
+}
+
+export async function writeCodexConfig(home, { apiKey = FW_CODEX_KEY, envRef = false } = {}) {
+  const configPath = path.join(home, CODEX_CONFIG_RELATIVE_PATH);
+  const authLines = envRef
+    ? ['env_key = "FIREWORKS_API_KEY"']
+    : [`experimental_bearer_token = "${apiKey}"`];
+  const toml = [
+    'model_provider = "fireworks-ai"',
+    `model = "accounts/fireworks/routers/${K2P7_FAST}"`,
+    "",
+    "[model_providers.fireworks-ai]",
+    'name = "Fireworks"',
+    'base_url = "https://api.fireworks.ai/inference/v1"',
+    'wire_api = "responses"',
+    ...authLines,
+    "requires_openai_auth = false",
+    "",
+  ].join("\n");
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, toml);
   return configPath;
 }
 

--- a/packages/setup-cli/test/key-resolution.test.mjs
+++ b/packages/setup-cli/test/key-resolution.test.mjs
@@ -3,17 +3,25 @@ import { describe, test } from "node:test";
 
 import claude from "../lib/harnesses/claude.mjs";
 import opencode from "../lib/harnesses/opencode.mjs";
+import codex from "../lib/harnesses/codex.mjs";
+import pi from "../lib/harnesses/pi.mjs";
 import { resolveFireworksApiKey } from "../lib/fireworks-models.mjs";
 import {
   FW_CLAUDE_KEY,
+  FW_CODEX_KEY,
   FW_OPENCODE_KEY,
   FPK_KEY,
   withTempHome,
+  withoutEnvFireworksKey,
   writeClaudeSettings,
+  writeCodexConfig,
   writeNativeAnthropicSettings,
   writeOpencodeConfig,
 } from "./helpers.mjs";
 import { OPENCODE_API_KEY_ENV_REF } from "../lib/opencode-core.mjs";
+import { PI_API_KEY_ENV_REF, piAuthPath } from "../lib/pi-core.mjs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 
 function harnessCtx(home) {
   return {
@@ -35,6 +43,15 @@ function harnessCtx(home) {
     harnesses: "",
     apiKeyMode: "",
   };
+}
+
+async function writePiAuth(home, apiKey) {
+  const authPath = piAuthPath(home);
+  await mkdir(path.dirname(authPath), { recursive: true });
+  await writeFile(
+    authPath,
+    `${JSON.stringify({ fireworks: { type: "api_key", key: apiKey } }, null, 2)}\n`,
+  );
 }
 
 describe("harness resolveKey", () => {
@@ -82,6 +99,61 @@ describe("harness resolveKey", () => {
       }
     });
   });
+
+  test("codex returns harness-local bearer token without env", async () => {
+    await withoutEnvFireworksKey(async () => {
+      await withTempHome("codex-bearer-key", async (home) => {
+        await writeCodexConfig(home, { apiKey: FW_CODEX_KEY });
+        const key = await codex.resolveKey(harnessCtx(home));
+        assert.equal(key, FW_CODEX_KEY);
+      });
+    });
+  });
+
+  test("codex resolves env_key to FIREWORKS_API_KEY", async () => {
+    await withTempHome("codex-envref", async (home) => {
+      await writeCodexConfig(home, { envRef: true });
+      const prev = process.env.FIREWORKS_API_KEY;
+      process.env.FIREWORKS_API_KEY = FW_CODEX_KEY;
+      try {
+        const key = await codex.resolveKey(harnessCtx(home));
+        assert.equal(key, FW_CODEX_KEY);
+      } finally {
+        if (prev === undefined) {
+          delete process.env.FIREWORKS_API_KEY;
+        } else {
+          process.env.FIREWORKS_API_KEY = prev;
+        }
+      }
+    });
+  });
+
+  test("codex resolveKey returns empty when fireworks routing is inactive", async () => {
+    await withoutEnvFireworksKey(async () => {
+      await withTempHome("codex-inactive", async (home) => {
+        const key = await codex.resolveKey(harnessCtx(home));
+        assert.equal(key, "");
+      });
+    });
+  });
+
+  test("pi resolves env-ref to FIREWORKS_API_KEY", async () => {
+    await withTempHome("pi-envref", async (home) => {
+      await writePiAuth(home, PI_API_KEY_ENV_REF);
+      const prev = process.env.FIREWORKS_API_KEY;
+      process.env.FIREWORKS_API_KEY = FPK_KEY;
+      try {
+        const key = await pi.resolveKey(harnessCtx(home));
+        assert.equal(key, FPK_KEY);
+      } finally {
+        if (prev === undefined) {
+          delete process.env.FIREWORKS_API_KEY;
+        } else {
+          process.env.FIREWORKS_API_KEY = prev;
+        }
+      }
+    });
+  });
 });
 
 describe("resolveFireworksApiKey with harness resolveKey", () => {
@@ -89,11 +161,13 @@ describe("resolveFireworksApiKey with harness resolveKey", () => {
     await withTempHome("chain-claude-local", async (home) => {
       await writeClaudeSettings(home, FPK_KEY);
       const ctx = harnessCtx(home);
-      const resolved = await resolveFireworksApiKey({
-        resolveKey: () => claude.resolveKey(ctx),
-        home,
+      await withoutEnvFireworksKey(async () => {
+        const resolved = await resolveFireworksApiKey({
+          resolveKey: () => claude.resolveKey(ctx),
+          home,
+        });
+        assert.equal(resolved, FPK_KEY);
       });
-      assert.equal(resolved, FPK_KEY);
     });
   });
 
@@ -133,11 +207,13 @@ describe("resolveFireworksApiKey with harness resolveKey", () => {
       await writeClaudeSettings(home, FW_CLAUDE_KEY);
       await writeOpencodeConfig(home, FW_OPENCODE_KEY);
       const ctx = harnessCtx(home);
-      const resolved = await resolveFireworksApiKey({
-        resolveKey: () => opencode.resolveKey(ctx),
-        home,
+      await withoutEnvFireworksKey(async () => {
+        const resolved = await resolveFireworksApiKey({
+          resolveKey: () => opencode.resolveKey(ctx),
+          home,
+        });
+        assert.equal(resolved, FW_OPENCODE_KEY);
       });
-      assert.equal(resolved, FW_OPENCODE_KEY);
     });
   });
 });

--- a/packages/setup-cli/test/opencode-harness.test.mjs
+++ b/packages/setup-cli/test/opencode-harness.test.mjs
@@ -5,6 +5,7 @@ import { spawn } from "node:child_process";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { OPENCODE_FIREWORKS_PROVIDER_ID, opencodeConfigPath } from "../lib/opencode-core.mjs";
+import { GLM_LATEST } from "./helpers.mjs";
 
 const CLI = path.join(import.meta.dirname, "..", "bin", "fireconnect.mjs");
 
@@ -41,7 +42,9 @@ describe("opencode harness integration", () => {
     const enabled = JSON.parse(await readFile(configPath, "utf8"));
     assert.ok(enabled.provider?.[OPENCODE_FIREWORKS_PROVIDER_ID]);
     assert.equal(enabled.provider?.fireworks, undefined);
-    assert.ok(enabled.model.startsWith(`${OPENCODE_FIREWORKS_PROVIDER_ID}/`));
+    const defaultModel = `accounts/fireworks/routers/${GLM_LATEST}`;
+    assert.equal(enabled.model, `${OPENCODE_FIREWORKS_PROVIDER_ID}/${defaultModel}`);
+    assert.equal(enabled.provider[OPENCODE_FIREWORKS_PROVIDER_ID].models[defaultModel].name, defaultModel);
 
     const offResult = await runFireconnect(["opencode", "off"], { HOME: home });
     assert.equal(offResult.code, 0);

--- a/packages/setup-cli/test/pi-harness.test.mjs
+++ b/packages/setup-cli/test/pi-harness.test.mjs
@@ -1,0 +1,123 @@
+import { mkdtemp, readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { spawn } from "node:child_process";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { piSettingsPath, piAuthPath, PI_API_KEY_ENV_REF, PI_DATA_RELATIVE_DIR } from "../lib/pi-core.mjs";
+
+const CLI = path.join(import.meta.dirname, "..", "bin", "fireconnect.mjs");
+
+function runFireconnect(args, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.on("error", reject);
+  });
+}
+
+describe("pi harness integration", () => {
+  it("on/off round-trip restores settings and auth", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-pi-"));
+    const settingsDir = path.join(home, ".pi/agent");
+    await mkdir(settingsDir, { recursive: true });
+    const settingsPath = piSettingsPath(home);
+    const authPath = piAuthPath(home);
+    const originalSettings = JSON.stringify({ defaultProvider: "openai" }, null, 2) + "\n";
+    const originalAuth = JSON.stringify({ openai: { type: "api_key", key: "sk-test" } }, null, 2) + "\n";
+    await writeFile(settingsPath, originalSettings);
+    await writeFile(authPath, originalAuth);
+
+    const onResult = await runFireconnect(
+      ["pi", "on", "--api-key", "fw_test_key_12345"],
+      { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" },
+    );
+    assert.equal(onResult.code, 0);
+
+    const enabledSettings = JSON.parse(await readFile(settingsPath, "utf8"));
+    assert.equal(enabledSettings.defaultProvider, "fireworks");
+    assert.ok(enabledSettings.defaultModel.startsWith("accounts/fireworks/"));
+
+    const enabledAuth = JSON.parse(await readFile(authPath, "utf8"));
+    assert.equal(enabledAuth.fireworks.managedBy, "fireconnect");
+
+    const offResult = await runFireconnect(["pi", "off"], { HOME: home });
+    assert.equal(offResult.code, 0);
+
+    const restoredSettings = await readFile(settingsPath, "utf8");
+    const restoredAuth = await readFile(authPath, "utf8");
+    assert.equal(restoredSettings, originalSettings);
+    assert.equal(restoredAuth, originalAuth);
+  });
+
+  it("writes $FIREWORKS_API_KEY env ref when key comes from environment", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-pi-env-"));
+    await mkdir(path.join(home, ".pi/agent"), { recursive: true });
+    const authPath = piAuthPath(home);
+
+    const onResult = await runFireconnect(
+      ["pi", "on"],
+      { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" },
+    );
+    assert.equal(onResult.code, 0);
+    assert.match(onResult.stdout, /\$FIREWORKS_API_KEY/);
+
+    const auth = JSON.parse(await readFile(authPath, "utf8"));
+    assert.equal(auth.fireworks.key, PI_API_KEY_ENV_REF);
+    assert.equal(auth.fireworks.managedBy, "fireconnect");
+  });
+
+  it("second off after on/off round-trip leaves settings unchanged", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-pi-double-off-"));
+    await mkdir(path.join(home, ".pi/agent"), { recursive: true });
+    const settingsPath = piSettingsPath(home);
+    const authPath = piAuthPath(home);
+    const originalSettings = JSON.stringify({ defaultProvider: "openai" }, null, 2) + "\n";
+    const originalAuth = JSON.stringify({ openai: { type: "api_key", key: "sk-test" } }, null, 2) + "\n";
+    await writeFile(settingsPath, originalSettings);
+    await writeFile(authPath, originalAuth);
+
+    await runFireconnect(
+      ["pi", "on", "--api-key", "fw_test_key_12345"],
+      { HOME: home, FIREWORKS_API_KEY: "" },
+    );
+    await runFireconnect(["pi", "off"], { HOME: home });
+
+    const secondOff = await runFireconnect(["pi", "off"], { HOME: home });
+    assert.equal(secondOff.code, 0);
+    assert.match(secondOff.stdout, /not enabled for Pi/);
+
+    assert.equal(await readFile(settingsPath, "utf8"), originalSettings);
+    assert.equal(await readFile(authPath, "utf8"), originalAuth);
+  });
+
+  it("re-on after data dir wipe snapshots so off can restore", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-pi-wipe-"));
+    await mkdir(path.join(home, ".pi/agent"), { recursive: true });
+    const settingsPath = piSettingsPath(home);
+    const authPath = piAuthPath(home);
+    const env = { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" };
+
+    await writeFile(settingsPath, `${JSON.stringify({ defaultProvider: "openai" }, null, 2)}\n`);
+    await writeFile(authPath, `${JSON.stringify({ openai: { type: "api_key", key: "sk-test" } }, null, 2)}\n`);
+
+    await runFireconnect(["pi", "on", "--api-key", "fw_test_key_12345"], env);
+    const beforeReOnSettings = await readFile(settingsPath, "utf8");
+    const beforeReOnAuth = await readFile(authPath, "utf8");
+
+    await rm(path.join(home, PI_DATA_RELATIVE_DIR), { recursive: true, force: true });
+
+    await runFireconnect(["pi", "on", "--api-key", "fw_test_key_12345"], env);
+    await runFireconnect(["pi", "off"], env);
+
+    assert.equal(await readFile(settingsPath, "utf8"), beforeReOnSettings);
+    assert.equal(await readFile(authPath, "utf8"), beforeReOnAuth);
+  });
+});

--- a/packages/setup-cli/test/uninstall.test.mjs
+++ b/packages/setup-cli/test/uninstall.test.mjs
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { userSettingsPath } from "../lib/fireconnect-core.mjs";
 import { opencodeConfigPath } from "../lib/opencode-core.mjs";
+import { codexConfigPath } from "../lib/codex-core.mjs";
 import { globalConfigPath } from "../lib/global-config.mjs";
 
 const CLI = path.join(import.meta.dirname, "..", "bin", "fireconnect.mjs");
@@ -35,12 +36,14 @@ async function pathExists(filePath) {
 }
 
 describe("uninstall", () => {
-  it("restores claude and opencode then removes state", async () => {
+  it("restores claude, opencode, and codex then removes state", async () => {
     const home = await mkdtemp(path.join(os.tmpdir(), "fc-uninstall-"));
     const settingsDir = path.join(home, ".claude");
     const opencodeDir = path.join(home, ".config/opencode");
+    const codexDir = path.join(home, ".codex");
     await mkdir(settingsDir, { recursive: true });
     await mkdir(opencodeDir, { recursive: true });
+    await mkdir(codexDir, { recursive: true });
 
     const settingsPath = userSettingsPath(home);
     await writeFile(
@@ -52,12 +55,23 @@ describe("uninstall", () => {
     const opencodeOriginal = JSON.stringify({ model: "openai/gpt-4" }, null, 2) + "\n";
     await writeFile(configPath, opencodeOriginal);
 
+    const codexPath = codexConfigPath(home);
+    const codexOriginal = [
+      'model_provider = "openai"',
+      'model = "gpt-4.1"',
+    ].join("\n") + "\n";
+    await writeFile(codexPath, codexOriginal);
+
     await runFireconnect(
-      ["configure", "--harnesses", "claude,opencode", "--api-key", "fw_test_key_12345", "--api-key-mode", "literal"],
+      ["configure", "--harnesses", "claude,opencode,codex", "--api-key", "fw_test_key_12345", "--api-key-mode", "literal"],
       { HOME: home },
     );
     await runFireconnect(["claude", "on", "--api-key", "fw_test_key_12345"], { HOME: home });
     await runFireconnect(["opencode", "on", "--api-key", "fw_test_key_12345"], { HOME: home });
+    await runFireconnect(
+      ["codex", "on", "--api-key", "fw_test_key_12345"],
+      { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" },
+    );
 
     const uninstallResult = await runFireconnect(["uninstall"], { HOME: home });
     assert.equal(uninstallResult.code, 0);
@@ -68,9 +82,13 @@ describe("uninstall", () => {
     const restoredOpencode = await readFile(configPath, "utf8");
     assert.equal(restoredOpencode, opencodeOriginal);
 
+    const restoredCodex = await readFile(codexPath, "utf8");
+    assert.equal(restoredCodex, codexOriginal);
+
     assert.equal(await pathExists(globalConfigPath(home)), false);
     assert.equal(await pathExists(path.join(home, ".fireconnect/claude")), false);
     assert.equal(await pathExists(path.join(home, ".fireconnect/opencode")), false);
+    assert.equal(await pathExists(path.join(home, ".fireconnect/codex")), false);
   });
 
   it("does not mutate settings when harness was configured but not enabled", async () => {

--- a/packages/setup-cli/test/update-notify.test.mjs
+++ b/packages/setup-cli/test/update-notify.test.mjs
@@ -1,0 +1,111 @@
+import { mkdtemp, mkdir, writeFile, readFile, utimes } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  shouldSpawnChecker,
+  hasActiveUpdateLock,
+  tryAcquireUpdateLock,
+} from "../lib/update-notify.mjs";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const FIVE_MIN = 5 * 60 * 1000;
+
+describe("shouldSpawnChecker", () => {
+  const now = 1_700_000_000_000;
+
+  it("spawns when cache is missing", () => {
+    assert.equal(shouldSpawnChecker(null, now), true);
+  });
+
+  it("does not spawn while a pending check is in flight", () => {
+    assert.equal(
+      shouldSpawnChecker({ checkedAt: now - FIVE_MIN + 1000, pending: true }, now),
+      false,
+    );
+  });
+
+  it("spawns after pending TTL expires", () => {
+    assert.equal(
+      shouldSpawnChecker({ checkedAt: now - FIVE_MIN - 1000, pending: true }, now),
+      true,
+    );
+  });
+
+  it("uses 24h TTL when latestVersion is known", () => {
+    assert.equal(
+      shouldSpawnChecker({ checkedAt: now - DAY + 1000, latestVersion: "0.3.0" }, now),
+      false,
+    );
+    assert.equal(
+      shouldSpawnChecker({ checkedAt: now - DAY - 1000, latestVersion: "0.3.0" }, now),
+      true,
+    );
+  });
+
+  it("uses 1h retry when fetch failed without a known version", () => {
+    assert.equal(
+      shouldSpawnChecker({ checkedAt: now - HOUR + 1000, latestVersion: null }, now),
+      false,
+    );
+    assert.equal(
+      shouldSpawnChecker({ checkedAt: now - HOUR - 1000, latestVersion: null }, now),
+      true,
+    );
+  });
+
+  it("uses 1h retry when fetchFailed is set even with a known version", () => {
+    assert.equal(
+      shouldSpawnChecker(
+        { checkedAt: now - HOUR + 1000, latestVersion: "0.3.0", fetchFailed: true },
+        now,
+      ),
+      false,
+    );
+    assert.equal(
+      shouldSpawnChecker(
+        { checkedAt: now - HOUR - 1000, latestVersion: "0.3.0", fetchFailed: true },
+        now,
+      ),
+      true,
+    );
+  });
+});
+
+describe("tryAcquireUpdateLock", () => {
+  it("prevents concurrent workers without touching the version cache", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-update-notify-"));
+    const cacheDir = path.join(home, ".fireconnect");
+    await mkdir(cacheDir, { recursive: true });
+    const cachePath = path.join(cacheDir, "update-check.json");
+
+    await writeFile(
+      cachePath,
+      JSON.stringify({ checkedAt: Date.now(), latestVersion: "0.3.0" }),
+    );
+
+    assert.equal(tryAcquireUpdateLock(home), true);
+    assert.equal(hasActiveUpdateLock(home), true);
+    assert.equal(tryAcquireUpdateLock(home), false);
+
+    const saved = JSON.parse(await readFile(cachePath, "utf8"));
+    assert.equal(saved.latestVersion, "0.3.0");
+    assert.equal(saved.pending, undefined);
+  });
+
+  it("allows a new worker after the lock TTL expires", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-update-notify-"));
+    await mkdir(path.join(home, ".fireconnect"), { recursive: true });
+
+    assert.equal(tryAcquireUpdateLock(home), true);
+
+    const lockPath = path.join(home, ".fireconnect", "update-check.lock");
+    const stale = new Date(Date.now() - FIVE_MIN - 1000);
+    await utimes(lockPath, stale, stale);
+
+    assert.equal(hasActiveUpdateLock(home), false);
+    assert.equal(tryAcquireUpdateLock(home), true);
+  });
+});


### PR DESCRIPTION
## Summary

v0.5.0 adds two new harnesses and several UX improvements on top of v0.4.0.

### New harnesses

- **Codex harness** — route Codex 0.134+ through Fireworks with `fireconnect codex on/off/status/model`. TOML config patching with byte-for-byte restore on `off`.
- **Pi harness** — route Pi through Fireworks with `fireconnect pi on/off/status/model`. Settings + `auth.json` management with `0600` perms and snapshot restore.

### Improvements

- **Background update notifications** — FireConnect checks for new versions in the background and notifies when an upgrade is available.
- **GLM-latest router defaults** — default model mapping now uses `glm-latest` for `main`/`opus`; Fire Pass keys use `glm-latest` for all aliases.
- **Install no longer auto-activates the Claude harness** — run `fireconnect claude on` explicitly after install.
- **Config file permissions hardened** — `config.json` and Codex `config.toml` are restricted to `0o600` when a literal API key is stored, so a permissive umask can't leak the key to other local users.
- **Claude model activation docs** — clarified how to activate new models in Claude Code after FireConnect changes.

### Folded in from internal main (post-squash follow-ups)

- **Recommended model slugs docs** — README now includes a short-ID recommendation table (`glm-latest`, `glm-5p1`, `minimax-m2p5`) and the per-harness list updated to include `pi`.
- **Codex Fire Pass error clarified** — the error thrown when a Fire Pass key is used with `codex on` now references the unsupported `/responses` endpoint and asks for a standard `fw_...` key, instead of the older Anthropic-protocol messaging.

### CLI usage (new harnesses)

```bash
fireconnect codex on --api-key fw_...
fireconnect codex status
fireconnect codex model select
fireconnect codex off

fireconnect pi on --api-key fw_...
fireconnect pi status
fireconnect pi model select
fireconnect pi off
```

Harness-first syntax is unchanged from v0.4.0.

## Test plan

- [x] `npm test` in `packages/setup-cli` — 91/91 pass
- [ ] `fireconnect codex on --api-key fw_...` enables routing for Codex 0.134+ and produces `~/.codex/config.toml` with mode `0o600`
- [ ] `fireconnect codex on --api-key fpk_...` errors with the `/responses endpoint is not supported for Fire Pass keys yet` message
- [ ] `fireconnect codex off` restores previous Codex config
- [ ] `fireconnect pi on --api-key fw_...` enables routing for Pi
- [ ] `fireconnect pi off` restores previous Pi settings + auth
- [ ] `fireconnect claude on` still works (no auto-activation on install)
- [ ] Background update notification fires when a newer version is available
- [ ] `install.sh` completes without forcing Claude routing on

Made with [Cursor](https://cursor.com)