### PR TITLE
fix(claude): detect enterprise credentials from macOS Keychain

### DIFF
--- a/packages/setup-cli/lib/anthropic-enterprise.mjs
+++ b/packages/setup-cli/lib/anthropic-enterprise.mjs
@@ -1,11 +1,43 @@
 import path from "node:path";
 import process from "node:process";
+import { spawnSync } from "node:child_process";
 import { readJsonIfExists } from "./fireconnect-core.mjs";
 import { HARNESS } from "./harness.mjs";
 import { OPENCODE_ANTHROPIC_PROVIDER_ID } from "./opencode-firerouter-core.mjs";
 
 export const CLAUDE_CREDENTIALS_FILENAME = ".credentials.json";
 export const OPENCODE_AUTH_RELATIVE_PATH = ".local/share/opencode/auth.json";
+
+/** macOS Keychain service name Claude Code stores OAuth credentials under. */
+export const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+/**
+ * Test-only override for the keychain credentials blob. When set to a string,
+ * {@link readClaudeKeychainCredentials} parses it instead of querying the OS
+ * keychain. Set to "" to simulate an empty keychain. `null` restores production
+ * behavior. This avoids race conditions from concurrent tests mutating
+ * `process.env`.
+ * @type {string | null}
+ */
+let testKeychainBlob = null;
+
+/**
+ * @internal — test seam for the macOS keychain Claude credentials blob.
+ * In-process tests use this setter; spawned-child tests use the
+ * `FIRECONNECT_TEST_CLAUDE_KEYCHAIN` env var (read once at module load).
+ * @param {string | null} blob
+ */
+export function _setTestClaudeKeychainBlob(blob) {
+  testKeychainBlob = blob;
+}
+
+/**
+ * Env-based test seam for spawned CLI subprocesses. Read once at module load
+ * so child processes inherit a neutralized keychain from the test runner env.
+ * Values: a JSON string to inject, "" to simulate an empty keychain, or unset
+ * for production behavior.
+ */
+const ENV_TEST_KEYCHAIN_BLOB = process.env.FIRECONNECT_TEST_CLAUDE_KEYCHAIN ?? null;
 
 /** @typedef {"none" | "api-key" | "oauth"} AnthropicAuthKind */
 
@@ -100,6 +132,60 @@ export function opencodeAuthPath(home) {
 }
 
 /**
+ * Read the Claude Code credentials blob from the macOS login keychain.
+ * Claude Code stores its OAuth token (same shape as `.credentials.json`)
+ * under the generic-password service "Claude Code-credentials".
+ * @returns {string} raw JSON string, or "" if not found / not on macOS.
+ */
+function macReadClaudeKeychainCredentials() {
+  const r = spawnSync("security", ["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE, "-w"], {
+    encoding: "utf8",
+  });
+  if (r.status !== 0) {
+    return "";
+  }
+  return (r.stdout || "").trim();
+}
+
+/**
+ * Read Claude Code credentials from the OS keychain, returning a parsed
+ * object (same shape as `.credentials.json`) or `null` when absent.
+ * macOS is the only platform where Claude Code is known to use the keychain
+ * today; Linux/Windows fall through to the credentials file.
+ *
+ * Tests inject a fake blob via `FIRECONNECT_TEST_CLAUDE_KEYCHAIN` so the
+ * keychain path can be exercised on any OS without hitting the real keychain.
+ * @returns {Record<string, unknown> | null}
+ */
+function readClaudeKeychainCredentials() {
+  const blob = testKeychainBlob !== null ? testKeychainBlob : ENV_TEST_KEYCHAIN_BLOB;
+  if (blob !== null) {
+    if (!blob) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(blob);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  const raw = macReadClaudeKeychainCredentials();
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Anthropic key already stored on the OpenCode anthropic provider block.
  * @param {object} config parsed opencode.json
  */
@@ -135,14 +221,22 @@ export async function readOpencodeAnthropicAuth(home) {
 }
 
 /**
+ * Read Claude Code's Anthropic auth. Checks the credentials file
+ * (`~/.claude/.credentials.json`) first, then falls back to the macOS
+ * keychain entry Claude Code writes when no credentials file is present.
  * @param {string} home
- * @returns {Promise<{ kind: AnthropicAuthKind, source: "claude-credentials" | "" }>}
+ * @returns {Promise<{ kind: AnthropicAuthKind, source: "claude-credentials" | "claude-keychain" | "" }>}
  */
 export async function readClaudeAnthropicAuth(home) {
   const creds = await readJsonIfExists(claudeCredentialsPath(home));
   const kind = classifyClaudeCredentials(creds);
   if (kind === "oauth") {
     return { kind, source: "claude-credentials" };
+  }
+  const keychainCreds = readClaudeKeychainCredentials();
+  const keychainKind = classifyClaudeCredentials(keychainCreds);
+  if (keychainKind === "oauth") {
+    return { kind: keychainKind, source: "claude-keychain" };
   }
   return { kind: "none", source: "" };
 }
@@ -174,7 +268,7 @@ export async function resolveEnterpriseAnthropicAuth(home, harness) {
   if (harness === HARNESS.OPENCODE) {
     const claude = await readClaudeAnthropicAuth(home);
     if (claude.kind === "oauth") {
-      return { enterpriseAuth: true, source: "claude-credentials" };
+      return { enterpriseAuth: true, source: claude.source };
     }
     return { enterpriseAuth: false, source: "" };
   }
@@ -182,7 +276,7 @@ export async function resolveEnterpriseAnthropicAuth(home, harness) {
   if (harness === HARNESS.CLAUDE) {
     const claude = await readClaudeAnthropicAuth(home);
     if (claude.kind === "oauth") {
-      return { enterpriseAuth: true, source: "claude-credentials" };
+      return { enterpriseAuth: true, source: claude.source };
     }
     return { enterpriseAuth: false, source: "" };
   }

--- a/packages/setup-cli/package.json
+++ b/packages/setup-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireconnect/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "FireConnect CLIs for using Fireworks models with Claude Code",
   "type": "module",
   "bin": {

--- a/packages/setup-cli/test/firerouter-core.test.mjs
+++ b/packages/setup-cli/test/firerouter-core.test.mjs
@@ -24,10 +24,16 @@ import {
   hasEnterpriseAnthropicCredentials,
   opencodeAuthPath,
   resolveEnterpriseAnthropicAuth,
+  _setTestClaudeKeychainBlob,
 } from "../lib/anthropic-enterprise.mjs";
 import { HARNESS } from "../lib/harness.mjs";
 
 describe("firerouter-core", () => {
+  // Neutralize the macOS keychain so tests that don't explicitly test it
+  // aren't affected by a real Claude Code keychain entry on the dev machine.
+  // Keychain-specific tests override this with _setTestClaudeKeychainBlob.
+  _setTestClaudeKeychainBlob("");
+
   it("detects FireRouter base URL", () => {
     assert.equal(isFirerouterBaseUrl(FIREROUTER_BASE_URL), true);
     assert.equal(isFirerouterBaseUrl("https://api.fireworks.ai/inference"), false);
@@ -320,6 +326,87 @@ describe("firerouter-core", () => {
     } finally {
       if (saved !== undefined) {
         process.env.ANTHROPIC_API_KEY = saved;
+      } else {
+        delete process.env.ANTHROPIC_API_KEY;
+      }
+    }
+  });
+
+  it("resolveHarnessOnAnthropicKey uses macOS keychain when credentials file is absent", async () => {
+    const savedAnthropic = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    _setTestClaudeKeychainBlob(JSON.stringify({
+      claudeAiOauth: { accessToken: "enterprise-keychain-token" },
+    }));
+    try {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-claude-keychain-"));
+      await mkdir(path.join(home, ".claude"), { recursive: true });
+
+      const resolved = await resolveHarnessOnAnthropicKey({
+        home,
+        harness: HARNESS.CLAUDE,
+      });
+      assert.equal(resolved.anthropicKey, "");
+      assert.equal(resolved.enterpriseAuth, true);
+      assert.equal(resolved.source, "claude-keychain");
+    } finally {
+      _setTestClaudeKeychainBlob("");
+      if (savedAnthropic !== undefined) {
+        process.env.ANTHROPIC_API_KEY = savedAnthropic;
+      } else {
+        delete process.env.ANTHROPIC_API_KEY;
+      }
+    }
+  });
+
+  it("credentials file takes priority over keychain", async () => {
+    const savedAnthropic = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    _setTestClaudeKeychainBlob(JSON.stringify({
+      claudeAiOauth: { accessToken: "keychain-token" },
+    }));
+    try {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-claude-file-over-keychain-"));
+      await mkdir(path.join(home, ".claude"), { recursive: true });
+      await writeFile(
+        claudeCredentialsPath(home),
+        JSON.stringify({ claudeAiOauth: { accessToken: "file-token" } }),
+      );
+
+      const resolved = await resolveHarnessOnAnthropicKey({
+        home,
+        harness: HARNESS.CLAUDE,
+      });
+      assert.equal(resolved.enterpriseAuth, true);
+      assert.equal(resolved.source, "claude-credentials");
+    } finally {
+      _setTestClaudeKeychainBlob("");
+      if (savedAnthropic !== undefined) {
+        process.env.ANTHROPIC_API_KEY = savedAnthropic;
+      } else {
+        delete process.env.ANTHROPIC_API_KEY;
+      }
+    }
+  });
+
+  it("keychain with empty OAuth material does not count as enterprise auth", async () => {
+    const savedAnthropic = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    _setTestClaudeKeychainBlob(JSON.stringify({
+      claudeAiOauth: {},
+    }));
+    try {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-claude-keychain-empty-oauth-"));
+      await mkdir(path.join(home, ".claude"), { recursive: true });
+
+      await assert.rejects(
+        () => resolveHarnessOnAnthropicKey({ home, harness: HARNESS.CLAUDE }),
+        (error) => error.message === MISSING_ANTHROPIC_KEY_MESSAGE,
+      );
+    } finally {
+      _setTestClaudeKeychainBlob("");
+      if (savedAnthropic !== undefined) {
+        process.env.ANTHROPIC_API_KEY = savedAnthropic;
       } else {
         delete process.env.ANTHROPIC_API_KEY;
       }

--- a/packages/setup-cli/test/helpers.mjs
+++ b/packages/setup-cli/test/helpers.mjs
@@ -18,6 +18,9 @@ export const FW_CODEX_KEY = "fw_test_codex_key_00000000000000";
 export const SK_ANT_KEY = "sk-ant-test-non-fireworks-token";
 
 export const NO_ENV_KEY = { FIREWORKS_API_KEY: "" };
+// Neutralize the macOS keychain in spawned CLI subprocesses so tests don't
+// pick up a real Claude Code keychain entry on the dev machine.
+const TEST_ENV_NEUTRALIZE_KEYCHAIN = { FIRECONNECT_TEST_CLAUDE_KEYCHAIN: "" };
 
 export async function withoutEnvFireworksKey(fn) {
   const prev = process.env.FIREWORKS_API_KEY;
@@ -66,6 +69,7 @@ export async function runCli(args, { home, env = {} } = {}) {
     const child = spawn(process.execPath, [CLI, ...args], {
       env: {
         ...process.env,
+        ...TEST_ENV_NEUTRALIZE_KEYCHAIN,
         ...env,
         HOME: home,
         FIREWORKS_API_KEY: env.FIREWORKS_API_KEY ?? "",


### PR DESCRIPTION
## Summary

- Claude Code on macOS stores OAuth credentials in the Keychain (service `Claude Code-credentials`), not in `~/.claude/.credentials.json` which is the Linux/Windows path ([docs](https://code.claude.com/docs/en/authentication#credential-management)). fireconnect only checked the credentials file, so enterprise Anthropic credentials were never detected on macOS.
- Added a macOS keychain read (`security find-generic-password`) with the same `classifyClaudeCredentials` classifier already used for the file path. `readClaudeAnthropicAuth` now checks the credentials file first, then falls back to the keychain.
- `resolveEnterpriseAnthropicAuth` propagates the actual source (`claude-credentials` vs `claude-keychain`) instead of hardcoding the file source.
- Bumped version to 0.7.1.

## Changes

| File | Change |
|------|--------|
| `lib/anthropic-enterprise.mjs` | Added macOS keychain read + fallback in `readClaudeAnthropicAuth`; fixed source propagation in `resolveEnterpriseAnthropicAuth` |
| `test/firerouter-core.test.mjs` | 3 new tests (keychain fallback, file-priority, empty-OAuth rejection); suite-level keychain neutralization |
| `test/helpers.mjs` | Neutralize keychain in spawned CLI subprocesses via `FIRECONNECT_TEST_CLAUDE_KEYCHAIN` env |
| `package.json` | Version bump to 0.7.1 |

## Test plan

- [x] All 356 existing tests pass (`npm test`)
- [x] 3 new keychain tests pass
- [x] Verified end-to-end on macOS: enterprise OAuth detected from keychain, no API key prompt

Made with [Cursor](https://cursor.com)