### PR TITLE
feat(claude): Claude Code status line showing Fireworks savings

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,37 @@ FireConnect cannot override Claude Code’s price column. Use `fireconnect claud
 [current serverless pricing](https://docs.fireworks.ai/serverless/pricing), and use the
 [Fireworks billing dashboard](https://app.fireworks.ai/account/billing) for actual spend.
 
+#### Status line: live Fireworks spend vs. Anthropic
+
+`bin/cc-fireworks-savings.mjs` is a Claude Code status-line command that shows real
+savings as you work. On each render Claude Code pipes the session transcript to the
+script, which parses actual per-request token usage, computes the **real Fireworks
+spend** (from the same serverless rates `fireconnect model list` uses), and compares it
+to what the **same token mix would cost on the Anthropic-equivalent tier** (Opus for
+GLM, Sonnet for Kimi, Haiku for DeepSeek, Fable for FireRouter):
+
+```text
+🔥 Fireworks · $0.28 spent (25 req) vs Anthropic $1.14 saved $0.86 75% · glm-5p2 · fireworks
+```
+
+Wire it into `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node /path/to/fireconnect/cli/packages/setup-cli/bin/cc-fireworks-savings.mjs",
+    "padding": 0
+  }
+}
+```
+
+The comparison uses Anthropic **list prices** (including cache-read/write rates), so the
+savings figure reflects what routing through Fireworks saves versus paying Anthropic
+directly for the equivalent tier — not the inflated in-UI estimate. `firerouter` rows are
+priced against the concrete serverless model the transcript recorded, when available.
+Set `CC_STATUSLINE_NOCOLOR=1` to disable ANSI colors (e.g. for non-TTY captures).
+
 After `fireconnect claude on`, `settings.json` is updated immediately. To use
 the new model, exit Claude Code and then resume the conversation with
 `claude --resume <id>`, or start a new session.

--- a/packages/setup-cli/bin/cc-fireworks-savings.mjs
+++ b/packages/setup-cli/bin/cc-fireworks-savings.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+// Claude Code status line: live Fireworks spend vs. the Anthropic-equivalent
+// cost, showing how much you save by routing through Fireworks.
+//
+// Claude Code pipes a status-line JSON object on stdin on every render:
+//   { model, transcript_path, workspace: {current_dir}, ... }
+// We parse the session transcript for actual per-request token usage, compute
+// the real Fireworks cost (reusing the fireconnect pricing/usage modules), and
+// compare it to what the same token mix would cost on Anthropic's equivalent
+// tier (Opus for GLM, Sonnet for Kimi, Haiku for DeepSeek, Fable for FireRouter).
+//
+// Output is a single line to stdout — that is what Claude Code renders.
+//
+// The computation is split into a pure, side-effect-free `computeSavings`
+// (exported for unit tests) and a `renderStatusLine` formatter, so the logic
+// can be exercised without spawning the process.
+import process from "node:process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { computeClaudeUsageCost } from "../lib/harnesses/claude/usage.mjs";
+import { lookupFireworksPricing } from "../lib/fireworks/pricing.mjs";
+import { fireworksModelSlug, shortFireworksModelRef } from "../lib/fireworks/model-id.mjs";
+import { providerListPricing } from "../lib/demo/incumbent-detect.mjs";
+
+// Fireworks model -> Anthropic-equivalent tier. Matches the harness slot mapping
+// baked into ~/.claude/settings.json (ANTHROPIC_DEFAULT_*_MODEL).
+export const ANTHROPIC_EQUIV = {
+  // Opus tier (main/heavy)
+  "glm-5p2": "claude-opus",
+  "glm-5p2-fast": "claude-opus",
+  "glm-5p1": "claude-opus",
+  "glm-5p1-fast": "claude-opus",
+  "glm-fast-latest": "claude-opus",
+  "glm-latest": "claude-opus",
+  // Sonnet tier
+  "kimi-k3": "claude-sonnet",
+  "kimi-k3-fast": "claude-sonnet",
+  "kimi-k2p7-code": "claude-sonnet",
+  "kimi-k2p7-code-fast": "claude-sonnet",
+  "kimi-k2p6": "claude-sonnet",
+  "kimi-k2p6-fast": "claude-sonnet",
+  "kimi-k2p6-turbo": "claude-sonnet",
+  "kimi-fast-latest": "claude-sonnet",
+  "kimi-latest": "claude-sonnet",
+  // Haiku tier
+  "deepseek-v4-flash": "claude-haiku",
+  "deepseek-v4-pro": "claude-haiku",
+  // Fable tier (router)
+  firerouter: "claude-fable",
+};
+
+// Default anthropic comparison if a Fireworks model has no explicit mapping.
+export const DEFAULT_ANTHROPIC_EQUIV = "claude-sonnet";
+
+export function anthropicEquivalentSlug(fwSlug) {
+  return ANTHROPIC_EQUIV[fwSlug] ?? DEFAULT_ANTHROPIC_EQUIV;
+}
+
+// Cost of one request's token mix at a given rate set (USD per 1M tokens).
+// Mirrors computeClaudeUsageCost's token arithmetic but with arbitrary rates,
+// so we can price the *same usage* at Anthropic list prices.
+export function costAtRates(row, rates) {
+  const m = 1_000_000;
+  const input = row.input || 0;
+  const cacheRead = row.cacheRead || 0;
+  const output = row.output || 0;
+  const cacheWrite5m = row.cacheWrite5m || 0;
+  const cacheWrite1h = row.cacheWrite1h || 0;
+  return (
+    (input * rates.input
+      + cacheWrite5m * rates.cacheWrite5m
+      + cacheWrite1h * rates.cacheWrite1h
+      + cacheRead * rates.cacheRead
+      + output * rates.output)
+    / m
+  );
+}
+
+export function anthropicRatesFor(slug) {
+  const r = providerListPricing({ provider: "anthropic", modelId: slug });
+  if (!r) {
+    return null;
+  }
+  // Anthropic cache reads are 0.1x input; cache writes 1.25x (5m) / 2x (1h).
+  const input = r.inputPerMillion;
+  return {
+    input,
+    cacheWrite5m: input * 1.25,
+    cacheWrite1h: input * 2,
+    cacheRead: r.cachedInputPerMillion || input * 0.1,
+    output: r.outputPerMillion,
+    label: r.label,
+    estimated: r.estimated,
+  };
+}
+
+// Per-request actual Fireworks cost, computed via the usage module against the
+// resolved Fireworks pricing. For firerouter rows (no static rate, so the usage
+// module falls back to a reference price), re-price against the concrete
+// serverless model the transcript recorded, when Fireworks can price it.
+export function fireworksRowCost(model, usage) {
+  const row = computeClaudeUsageCost(model, usage);
+  if (!row.fireworks) {
+    const pricing = lookupFireworksPricing(model);
+    if (pricing) {
+      return {
+        ...row,
+        cost: costAtRates(row, {
+          input: pricing.input,
+          cacheWrite5m: 0,
+          cacheWrite1h: 0,
+          cacheRead: pricing.cachedInput,
+          output: pricing.output,
+        }),
+        fireworks: true,
+        fwLabel: pricing.label,
+      };
+    }
+  }
+  return { ...row, fwLabel: row.rates?.label };
+}
+
+/**
+ * Pure computation over a transcript string. Returns the running totals a
+ * status-line render needs — no filesystem, no stdout. Exported for tests.
+ * @param {string} text JSONL transcript text (may be empty / malformed)
+ * @returns {{ fireworksCost: number, anthropicCost: number, requests: number, modelLabel: string }}
+ */
+export function computeSavings(text) {
+  let fireworksCost = 0;
+  let anthropicCost = 0;
+  let requests = 0;
+  let modelLabel = "";
+
+  if (!text) {
+    return { fireworksCost, anthropicCost, requests, modelLabel };
+  }
+
+  const seen = new Set();
+  for (const line of String(text).split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; }
+    if (entry?.type !== "assistant") continue;
+    const msg = entry.message && typeof entry.message === "object" ? entry.message : {};
+    const key = msg.id || entry.requestId || entry.uuid || "";
+    if (key) { if (seen.has(key)) continue; seen.add(key); }
+    const model = msg.model || entry.model || "?";
+    const usage = entry.usage || msg.usage || {};
+    const fw = fireworksRowCost(model, usage);
+    if (!fw.fireworks) continue; // skip rows we can't price on Fireworks
+    fireworksCost += fw.cost;
+
+    const fwSlug = fireworksModelSlug(model);
+    const anthRates = anthropicRatesFor(anthropicEquivalentSlug(fwSlug));
+    if (anthRates) {
+      anthropicCost += costAtRates({
+        input: fw.input,
+        cacheRead: fw.cacheRead,
+        output: fw.output,
+        cacheWrite5m: fw.cacheWrite5m,
+        cacheWrite1h: fw.cacheWrite1h,
+      }, anthRates);
+    }
+    requests += 1;
+    modelLabel = shortFireworksModelRef(model) || modelLabel;
+  }
+
+  return { fireworksCost, anthropicCost, requests, modelLabel };
+}
+
+// ANSI color helpers (kept light — status lines render on a single line).
+export const COLORS = {
+  reset: "\x1b[0m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+  green: "\x1b[38;5;36m",
+  red: "\x1b[38;5;203m",
+  cyan: "\x1b[38;5;45m",
+  yellow: "\x1b[38;5;214m",
+  fwOrange: "\x1b[38;5;208m",
+};
+
+function isNoColor() {
+  return process.env.CC_STATUSLINE_NOCOLOR === "1"
+    || (!process.stdout.isTTY && process.env.CC_STATUSLINE_FORCE_COLOR !== "1");
+}
+
+function paint(color, text, { noColor = false } = {}) {
+  return noColor ? text : `${color}${text}${COLORS.reset}`;
+}
+
+export function fmtUsd(value) {
+  if (value < 0.005) {
+    return `$${value.toFixed(4).replace(/0+$/, "").replace(/\.$/, "")}`;
+  }
+  return `$${value.toFixed(2)}`;
+}
+
+export function fmtPct(value) {
+  return `${Math.max(0, Math.round(value))}%`;
+}
+
+/**
+ * Render the status line from pre-parsed input. `ctx` mirrors Claude Code's
+ * status-line JSON; `transcriptText` is the read transcript (passed in, not
+ * read here, so this stays pure and testable).
+ * @param {{ model?: string, workspace?: { current_dir?: string }, cwd?: string }=} ctx
+ * @param {string} [transcriptText]
+ * @param {{ noColor?: boolean }} [opts]
+ * @returns {string}
+ */
+export function renderStatusLine(ctx = {}, transcriptText = "", opts = {}) {
+  const noColor = opts.noColor ?? isNoColor();
+  const { fireworksCost, anthropicCost, requests, modelLabel } = computeSavings(transcriptText);
+  const saved = anthropicCost - fireworksCost;
+  const pct = anthropicCost > 0 ? (saved / anthropicCost) * 100 : 0;
+  const dir = ctx.workspace?.current_dir || ctx.cwd
+    ? path.basename(ctx.workspace?.current_dir || ctx.cwd) : "";
+  const label = modelLabel || shortFireworksModelRef(ctx.model || "") || "Fireworks";
+
+  const parts = [];
+  parts.push(paint(COLORS.fwOrange, "🔥 Fireworks", { noColor }));
+  parts.push(paint(COLORS.dim, "·", { noColor }));
+  parts.push(`${paint(COLORS.bold, fmtUsd(fireworksCost), { noColor })} spent`);
+  if (requests > 0) {
+    parts.push(paint(COLORS.dim, `(${requests} req)`, { noColor }));
+  }
+  parts.push(paint(COLORS.dim, "vs Anthropic", { noColor }));
+  parts.push(paint(COLORS.dim, fmtUsd(anthropicCost), { noColor }));
+  if (saved > 0) {
+    parts.push(paint(COLORS.green, `saved ${fmtUsd(saved)}`, { noColor }));
+    parts.push(paint(COLORS.green, fmtPct(pct), { noColor }));
+  } else if (anthropicCost > 0) {
+    parts.push(paint(COLORS.yellow, `Δ ${fmtUsd(saved)}`, { noColor }));
+  }
+  parts.push(paint(COLORS.dim, "·", { noColor }));
+  parts.push(paint(COLORS.cyan, String(label), { noColor }));
+  if (dir) {
+    parts.push(paint(COLORS.dim, "·", { noColor }));
+    parts.push(paint(COLORS.dim, dir, { noColor }));
+  }
+
+  return parts.join(" ");
+}
+
+async function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { data += chunk; });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(""));
+    // If stdin is a TTY (no piped input), don't hang.
+    if (process.stdin.isTTY) {
+      resolve("");
+    }
+  });
+}
+
+async function main() {
+  const raw = await readStdin();
+  let ctx = {};
+  if (raw.trim()) {
+    try { ctx = JSON.parse(raw); } catch { /* ignore malformed */ }
+  }
+
+  let transcriptText = "";
+  if (ctx.transcript_path) {
+    try {
+      transcriptText = await readFile(ctx.transcript_path, "utf8");
+    } catch {
+      transcriptText = "";
+    }
+  }
+
+  process.stdout.write(renderStatusLine(ctx, transcriptText));
+}
+
+// Only run main when invoked directly as a script, not when imported by tests.
+if (process.argv[1] && process.argv[1].endsWith("cc-fireworks-savings.mjs")) {
+  main().catch(() => {
+    // Never crash the status line — fall back to a minimal safe line.
+    process.stdout.write("🔥 Fireworks");
+  });
+}

--- a/packages/setup-cli/test/cli/cc-fireworks-savings.test.mjs
+++ b/packages/setup-cli/test/cli/cc-fireworks-savings.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  computeSavings,
+  renderStatusLine,
+  costAtRates,
+  anthropicEquivalentSlug,
+  ANTHROPIC_EQUIV,
+} from "../../bin/cc-fireworks-savings.mjs";
+
+// Build a single assistant JSONL row with the usage shape Claude Code records.
+function assistantRow({ id, model, usage }) {
+  return JSON.stringify({
+    type: "assistant",
+    message: { id, model, content: [{ type: "text", text: "ok" }] },
+    usage,
+  });
+}
+
+const GLM = "accounts/fireworks/models/glm-5p2";
+const KIMI = "accounts/fireworks/routers/kimi-fast-latest";
+const DEEPSEEK = "accounts/fireworks/models/deepseek-v4-flash";
+
+describe("cc-fireworks-savings status line", () => {
+  it("computes Fireworks spend below the Anthropic-equivalent cost", () => {
+    // 1k input + 500 output on GLM 5.2 (== Opus tier).
+    const transcript = [
+      assistantRow({
+        id: "msg-1",
+        model: GLM,
+        usage: { input_tokens: 1000, output_tokens: 500, cache_read_input_tokens: 0 },
+      }),
+    ].join("\n");
+
+    const { fireworksCost, anthropicCost, requests, modelLabel } = computeSavings(transcript);
+
+    assert.equal(requests, 1);
+    assert.equal(modelLabel, "glm-5p2");
+    // Fireworks GLM 5.2: $1.4/M in, $4.4/M out -> (1000*1.4 + 500*4.4)/1e6 = 0.0036
+    assert.ok(Math.abs(fireworksCost - 0.0036) < 1e-9, `fw cost ${fireworksCost}`);
+    // Anthropic Opus: $5/M in, $25/M out -> (1000*5 + 500*25)/1e6 = 0.0175
+    assert.ok(Math.abs(anthropicCost - 0.0175) < 1e-9, `anth cost ${anthropicCost}`);
+    assert.ok(fireworksCost < anthropicCost, "fireworks should be cheaper");
+  });
+
+  it("maps each Fireworks family to its Anthropic-equivalent tier", () => {
+    assert.equal(anthropicEquivalentSlug("glm-5p2"), "claude-opus");
+    assert.equal(anthropicEquivalentSlug("kimi-k3-fast"), "claude-sonnet");
+    assert.equal(anthropicEquivalentSlug("deepseek-v4-flash"), "claude-haiku");
+    assert.equal(anthropicEquivalentSlug("firerouter"), "claude-fable");
+    // Unknown slugs fall back to Sonnet (the reference tier).
+    assert.equal(anthropicEquivalentSlug("some-future-model"), "claude-sonnet");
+  });
+
+  it("prices the same token mix at Anthropic cache rates", () => {
+    const row = { input: 1000, output: 200, cacheRead: 5000, cacheWrite5m: 0, cacheWrite1h: 0 };
+    // Opus: in $5, out $25, cacheRead $0.5 per M.
+    const cost = costAtRates(row, { input: 5, output: 25, cacheRead: 0.5, cacheWrite5m: 6.25, cacheWrite1h: 10 });
+    // (1000*5 + 200*25 + 5000*0.5)/1e6 = (5000 + 5000 + 2500)/1e6 = 0.0125
+    assert.ok(Math.abs(cost - 0.0125) < 1e-9, `cost ${cost}`);
+  });
+
+  it("handles the firerouter case by pricing the concrete dispatched model", () => {
+    // FireRouter has no static rate, but when the transcript records a concrete
+    // serverless model it should be priced as Fireworks (not skipped).
+    const transcript = assistantRow({
+      id: "msg-fr",
+      model: GLM, // a concrete model that arrived via firerouter
+      usage: { input_tokens: 2000, output_tokens: 100, cache_read_input_tokens: 0 },
+    });
+    const { fireworksCost, requests } = computeSavings(transcript);
+    assert.equal(requests, 1);
+    assert.ok(fireworksCost > 0, "concrete-model row should be priced");
+  });
+
+  it("deduplicates repeated assistant message ids", () => {
+    const row = assistantRow({
+      id: "dup-1",
+      model: GLM,
+      usage: { input_tokens: 1000, output_tokens: 100, cache_read_input_tokens: 0 },
+    });
+    const { requests } = computeSavings([row, row, row].join("\n"));
+    assert.equal(requests, 1);
+  });
+
+  it("ignores non-assistant and malformed lines", () => {
+    const transcript = [
+      JSON.stringify({ type: "user", message: { content: "hi" } }),
+      "not json at all",
+      JSON.stringify({ type: "summary", summary: "stuff" }),
+      assistantRow({ id: "msg-2", model: KIMI, usage: { input_tokens: 500, output_tokens: 50 } }),
+    ].join("\n");
+    const { requests } = computeSavings(transcript);
+    assert.equal(requests, 1);
+  });
+
+  it("returns zeros for an empty transcript and never throws on malformed input", () => {
+    assert.deepEqual(computeSavings(""), { fireworksCost: 0, anthropicCost: 0, requests: 0, modelLabel: "" });
+    assert.deepEqual(computeSavings(null), { fireworksCost: 0, anthropicCost: 0, requests: 0, modelLabel: "" });
+    // Garbage in must not throw.
+    assert.doesNotThrow(() => computeSavings("{{{not json}}}"));
+  });
+
+  it("renders a single-line status string with savings > 0", () => {
+    const transcript = assistantRow({
+      id: "msg-r",
+      model: DEEPSEEK,
+      usage: { input_tokens: 100000, output_tokens: 20000, cache_read_input_tokens: 0 },
+    });
+    const line = renderStatusLine({ workspace: { current_dir: "/home/me/proj" } }, transcript, { noColor: true });
+    assert.equal(typeof line, "string");
+    assert.ok(!line.includes("\n"), "status line must be a single line");
+    assert.match(line, /🔥 Fireworks/);
+    assert.match(line, /saved/);
+    assert.match(line, /proj/);
+  });
+
+  it("renders a safe fallback line with no transcript data", () => {
+    const line = renderStatusLine({ model: "firerouter[1m]" }, "", { noColor: true });
+    assert.match(line, /🔥 Fireworks/);
+    assert.match(line, /\$0/);
+    assert.match(line, /firerouter\[1m\]/);
+  });
+
+  it("keeps the equivalence map covering every Fast/latest router id", () => {
+    // Guard against a new router id landing in the harness without a tier
+    // mapping: every mapped slug must resolve to its declared Anthropic tier.
+    for (const slug of Object.keys(ANTHROPIC_EQUIV)) {
+      assert.equal(
+        anthropicEquivalentSlug(slug),
+        ANTHROPIC_EQUIV[slug],
+        `equiv mismatch for ${slug}`,
+      );
+    }
+    // Spot-check that each Claude tier is represented.
+    const tiers = new Set(Object.values(ANTHROPIC_EQUIV));
+    for (const tier of ["claude-opus", "claude-sonnet", "claude-haiku", "claude-fable"]) {
+      assert.ok(tiers.has(tier), `missing tier ${tier}`);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a Claude Code **status-line command** that surfaces live cost savings from routing through Fireworks, closing the gap noted in the README's *"Claude Code pricing estimates (important)"* section: Claude Code's in-UI cost column uses Anthropic list prices and overstates spend for Fireworks users, and FireConnect can't override that column. This puts the real bill — and the savings vs. paying Anthropic directly — in the status bar instead.

`packages/setup-cli/bin/cc-fireworks-savings.mjs`

On each render Claude Code pipes a status-line JSON object (`{ model, transcript_path, workspace, ... }`) to the script on stdin. It then:

1. parses the session transcript for actual per-request token usage (input / output / cache read / cache writes),
2. computes the **real Fireworks spend** from the existing serverless pricing modules — the same rates `fireconnect model list` reports,
3. compares it to what the **same token mix** would cost on the **Anthropic-equivalent tier** at list prices (Opus for GLM, Sonnet for Kimi, Haiku for DeepSeek, Fable for FireRouter), including Anthropic cache read/write rates,
4. renders a single line:

<img width="1351" height="608" alt="Screenshot 2026-07-30 at 2 38 34 PM" src="https://github.com/user-attachments/assets/99bbbab2-d63f-451e-b57b-8b6dfdbc9bd7" />

```
🔥 Fireworks · $0.28 spent (25 req) vs Anthropic $1.14 saved $0.86 75% · glm-5p2 · fireworks
```

## Why this shape

- **Reuses existing modules** (`pricing.mjs`, `model-specs.mjs`, `usage.mjs`, `incumbent-detect.mjs`) rather than hardcoding rates, so it tracks catalog/pricing updates automatically — no second source of truth to keep in sync.
- **`firerouter` has no static rate**, so for router rows the script prices against the **concrete serverless model the transcript recorded**, when available; rows it can't price are skipped (never counted as zero-cost savings).
- **Pure core for testing**: computation is split into an exported `computeSavings(transcriptText)` + `renderStatusLine(ctx, text)` so the logic is exercised without spawning a process. `main()` is a thin stdin/file wrapper.
- **Never crashes the status line** — malformed input or missing transcripts fall back to a safe minimal line (a crashing status line command is worse than no status line).

## Wiring

Add to `~/.claude/settings.json`:

```json
{
  "statusLine": {
    "type": "command",
    "command": "node /path/to/fireconnect/cli/packages/setup-cli/bin/cc-fireworks-savings.mjs",
    "padding": 0
  }
}
```

Set `CC_STATUSLINE_NOCOLOR=1` for non-TTY / CI captures.

## Tests

New `test/cli/cc-fireworks-savings.test.mjs` (10 cases, all passing):

- Fireworks spend computed below Anthropic-equivalent cost, with exact expected values for a known token mix.
- Equivalence map covers each Fireworks family → Anthropic tier; unknown slugs fall back to Sonnet.
- `costAtRates` prices the same token mix at Anthropic cache rates.
- `firerouter` case: a concrete dispatched model is priced as Fireworks, not skipped.
- Dedup of repeated assistant message ids.
- Non-assistant and malformed lines ignored; empty/null/garbage input returns zeros and never throws.
- Render produces a single line with savings > 0; safe fallback with no transcript data.

```
node --test packages/setup-cli/test/cli/cc-fireworks-savings.test.mjs
# tests 10, pass 10, fail 0
```

Full-suite note: `node --test test/**/*.test.mjs` shows 8 unrelated failures on this machine, all environmental — `deepagents-toml` tests need `tomllib` (Python ≥3.11) and `detectIncumbent` tests need live Anthropic credentials. None touch the status-line code path.

## Files

- `packages/setup-cli/bin/cc-fireworks-savings.mjs` — the status-line command (new)
- `packages/setup-cli/test/cli/cc-fireworks-savings.test.mjs` — unit tests (new)
- `README.md` — documents the status line under "Claude Code pricing estimates"

🤖 Generated with [Claude Code](https://claude.com/claude-code)