### PR TITLE
feat(kimi): add Kimi Code CLI harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/fw-ai/fireconnect/blob/main/LICENSE)
 
-> Use [Fireworks AI](https://fireworks.ai) models in Claude Code, OpenCode, Codex, Pi, Cursor, VS Code, and Deep Agents.
+> Use [Fireworks AI](https://fireworks.ai) models in Claude Code, OpenCode, Codex, Pi, Cursor, VS Code, Deep Agents, and Kimi Code.
 
 One CLI points your existing AI coding tools at Fireworks. `on` rewrites the tool's own config,
 `off` restores your original file **byte-for-byte** — no proxy to run, no wrapper to launch.
@@ -10,7 +10,7 @@ One CLI points your existing AI coding tools at Fireworks. `on` rewrites the too
 **Contents:** [Quick start](#quick-start) · [Supported harnesses](#supported-harnesses) ·
 [Default models](#default-models) · [Claude Code](#claude-code) · [Codex](#codex) ·
 [OpenCode](#opencode) · [Pi](#pi) · [Cursor](#cursor) · [VS Code Chat](#vs-code-chat) ·
-[Deep Agents](#deep-agents) · [FireRouter](#firerouter) · [Models](#models) ·
+[Deep Agents](#deep-agents) · [Kimi Code](#kimi-code) · [FireRouter](#firerouter) · [Models](#models) ·
 [Azure / Foundry](#azure-microsoft-foundry-endpoints) · [CLI reference](#cli-reference) ·
 [Keys and storage](#keys-and-storage) · [Troubleshooting](#troubleshooting) ·
 [Upgrade and uninstall](#upgrade-and-uninstall)
@@ -68,7 +68,7 @@ Model mapping:
   fable    -> kimi-fast-latest  $4.5 / $22.5 · vision
 ```
 
-Swap `claude` for any harness: `opencode`, `codex`, `pi`, `cursor`, `vscode`, `deepagents`.
+Swap `claude` for any harness: `opencode`, `codex`, `pi`, `cursor`, `vscode`, `deepagents`, `kimi`.
 Run `fireconnect help` or `fireconnect <harness> help` for every option.
 
 ### Install notes
@@ -101,6 +101,7 @@ mkdir -p ~/.fireconnect && git clone git@github.com:fw-ai/fireconnect.git ~/.fir
 | [Cursor](#cursor) | `fireconnect cursor` | `state.vscdb` (SQLite) | IDE `safeStorage` | **Quit Cursor first** |
 | [VS Code Chat](#vs-code-chat) | `fireconnect vscode` | `chatLanguageModels.json` + `state.vscdb` | IDE `safeStorage` | **Quit VS Code first** |
 | [Deep Agents](#deep-agents) | `fireconnect deepagents` | `~/.deepagents/config.toml` | Baked literal (`0600`) | Restart `dcode` after |
+| [Kimi Code](#kimi-code) | `fireconnect kimi` | `~/.kimi-code/config.toml` | Baked literal (`0600`) | Restart after |
 
 Every harness supports `on`, `off`, `status`, and `help`. `off` restores your pre-connect
 configuration — file-based harnesses byte-for-byte from a snapshot under `~/.fireconnect/`,
@@ -114,7 +115,7 @@ and the IDEs by removing only what FireConnect registered.
 | Claude `opus`, `sonnet` | `glm-fast-latest` |
 | Claude `fable` | `kimi-fast-latest` |
 | Claude `haiku`, `subagent` | `deepseek-v4-flash` |
-| OpenCode, Codex, Pi, Cursor, VS Code, Deep Agents | `kimi-fast-latest` |
+| OpenCode, Codex, Pi, Cursor, VS Code, Deep Agents, Kimi Code | `kimi-fast-latest` |
 | Fire Pass (`fpk_...`) | `kimi-fast-latest` everywhere |
 
 Fire Pass keys are detected automatically — no flags needed. Saved Claude mappings are
@@ -396,6 +397,26 @@ fireconnect deepagents off
 
 Use `--config-path <path>` for a non-default config.
 
+## Kimi Code
+
+Routes [Kimi Code](https://github.com/MoonshotAI/kimi-code) through Fireworks.
+
+```bash
+fireconnect kimi on
+fireconnect kimi status
+fireconnect kimi on --model glm-5p1
+fireconnect kimi off
+```
+
+- Sets the root `default_model` and configures `[providers.fireworks]` (`type = "openai"`) in
+  `~/.kimi-code/config.toml` with the Fireworks OpenAI-compatible base URL and a **baked**
+  `api_key` literal (mode `0600`), plus a `[models."fireworks/<slug>"]` entry carrying the
+  model's context window and capabilities.
+- Kimi Code OAuth credentials are untouched — only FireConnect-owned provider and model entries
+  are written, and `off` restores your previous config.
+
+Use `--config-path <path>` for a non-default config.
+
 ## FireRouter
 
 FireRouter is a judge-model router: simpler requests go to cheaper models, harder ones pass
@@ -428,6 +449,7 @@ server-side — no extra flags. Otherwise pass `--anthropic-api-key sk-ant-...` 
 | Codex | `ANTHROPIC_API_KEY` env reference | No | Export the key, or use workspace BYOK |
 | Cursor | Workspace BYOK only | No | Override UI can't attach a local Anthropic key |
 | Deep Agents | Workspace BYOK only | No | Same BYOK shape as Cursor |
+| Kimi Code | Workspace BYOK only | No | Same BYOK shape as Cursor |
 
 Tune the cost/quality tradeoff where supported:
 
@@ -473,8 +495,8 @@ slugs and migrate legacy canonical configs on the next `on`. Not sure what to pi
 Fireworks models are also first-party models inside
 [Microsoft Foundry](https://docs.fireworks.ai/ecosystem/integrations/azure-foundry), billed
 through Azure and counting toward your MACC. Foundry exposes an **OpenAI-compatible** endpoint,
-so **OpenCode, Codex, Pi, Deep Agents, Cursor, and VS Code** can route there instead of the
-Fireworks gateway.
+so **OpenCode, Codex, Pi, Deep Agents, Kimi Code, Cursor, and VS Code** can route there instead
+of the Fireworks gateway.
 
 Configure once, then `<harness> on` uses it — no per-command flags:
 
@@ -501,7 +523,8 @@ fireconnect opencode on --azure --base-url https://<resource>.services.ai.azure.
   `https://<resource>.services.ai.azure.com/openai/v1`. Find it in the Foundry portal under
   **Project settings**.
 - **Auth.** Use your **Azure** API key (not `fw_`/`fpk_`). `--api-key` writes it literally;
-  exporting `AZURE_API_KEY` writes an environment reference instead.
+  exporting `AZURE_API_KEY` writes an environment reference instead (Kimi Code always bakes a
+  literal — its provider config has no env-reference field).
 - **Model.** The id is your Foundry **deployment** name — the catalog model name without the
   `fireworks-ai/` prefix (e.g. `FW-GLM-5.2`, `FW-MiniMax-M2.5`). Defaults to `FW-GLM-5.2`.
 - **Isolation.** Each harness writes a dedicated `fireworks-azure` provider separate from the
@@ -513,6 +536,7 @@ fireconnect opencode on --azure --base-url https://<resource>.services.ai.azure.
 | Codex | `[model_providers.fireworks-azure]` in `config.toml` (`wire_api = "chat"`, bearer or `env_key = "AZURE_API_KEY"`) | `fireworks-azure` |
 | Pi | custom `openai-completions` provider in `models.json` (`baseUrl`, `authHeader`, `apiKey` literal or `$AZURE_API_KEY`) + `defaultProvider` in `settings.json` | `fireworks-azure` |
 | Deep Agents | `[models.providers.fireworks-azure]` in `config.toml` | `fireworks-azure:<deployment>` |
+| Kimi Code | `[providers.fireworks-azure]` in `config.toml` | `fireworks-azure/<deployment>` |
 | Cursor | OpenAI-compatible URL, deployment, and key in `state.vscdb` | `<deployment>` |
 | VS Code | custom endpoint model in `chatLanguageModels.json`; key in `safeStorage` | `<deployment>` |
 
@@ -526,7 +550,7 @@ fireconnect opencode on --azure --base-url https://<resource>.services.ai.azure.
 
 Harness-first: `fireconnect <harness> <command>`, plus a few global commands.
 
-**Per harness** (`claude`, `opencode`, `codex`, `pi`, `cursor`, `vscode`, `deepagents`)
+**Per harness** (`claude`, `opencode`, `codex`, `pi`, `cursor`, `vscode`, `deepagents`, `kimi`)
 
 ```text
 fireconnect <harness> on           Route the harness through Fireworks (default if no command).
@@ -567,8 +591,8 @@ runs the same sign-in inline when a key is needed.
   literal key. Legacy installs may still have `{env:FIREWORKS_API_KEY}`.
 - The key itself lives in the OS keychain, or an encrypted-file / plaintext fallback tier when
   no secret service is available (`fireconnect status` reports which).
-- Harness configs hold **baked literals** for Claude's custom header, Codex, OpenCode, Pi, and
-  Deep Agents; Cursor and VS Code use IDE `safeStorage`.
+- Harness configs hold **baked literals** for Claude's custom header, Codex, OpenCode, Pi,
+  Deep Agents, and Kimi Code; Cursor and VS Code use IDE `safeStorage`.
 - Claude websearch MCP no longer uses a shell hook — the Bearer token is baked into
   `~/.claude.json`. Re-running `install.sh` or `fireconnect upgrade` shares one finalize path
   that rebakes enabled harness configs (and any existing websearch entry) to literals, including

--- a/packages/setup-cli/lib/cli/commands/global.mjs
+++ b/packages/setup-cli/lib/cli/commands/global.mjs
@@ -144,7 +144,7 @@ function claudeHelp() {
 function configHarnessHelp(id, label, { configPath, configPathNote = "", codexNote = "" } = {}) {
   const onOpts = standardOnOpts({
     firerouter: getHarness(id).firerouter,
-    modelNote: id === "deepagents" ? "use firerouter for FireRouter" : id === "codex" ? "use firerouter for FireRouter" : "",
+    modelNote: ["deepagents", "codex", "kimi"].includes(id) ? "use firerouter for FireRouter" : "",
   });
   const allOpts = [
     OPT_HOME,
@@ -223,6 +223,7 @@ export function mainCommandsHelp() {
       ["cursor", "Cursor IDE"],
       ["vscode", "VS Code Chat"],
       ["deepagents", "Deep Agents (dcode)"],
+      ["kimi", "Kimi Code"],
     ]),
     "",
     cmdBlock("Per harness", [
@@ -281,6 +282,10 @@ export function printHelp(topic = "") {
     deepagents: configHarnessHelp("deepagents", "Deep Agents (dcode)", {
       configPath: "--config-path <path>",
       configPathNote: "Explicit ~/.deepagents/config.toml path.",
+    }),
+    kimi: configHarnessHelp("kimi", "Kimi Code", {
+      configPath: "--config-path <path>",
+      configPathNote: "Explicit ~/.kimi-code/config.toml path.",
     }),
     login: helpLines(
       `Usage: ${CLI_NAME} login [options]`,
@@ -359,6 +364,7 @@ export function printHelp(topic = "") {
       ["cursor", "Cursor IDE"],
       ["vscode", "VS Code Chat"],
       ["deepagents", "Deep Agents (dcode)"],
+      ["kimi", "Kimi Code"],
     ]),
     "",
     cmdBlock("Harness commands", [
@@ -716,7 +722,7 @@ export async function runUninstallCommand(ctx) {
 
   const hasErrors = offErrors.length > 0 || removalFailures.length > 0;
   if (!hasErrors) {
-    console.log("FireConnect has been uninstalled. Restart any running harnesses (Claude Code, OpenCode, Codex, Pi, Cursor, VS Code, Deep Agents) to fully apply.");
+    console.log("FireConnect has been uninstalled. Restart any running harnesses (Claude Code, OpenCode, Codex, Pi, Cursor, VS Code, Deep Agents, Kimi Code) to fully apply.");
   } else {
     if (removalFailures.length > 0) {
       console.error("FireConnect uninstall completed with file removal errors:");

--- a/packages/setup-cli/lib/cli/commands/harness.mjs
+++ b/packages/setup-cli/lib/cli/commands/harness.mjs
@@ -86,7 +86,7 @@ function validateHarnessOptions(route, ctx) {
     throw new Error("--settings-path is supported only by Claude and Pi.");
   }
   if (ctx.configPath && !FILE_CONFIG_HARNESS_SET.has(harnessId)) {
-    throw new Error("--config-path is supported only by OpenCode, Codex, Pi, and Deep Agents.");
+    throw new Error("--config-path is supported only by OpenCode, Codex, Pi, Deep Agents, and Kimi Code.");
   }
   if (ctx.dbPath && harnessId !== HARNESS.CURSOR) {
     throw new Error("--db-path is supported only by Cursor.");

--- a/packages/setup-cli/lib/cli/messages.mjs
+++ b/packages/setup-cli/lib/cli/messages.mjs
@@ -14,6 +14,7 @@ export const FIREROUTER_DOCS_URL =
 const FIREROUTER_HARNESS_LABELS = {
   cursor: "Cursor",
   deepagents: "Deep Agents",
+  kimi: "Kimi Code",
 };
 
 function displayModel(model) {
@@ -330,6 +331,10 @@ export function printPiRestartHint() {
 
 export function printDeepagentsRestartHint() {
   printSessionRestartHint("Deep Agents");
+}
+
+export function printKimiRestartHint() {
+  printSessionRestartHint("Kimi Code");
 }
 
 export function printOpenCodeRestartHint() {

--- a/packages/setup-cli/lib/harness/context.mjs
+++ b/packages/setup-cli/lib/harness/context.mjs
@@ -12,6 +12,10 @@ import {
   deepagentsDataDir,
 } from "../harnesses/deepagents/core.mjs";
 import {
+  kimiConfigPath,
+  kimiDataDir,
+} from "../harnesses/kimi/core.mjs";
+import {
   opencodeConfigPath,
   opencodeDataDir,
 } from "../harnesses/opencode/core.mjs";
@@ -102,6 +106,16 @@ export function deepagentsPathsFor(ctx) {
   };
 }
 
+/**
+ * @param {HarnessContext} ctx
+ */
+export function kimiPathsFor(ctx) {
+  return {
+    configPath: kimiConfigPath(ctx.home, ctx.configPath),
+    dataDir: kimiDataDir(ctx.home, ctx.dataDir),
+  };
+}
+
 /** Per-harness path-override fields + the flag to suggest in the error message. */
 const HOME_VALIDATION = {
   claude: { fields: ["settingsPath"], flag: "--settings-path" },
@@ -111,11 +125,12 @@ const HOME_VALIDATION = {
   cursor: { fields: ["dbPath"], flag: "--db-path" },
   vscode: { fields: ["vscodePath"], flag: "--vscode-path" },
   deepagents: { fields: ["configPath"], flag: "--config-path" },
+  kimi: { fields: ["configPath"], flag: "--config-path" },
 };
 
 /**
  * @param {HarnessContext} ctx
- * @param {"claude" | "opencode" | "codex" | "pi" | "cursor" | "vscode" | "deepagents"} harnessId
+ * @param {"claude" | "opencode" | "codex" | "pi" | "cursor" | "vscode" | "deepagents" | "kimi"} harnessId
  */
 export function ensureHomeForHarness(ctx, harnessId) {
   const req = HOME_VALIDATION[harnessId] ?? HOME_VALIDATION.claude;

--- a/packages/setup-cli/lib/harness/detect.mjs
+++ b/packages/setup-cli/lib/harness/detect.mjs
@@ -31,6 +31,7 @@ export function detectInstalledHarnesses(home) {
     // itself only appears once the user touches custom models.
     [HARNESS.VSCODE]: [path.dirname(chatLanguageModelsPath({ home }))],
     [HARNESS.DEEPAGENTS]: [path.join(home, ".deepagents")],
+    [HARNESS.KIMI]: [path.join(home, ".kimi-code")],
   };
 
   return Object.entries(probes)

--- a/packages/setup-cli/lib/harness/id.mjs
+++ b/packages/setup-cli/lib/harness/id.mjs
@@ -1,4 +1,4 @@
-/** @typedef {"" | "claude" | "opencode" | "codex" | "pi" | "cursor" | "vscode" | "deepagents"} HarnessArg */
+/** @typedef {"" | "claude" | "opencode" | "codex" | "pi" | "cursor" | "vscode" | "deepagents" | "kimi"} HarnessArg */
 
 export const HARNESS = Object.freeze({
   CLAUDE: "claude",
@@ -8,16 +8,18 @@ export const HARNESS = Object.freeze({
   CURSOR: "cursor",
   VSCODE: "vscode",
   DEEPAGENTS: "deepagents",
+  KIMI: "kimi",
 });
 
 export const HARNESSES = Object.freeze(Object.values(HARNESS));
 
-/** Codex, OpenCode, Pi, and Deep Agents — file-based configs (literal or legacy env ref). */
+/** Codex, OpenCode, Pi, Deep Agents, and Kimi Code — file-based configs (literal or legacy env ref). */
 export const FILE_CONFIG_HARNESS_IDS = Object.freeze([
   HARNESS.CODEX,
   HARNESS.OPENCODE,
   HARNESS.PI,
   HARNESS.DEEPAGENTS,
+  HARNESS.KIMI,
 ]);
 
 export const FILE_CONFIG_HARNESS_SET = new Set(FILE_CONFIG_HARNESS_IDS);

--- a/packages/setup-cli/lib/harness/registry.mjs
+++ b/packages/setup-cli/lib/harness/registry.mjs
@@ -2,6 +2,7 @@ import claude from "../harnesses/claude/index.mjs";
 import codex from "../harnesses/codex/index.mjs";
 import cursor from "../harnesses/cursor/index.mjs";
 import deepagents from "../harnesses/deepagents/index.mjs";
+import kimi from "../harnesses/kimi/index.mjs";
 import opencode from "../harnesses/opencode/index.mjs";
 import pi from "../harnesses/pi/index.mjs";
 import vscode from "../harnesses/vscode/index.mjs";
@@ -10,7 +11,7 @@ import { HARNESSES } from "./id.mjs";
 /** @typedef {import("./types.mjs").HarnessAdapter} HarnessAdapter */
 
 const REGISTRY = new Map(
-  [claude, opencode, codex, pi, cursor, vscode, deepagents].map((adapter) => [adapter.id, adapter]),
+  [claude, opencode, codex, pi, cursor, vscode, deepagents, kimi].map((adapter) => [adapter.id, adapter]),
 );
 
 /**

--- a/packages/setup-cli/lib/harness/status-display.mjs
+++ b/packages/setup-cli/lib/harness/status-display.mjs
@@ -9,6 +9,7 @@ const HARNESS_LABELS = {
   cursor: "Cursor",
   vscode: "VS Code",
   deepagents: "Deep Agents",
+  kimi: "Kimi Code",
 };
 
 const AUTH_MODE_LABELS = {

--- a/packages/setup-cli/lib/harnesses/kimi/core.mjs
+++ b/packages/setup-cli/lib/harnesses/kimi/core.mjs
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import { chmod, mkdir, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import {
+  DEFAULT_FIREPASS_MAIN_MODEL,
+  defaultMainModel,
+  normalizeModelId,
+  shortFireworksModelRef,
+} from "../../fireworks/model-id.mjs";
+import { lookupFireworksModelLimits } from "../../fireworks/model-specs.mjs";
+import { readJsonIfExists, writeJson } from "../../io/json.mjs";
+import { warmServerlessPricingCache } from "../../fireworks/models.mjs";
+import {
+  detectApiKeyType,
+  isFireworksShapedKey,
+  MISSING_FIREWORKS_API_KEY_MESSAGE,
+} from "../../keys/key-type.mjs";
+import { readRawIfExists } from "../opencode/core.mjs";
+import { parseToml } from "../codex/toml.mjs";
+import {
+  patchFireconnectAzureRoutingRaw,
+  patchFireconnectRoutingRaw,
+  stripFireconnectRoutingRaw,
+  upsertProviderApiKeyRaw,
+} from "./toml-patch.mjs";
+import {
+  AZURE_API_KEY_ENV,
+  AZURE_API_KEY_ENV_REF,
+  DEFAULT_AZURE_MODEL,
+  MISSING_AZURE_API_KEY_MESSAGE,
+  MISSING_AZURE_BASE_URL_MESSAGE,
+  normalizeAzureBaseUrl,
+} from "../../fireworks/azure-core.mjs";
+
+export const KIMI_CONFIG_RELATIVE_PATH = ".kimi-code/config.toml";
+export const KIMI_DATA_RELATIVE_DIR = ".fireconnect/kimi";
+export const KIMI_API_KEY_ENV = "FIREWORKS_API_KEY";
+export const KIMI_FIREWORKS_PROVIDER_ID = "fireworks";
+export const KIMI_FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
+export const KIMI_PROVIDER_TABLE = `providers.${KIMI_FIREWORKS_PROVIDER_ID}`;
+export const KIMI_AZURE_PROVIDER_ID = "fireworks-azure";
+export const KIMI_AZURE_PROVIDER_TABLE = `providers.${KIMI_AZURE_PROVIDER_ID}`;
+
+export function kimiConfigPath(home, configPath = "") {
+  return configPath || path.join(home, KIMI_CONFIG_RELATIVE_PATH);
+}
+
+export function kimiDataDir(home, dataDir = "") {
+  return dataDir || path.join(home, KIMI_DATA_RELATIVE_DIR);
+}
+
+export function kimiBackupPath(dataDir, configPath) {
+  const key = createHash("sha256").update(path.resolve(configPath)).digest("hex").slice(0, 16);
+  return path.join(dataDir, `config-backup.${key}.json`);
+}
+
+function emptyTomlDoc() {
+  return { root: {}, tables: {} };
+}
+
+function readTomlDoc(raw) {
+  if (!raw.trim()) {
+    return emptyTomlDoc();
+  }
+  return parseToml(raw);
+}
+
+function fireworksProviderTable(doc) {
+  return doc.tables[KIMI_PROVIDER_TABLE] ?? {};
+}
+
+function azureProviderTable(doc) {
+  return doc.tables[KIMI_AZURE_PROVIDER_TABLE] ?? {};
+}
+
+function defaultModelAlias(doc) {
+  return typeof doc.root.default_model === "string" ? doc.root.default_model : "";
+}
+
+function isManagedProviderTable(table) {
+  return table.type === "openai"
+    && table.base_url === KIMI_FIREWORKS_BASE_URL
+    && typeof table.api_key === "string";
+}
+
+function isManagedAzureProviderTable(table) {
+  return table.type === "openai"
+    && typeof table.base_url === "string"
+    && table.base_url.length > 0
+    && typeof table.api_key === "string";
+}
+
+export function fireconnectManagedVariant(doc) {
+  const alias = defaultModelAlias(doc);
+  if (alias.startsWith(`${KIMI_FIREWORKS_PROVIDER_ID}/`)
+    && isManagedProviderTable(fireworksProviderTable(doc))) {
+    return "fireworks";
+  }
+  if (alias.startsWith(`${KIMI_AZURE_PROVIDER_ID}/`)
+    && isManagedAzureProviderTable(azureProviderTable(doc))) {
+    return "azure";
+  }
+  return null;
+}
+
+export function fireconnectManaged(doc) {
+  return fireconnectManagedVariant(doc) !== null;
+}
+
+export function kimiCurrentModelId(doc) {
+  const variant = fireconnectManagedVariant(doc);
+  if (!variant) {
+    return null;
+  }
+  const prefix = variant === "azure"
+    ? `${KIMI_AZURE_PROVIDER_ID}/`
+    : `${KIMI_FIREWORKS_PROVIDER_ID}/`;
+  return defaultModelAlias(doc).slice(prefix.length);
+}
+
+export function kimiFireworksStoredKey(doc) {
+  const table = fireworksProviderTable(doc);
+  return typeof table.api_key === "string" ? table.api_key.trim() : "";
+}
+
+export function kimiAuthMode(doc) {
+  return kimiFireworksStoredKey(doc) ? "literal" : "missing";
+}
+
+export function kimiAzureStoredKey(doc) {
+  const table = azureProviderTable(doc);
+  return typeof table.api_key === "string" ? table.api_key.trim() : "";
+}
+
+export function kimiAzureBaseUrl(doc) {
+  const table = azureProviderTable(doc);
+  return typeof table.base_url === "string" ? table.base_url : null;
+}
+
+export function kimiProviderStatus(doc) {
+  const variant = fireconnectManagedVariant(doc);
+  if (variant) {
+    return variant;
+  }
+  const alias = defaultModelAlias(doc);
+  if (Object.keys(fireworksProviderTable(doc)).length > 0
+    || alias.startsWith(`${KIMI_FIREWORKS_PROVIDER_ID}/`)
+    || alias.startsWith(`${KIMI_AZURE_PROVIDER_ID}/`)) {
+    return "custom";
+  }
+  return "default";
+}
+
+function kimiModelCapabilities(limits) {
+  return limits.vision
+    ? ["image_in", "tool_use", "thinking"]
+    : ["tool_use", "thinking"];
+}
+
+function assertBackupMatchesConfig(backup, configPath, backupPath) {
+  if (backup.snapshot !== undefined
+    && backup.configPath !== undefined
+    && backup.configPath !== path.resolve(configPath)) {
+    throw new Error(
+      `Backup at ${backupPath} was taken for ${backup.configPath}, not ${configPath}; refusing to restore.`,
+    );
+  }
+}
+
+function backupContainsManagedRouting(backup) {
+  if (backup.snapshot === undefined
+    || !backup.snapshot.existed
+    || !backup.snapshot.raw.trim()) {
+    return false;
+  }
+  return fireconnectManaged(readTomlDoc(backup.snapshot.raw));
+}
+
+async function restoreConfigFromBackup(backup, configPath, backupPath) {
+  if (backup.snapshot.existed) {
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(configPath, backup.snapshot.raw, "utf8");
+  } else {
+    try {
+      await unlink(configPath);
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  await unlink(backupPath);
+}
+
+async function snapshotConfigIfNeeded({ configPath, dataDir, snapshot, doc }) {
+  const backupPath = kimiBackupPath(dataDir, configPath);
+  const hasBackup = (await readJsonIfExists(backupPath)).snapshot !== undefined;
+  if (hasBackup || fireconnectManaged(doc)) {
+    return;
+  }
+  await mkdir(path.dirname(backupPath), { recursive: true, mode: 0o700 });
+  await writeJson(backupPath, { configPath: path.resolve(configPath), snapshot });
+  await chmod(backupPath, 0o600);
+}
+
+export async function readKimiTomlIfExists(configPath) {
+  const snapshot = await readRawIfExists(configPath);
+  if (!snapshot.existed || !snapshot.raw.trim()) {
+    return { existed: false, doc: emptyTomlDoc() };
+  }
+  return { existed: true, doc: readTomlDoc(snapshot.raw) };
+}
+
+export async function enableKimiFireworks({
+  configPath,
+  dataDir,
+  effectiveApiKey = "",
+  modelId,
+  keyType = "fireworks",
+}) {
+  const apiKey = effectiveApiKey.trim();
+  if (!apiKey) {
+    throw new Error(MISSING_FIREWORKS_API_KEY_MESSAGE);
+  }
+
+  const snapshot = await readRawIfExists(configPath);
+  const doc = snapshot.existed && snapshot.raw.trim()
+    ? readTomlDoc(snapshot.raw)
+    : emptyTomlDoc();
+
+  const resolvedKeyType = keyType === "fireworks" ? detectApiKeyType(apiKey) : keyType;
+  if (resolvedKeyType === "fireworks") {
+    await warmServerlessPricingCache(apiKey, resolvedKeyType);
+  }
+
+  let effectiveModelId = modelId;
+  if (resolvedKeyType === "firepass" && !modelId) {
+    effectiveModelId = DEFAULT_FIREPASS_MAIN_MODEL;
+  }
+  const currentGatewayModel = fireconnectManagedVariant(doc) === "fireworks"
+    ? kimiCurrentModelId(doc)
+    : "";
+  const resolvedModel = normalizeModelId(
+    effectiveModelId || currentGatewayModel || defaultMainModel(),
+  );
+  const storedModel = shortFireworksModelRef(resolvedModel);
+
+  await snapshotConfigIfNeeded({ configPath, dataDir, snapshot, doc });
+
+  const limits = lookupFireworksModelLimits(storedModel);
+  const nextRaw = patchFireconnectRoutingRaw(snapshot.raw, {
+    alias: `${KIMI_FIREWORKS_PROVIDER_ID}/${storedModel}`,
+    modelId: storedModel,
+    baseUrl: KIMI_FIREWORKS_BASE_URL,
+    apiKey,
+    maxContextSize: limits.contextWindow,
+    capabilities: kimiModelCapabilities(limits),
+  });
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, nextRaw, "utf8");
+  await chmod(configPath, 0o600);
+
+  return {
+    model: storedModel,
+    modelsAdded: [storedModel],
+    keyType: resolvedKeyType,
+    authMode: "literal",
+    apiKeyMode: "literal",
+  };
+}
+
+export async function enableKimiAzure({
+  configPath,
+  dataDir,
+  apiKey,
+  baseUrl,
+  modelId = "",
+}) {
+  const normalizedBaseUrl = normalizeAzureBaseUrl(baseUrl);
+  if (!normalizedBaseUrl) {
+    throw new Error(MISSING_AZURE_BASE_URL_MESSAGE);
+  }
+  const effectiveApiKey = apiKey === AZURE_API_KEY_ENV_REF
+    ? (process.env[AZURE_API_KEY_ENV] ?? "")
+    : apiKey;
+  if (!effectiveApiKey) {
+    throw new Error(MISSING_AZURE_API_KEY_MESSAGE);
+  }
+
+  const snapshot = await readRawIfExists(configPath);
+  const doc = snapshot.existed && snapshot.raw.trim()
+    ? readTomlDoc(snapshot.raw)
+    : emptyTomlDoc();
+
+  const currentAzureModel = fireconnectManagedVariant(doc) === "azure"
+    ? kimiCurrentModelId(doc)
+    : "";
+  const resolvedModel = modelId || currentAzureModel || DEFAULT_AZURE_MODEL;
+
+  await snapshotConfigIfNeeded({ configPath, dataDir, snapshot, doc });
+
+  const limits = lookupFireworksModelLimits(resolvedModel);
+  const nextRaw = patchFireconnectAzureRoutingRaw(snapshot.raw, {
+    alias: `${KIMI_AZURE_PROVIDER_ID}/${resolvedModel}`,
+    modelId: resolvedModel,
+    baseUrl: normalizedBaseUrl,
+    apiKey: effectiveApiKey,
+    maxContextSize: limits.contextWindow,
+    capabilities: kimiModelCapabilities(limits),
+  });
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, nextRaw, "utf8");
+  await chmod(configPath, 0o600);
+
+  return {
+    model: resolvedModel,
+    baseUrl: normalizedBaseUrl,
+    apiKeyMode: "literal",
+  };
+}
+
+export async function refreshKimiGatewayKey({ configPath, fireworksKey }) {
+  const key = fireworksKey?.trim();
+  if (!key) return false;
+  const snapshot = await readRawIfExists(configPath);
+  if (!snapshot.existed || !snapshot.raw.trim()) {
+    return false;
+  }
+  const doc = readTomlDoc(snapshot.raw);
+  if (fireconnectManagedVariant(doc) !== "fireworks") {
+    return false;
+  }
+  const current = kimiFireworksStoredKey(doc);
+  if (!current || !isFireworksShapedKey(current) || current === key) {
+    return false;
+  }
+  await writeFile(configPath, upsertProviderApiKeyRaw(snapshot.raw, key), "utf8");
+  await chmod(configPath, 0o600);
+  return true;
+}
+
+export async function disableKimiFireworks({
+  configPath,
+  dataDir,
+  wasEnabled = false,
+}) {
+  const backupPath = kimiBackupPath(dataDir, configPath);
+  const backup = await readJsonIfExists(backupPath);
+  const snapshot = await readRawIfExists(configPath);
+  const doc = snapshot.existed && snapshot.raw.trim()
+    ? readTomlDoc(snapshot.raw)
+    : emptyTomlDoc();
+  const hasBackup = backup.snapshot !== undefined;
+
+  if (!wasEnabled && !hasBackup && kimiProviderStatus(doc) !== "fireworks") {
+    return "noop";
+  }
+
+  assertBackupMatchesConfig(backup, configPath, backupPath);
+
+  if (hasBackup) {
+    if (backupContainsManagedRouting(backup)) {
+      await unlink(backupPath);
+    } else {
+      await restoreConfigFromBackup(backup, configPath, backupPath);
+      return "restored";
+    }
+  }
+
+  if (!snapshot.existed) {
+    return "noop";
+  }
+
+  const stripped = stripFireconnectRoutingRaw(snapshot.raw);
+  if (stripped !== snapshot.raw) {
+    await writeFile(configPath, stripped, "utf8");
+    return "stripped";
+  }
+  return "noop";
+}

--- a/packages/setup-cli/lib/harnesses/kimi/index.mjs
+++ b/packages/setup-cli/lib/harnesses/kimi/index.mjs
@@ -1,0 +1,151 @@
+import {
+  printStructuredHarnessStatus,
+} from "../../harness/status-display.mjs";
+import {
+  printKimiRestartHint,
+} from "../../cli/messages.mjs";
+import { defaultMainModel } from "../../fireworks/model-id.mjs";
+import {
+  KIMI_API_KEY_ENV,
+  KIMI_AZURE_PROVIDER_ID,
+  KIMI_FIREWORKS_BASE_URL,
+  KIMI_FIREWORKS_PROVIDER_ID,
+  disableKimiFireworks,
+  enableKimiAzure,
+  enableKimiFireworks,
+  kimiAuthMode,
+  kimiAzureBaseUrl,
+  kimiAzureStoredKey,
+  kimiCurrentModelId,
+  kimiFireworksStoredKey,
+  kimiProviderStatus,
+  readKimiTomlIfExists,
+} from "./core.mjs";
+import { DEFAULT_AZURE_MODEL } from "../../fireworks/azure-core.mjs";
+import { harnessFullKey } from "../../keys/harness-api-key.mjs";
+import { finishEnvHarnessOn } from "../../harness/env-hook.mjs";
+import { defineHarnessProfile } from "../../harness/engine.mjs";
+import {
+  ensureHomeForHarness,
+  kimiPathsFor,
+} from "../../harness/context.mjs";
+import { HARNESS } from "../../harness/id.mjs";
+import { harnessStatusKeySource } from "../../keys/api-key.mjs";
+
+async function kimiResolveKey(ctx) {
+  const { configPath } = kimiPathsFor(ctx);
+  const { doc } = await readKimiTomlIfExists(configPath);
+  if (kimiProviderStatus(doc) !== "fireworks") {
+    return "";
+  }
+  return kimiFireworksStoredKey(doc);
+}
+
+async function kimiApiKey(ctx) {
+  return harnessFullKey(ctx, kimiResolveKey);
+}
+
+export default defineHarnessProfile({
+  id: HARNESS.KIMI,
+  label: "Kimi Code",
+  resolveKey: kimiResolveKey,
+  paths: (ctx) => kimiPathsFor(ctx),
+  keyEnvRef: KIMI_API_KEY_ENV,
+  firerouter: {
+    byok: "none",
+    autoCatalog: true,
+  },
+  azure: {
+    read: async (_ctx, { configPath }) => {
+      const { doc } = await readKimiTomlIfExists(configPath);
+      return {
+        active: kimiProviderStatus(doc) === "azure",
+        storedKey: kimiAzureStoredKey(doc),
+        storedBaseUrl: kimiAzureBaseUrl(doc) ?? "",
+      };
+    },
+    enable: ({ ctx, paths, apiKey, baseUrl }) => enableKimiAzure({
+      configPath: paths.configPath,
+      dataDir: paths.dataDir,
+      apiKey,
+      baseUrl,
+      modelId: ctx.main,
+    }),
+    restart: () => printKimiRestartHint(),
+  },
+  enable: ({ paths, effectiveKey, keyType, modelId }) => enableKimiFireworks({
+    configPath: paths.configPath,
+    dataDir: paths.dataDir,
+    effectiveApiKey: effectiveKey,
+    modelId,
+    keyType,
+  }),
+  envHookOn: (ctx, effectiveKey) => finishEnvHarnessOn(ctx.home, {
+    harnessId: "kimi",
+    expectedKey: effectiveKey,
+  }),
+  restartHint: () => printKimiRestartHint(),
+  disable: ({ paths, wasEnabled }) => disableKimiFireworks({
+    configPath: paths.configPath,
+    dataDir: paths.dataDir,
+    wasEnabled,
+  }),
+  restartHintOff: () => printKimiRestartHint(),
+  async status(ctx) {
+    ensureHomeForHarness(ctx, HARNESS.KIMI);
+    const { configPath } = kimiPathsFor(ctx);
+    const { doc } = await readKimiTomlIfExists(configPath);
+
+    if (kimiProviderStatus(doc) === "azure") {
+      const storedKey = kimiAzureStoredKey(doc);
+      const payload = {
+        harness: HARNESS.KIMI,
+        provider: "azure",
+        baseUrl: kimiAzureBaseUrl(doc),
+        modelProvider: KIMI_AZURE_PROVIDER_ID,
+        hasAuthToken: Boolean(storedKey),
+        defaults: { main: DEFAULT_AZURE_MODEL },
+        current: { main: kimiCurrentModelId(doc) },
+      };
+      if (ctx.json) {
+        console.log(JSON.stringify(payload, null, 2));
+        return;
+      }
+      printStructuredHarnessStatus(HARNESS.KIMI, {
+        provider: payload.provider,
+        keyConfigured: payload.hasAuthToken,
+        authMode: storedKey ? "literal" : "missing",
+        model: payload.current.main,
+        endpoint: payload.baseUrl,
+      });
+      return;
+    }
+
+    const model = kimiCurrentModelId(doc);
+    const apiKeyMode = kimiAuthMode(doc);
+    const resolvedKey = await kimiApiKey(ctx);
+    const payload = {
+      harness: HARNESS.KIMI,
+      provider: kimiProviderStatus(doc),
+      baseUrl: KIMI_FIREWORKS_BASE_URL,
+      modelProvider: KIMI_FIREWORKS_PROVIDER_ID,
+      hasAuthToken: Boolean(resolvedKey),
+      apiKeyMode,
+      defaults: { main: defaultMainModel() },
+      current: { main: model },
+    };
+
+    if (ctx.json) {
+      console.log(JSON.stringify(payload, null, 2));
+      return;
+    }
+
+    printStructuredHarnessStatus(HARNESS.KIMI, {
+      provider: payload.provider,
+      keyConfigured: payload.hasAuthToken,
+      authMode: payload.apiKeyMode,
+      model: payload.current.main,
+      keySource: harnessStatusKeySource(HARNESS.KIMI, payload.provider),
+    });
+  },
+});

--- a/packages/setup-cli/lib/harnesses/kimi/toml-patch.mjs
+++ b/packages/setup-cli/lib/harnesses/kimi/toml-patch.mjs
@@ -1,0 +1,165 @@
+import {
+  findTomlSection,
+  isAnyTableHeader,
+  parseTomlSections,
+  removeTomlSection,
+  serializeTomlSections,
+} from "../../io/toml-section-utils.mjs";
+
+const FIREWORKS_PROVIDER_TABLE_HEADER = "[providers.fireworks]";
+const FIREWORKS_AZURE_PROVIDER_TABLE_HEADER = "[providers.fireworks-azure]";
+const MANAGED_MODEL_HEADER_PREFIXES = ['[models."fireworks/', '[models."fireworks-azure/'];
+const ANY_DEFAULT_MODEL_LINE = /^default_model\s*=/;
+const MANAGED_DEFAULT_MODEL_LINE = /^default_model\s*=\s*"fireworks(?:-azure)?\//;
+
+function mutateKimiToml(raw, mutate) {
+  const sections = raw.trim() ? parseTomlSections(raw) : [];
+  mutate(sections);
+  return serializeTomlSections(sections);
+}
+
+function removeManagedModelSections(sections) {
+  for (let i = sections.length - 1; i >= 0; i -= 1) {
+    const header = sections[i].header ?? "";
+    if (MANAGED_MODEL_HEADER_PREFIXES.some((prefix) => header.startsWith(prefix))) {
+      sections.splice(i, 1);
+    }
+  }
+}
+
+function scanRootLine(line, state) {
+  for (let i = 0; i < line.length; ) {
+    if (state.stringDelim) {
+      const close = line.indexOf(state.stringDelim, i);
+      if (close === -1) {
+        return;
+      }
+      i = close + state.stringDelim.length;
+      state.stringDelim = "";
+      continue;
+    }
+    const ch = line[i];
+    if (ch === "#") {
+      return;
+    }
+    if (ch === '"' || ch === "'") {
+      const triple = ch.repeat(3);
+      if (line.startsWith(triple, i)) {
+        const close = line.indexOf(triple, i + 3);
+        if (close === -1) {
+          state.stringDelim = triple;
+          return;
+        }
+        i = close + 3;
+        continue;
+      }
+      let j = i + 1;
+      while (j < line.length && line[j] !== ch) {
+        j += ch === '"' && line[j] === "\\" ? 2 : 1;
+      }
+      if (j >= line.length) {
+        return;
+      }
+      i = j + 1;
+      continue;
+    }
+    if (ch === "[") {
+      state.arrayDepth += 1;
+    } else if (ch === "]" && state.arrayDepth > 0) {
+      state.arrayDepth -= 1;
+    }
+    i += 1;
+  }
+}
+
+function stripRootDefaultModelLines(raw, pattern) {
+  const out = [];
+  const state = { stringDelim: "", arrayDepth: 0 };
+  let atRoot = true;
+  let removingValue = false;
+  for (const line of raw.split("\n")) {
+    if (removingValue) {
+      scanRootLine(line, state);
+      removingValue = Boolean(state.stringDelim) || state.arrayDepth > 0;
+      continue;
+    }
+    if (atRoot && !state.stringDelim && state.arrayDepth === 0) {
+      const trimmed = line.trim();
+      if (isAnyTableHeader(trimmed)) {
+        atRoot = false;
+      } else if (pattern.test(trimmed)) {
+        scanRootLine(line, state);
+        removingValue = Boolean(state.stringDelim) || state.arrayDepth > 0;
+        continue;
+      }
+    }
+    if (atRoot) {
+      scanRootLine(line, state);
+    }
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+function stripRoutingSections(sections) {
+  removeTomlSection(sections, FIREWORKS_PROVIDER_TABLE_HEADER);
+  removeTomlSection(sections, FIREWORKS_AZURE_PROVIDER_TABLE_HEADER);
+  removeManagedModelSections(sections);
+}
+
+export function stripFireconnectRoutingRaw(raw) {
+  return mutateKimiToml(
+    stripRootDefaultModelLines(raw, MANAGED_DEFAULT_MODEL_LINE),
+    stripRoutingSections,
+  );
+}
+
+export function upsertProviderApiKeyRaw(raw, apiKey) {
+  return mutateKimiToml(raw, (sections) => {
+    const provider = findTomlSection(sections, FIREWORKS_PROVIDER_TABLE_HEADER);
+    if (!provider) {
+      return;
+    }
+    const line = `api_key = "${apiKey}"`;
+    const index = provider.lines.findIndex((entry) => /^api_key\s*=/.test(entry.trim()));
+    if (index === -1) {
+      provider.lines.push(line);
+    } else {
+      provider.lines[index] = line;
+    }
+  });
+}
+
+function patchRoutingRaw(raw, providerId, tableHeader, patch) {
+  const base = mutateKimiToml(
+    stripRootDefaultModelLines(raw, ANY_DEFAULT_MODEL_LINE),
+    stripRoutingSections,
+  ).replace(/^\n+/, "");
+  const rootLine = `default_model = "${patch.alias}"`;
+  const tablesBlock = [
+    tableHeader,
+    'type = "openai"',
+    `base_url = "${patch.baseUrl}"`,
+    `api_key = "${patch.apiKey}"`,
+    "",
+    `[models."${patch.alias}"]`,
+    `provider = "${providerId}"`,
+    `model = "${patch.modelId}"`,
+    `max_context_size = ${patch.maxContextSize}`,
+    `capabilities = [${patch.capabilities.map((cap) => `"${cap}"`).join(", ")}]`,
+  ].join("\n");
+
+  if (!base.trim()) {
+    return `${rootLine}\n\n${tablesBlock}\n`;
+  }
+  const separator = base.endsWith("\n") ? "" : "\n";
+  return `${rootLine}\n\n${base}${separator}\n${tablesBlock}\n`;
+}
+
+export function patchFireconnectRoutingRaw(raw, patch) {
+  return patchRoutingRaw(raw, "fireworks", FIREWORKS_PROVIDER_TABLE_HEADER, patch);
+}
+
+export function patchFireconnectAzureRoutingRaw(raw, patch) {
+  return patchRoutingRaw(raw, "fireworks-azure", FIREWORKS_AZURE_PROVIDER_TABLE_HEADER, patch);
+}

--- a/packages/setup-cli/lib/keys/api-key.mjs
+++ b/packages/setup-cli/lib/keys/api-key.mjs
@@ -122,6 +122,9 @@ const HARNESS_KEY_SOURCE = {
   deepagents: {
     readsFrom: "literal api_key in config.toml",
   },
+  kimi: {
+    readsFrom: "literal api_key in config.toml",
+  },
   vscode: {
     readsFrom: "VS Code safeStorage (state.vscdb)",
     storage: "IDE Electron safeStorage (encrypted)",

--- a/packages/setup-cli/lib/keys/sync.mjs
+++ b/packages/setup-cli/lib/keys/sync.mjs
@@ -5,6 +5,10 @@ import {
   deepagentsConfigPath,
   refreshDeepagentsGatewayKey,
 } from "../harnesses/deepagents/core.mjs";
+import {
+  kimiConfigPath,
+  refreshKimiGatewayKey,
+} from "../harnesses/kimi/core.mjs";
 import { opencodeConfigPath, refreshOpencodeGatewayKey } from "../harnesses/opencode/core.mjs";
 import { piAuthPath, refreshPiGatewayKey } from "../harnesses/pi/core.mjs";
 import { migrateVscodeResponsesApiType } from "../harnesses/vscode/core.mjs";
@@ -53,6 +57,7 @@ export async function syncBakedKeysAfterStore(home, fireworksKey) {
   const opencodeConfig = opencodeConfigPath(home, "");
   const codexConfig = codexConfigPath(home, "");
   const deepagentsConfig = deepagentsConfigPath(home, "");
+  const kimiConfig = kimiConfigPath(home, "");
   const targets = [
     {
       id: HARNESS.CLAUDE,
@@ -83,6 +88,12 @@ export async function syncBakedKeysAfterStore(home, fireworksKey) {
       label: "Deep Agents",
       hint: "fireconnect deepagents on",
       refresh: () => refreshDeepagentsGatewayKey({ configPath: deepagentsConfig, fireworksKey }),
+    },
+    {
+      id: HARNESS.KIMI,
+      label: "Kimi Code",
+      hint: "fireconnect kimi on",
+      refresh: () => refreshKimiGatewayKey({ configPath: kimiConfig, fireworksKey }),
     },
   ];
   const notes = [];

--- a/packages/setup-cli/test/cli/cli-commands.test.mjs
+++ b/packages/setup-cli/test/cli/cli-commands.test.mjs
@@ -73,7 +73,7 @@ describe("fireconnect help quick", () => {
 
 describe("harness help matches supported command features", () => {
   test("documents shared Azure options only on Azure-capable harnesses", async () => {
-    for (const harness of ["opencode", "codex", "pi", "cursor", "vscode", "deepagents"]) {
+    for (const harness of ["opencode", "codex", "pi", "cursor", "vscode", "deepagents", "kimi"]) {
       const result = await runCli(["help", harness]);
       assert.equal(result.code, 0, result.stderr);
       assert.match(result.stdout, /--azure/);

--- a/packages/setup-cli/test/cli/configure-on.test.mjs
+++ b/packages/setup-cli/test/cli/configure-on.test.mjs
@@ -12,7 +12,7 @@ import { runFireconnect, seedKeychainConfig } from "../helpers.mjs";
 
 describe("configure to harness on propagation", () => {
   it("gives every direct harness the same login and custom SSO guidance when no key exists", async () => {
-    for (const harness of ["claude", "opencode", "codex", "pi", "cursor", "vscode", "deepagents"]) {
+    for (const harness of ["claude", "opencode", "codex", "pi", "cursor", "vscode", "deepagents", "kimi"]) {
       const home = await mkdtemp(path.join(os.tmpdir(), `fc-missing-${harness}-`));
       const result = await runFireconnect(
         [harness, "on"],

--- a/packages/setup-cli/test/harness/harness-detect.test.mjs
+++ b/packages/setup-cli/test/harness/harness-detect.test.mjs
@@ -25,10 +25,12 @@ describe("detectInstalledHarnesses", () => {
       await mkdir(path.join(home, ".claude"), { recursive: true });
       await mkdir(path.join(home, ".codex"), { recursive: true });
       await mkdir(path.join(home, ".deepagents"), { recursive: true });
+      await mkdir(path.join(home, ".kimi-code"), { recursive: true });
       const detected = detectInstalledHarnesses(home);
       assert.ok(detected.includes("claude"));
       assert.ok(detected.includes("codex"));
       assert.ok(detected.includes("deepagents"));
+      assert.ok(detected.includes("kimi"));
       assert.ok(!detected.includes("pi"));
     } finally {
       await rm(home, { recursive: true, force: true });

--- a/packages/setup-cli/test/harnesses/kimi/kimi-azure.test.mjs
+++ b/packages/setup-cli/test/harnesses/kimi/kimi-azure.test.mjs
@@ -1,0 +1,199 @@
+import { mkdtemp, readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { spawn } from "node:child_process";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { kimiConfigPath } from "../../../lib/harnesses/kimi/core.mjs";
+
+const CLI = path.join(import.meta.dirname, "..", "..", "..", "bin", "fireconnect.mjs");
+const AZURE_ENDPOINT = "https://msft-fw-foundry-resource.services.ai.azure.com";
+const AZURE_BASE_URL = "https://msft-fw-foundry-resource.services.ai.azure.com/openai/v1";
+const AZURE_KEY = "azure-test-key-1234567890";
+
+function runFireconnect(args, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: { ...process.env, FIREWORKS_API_KEY: "", AZURE_API_KEY: "", FIRECONNECT_SECRET_STORE: "memory", FIRECONNECT_TEST: "1", ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.on("error", reject);
+  });
+}
+
+async function withHome(fn) {
+  const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-azure-"));
+  try {
+    await mkdir(path.join(home, ".kimi-code"), { recursive: true });
+    return await fn(home);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+describe("kimi azure harness", () => {
+  it("writes a fireworks-azure provider table with a literal api_key (--api-key)", async () => {
+    await withHome(async (home) => {
+      const configPath = kimiConfigPath(home);
+      const result = await runFireconnect(
+        ["kimi", "on", "--azure", "--base-url", AZURE_ENDPOINT, "--api-key", AZURE_KEY, "--model", "FW-MiniMax-M2.5"],
+        { HOME: home },
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const toml = await readFile(configPath, "utf8");
+      assert.match(toml, /default_model = "fireworks-azure\/FW-MiniMax-M2\.5"/);
+      assert.match(toml, /\[providers\.fireworks-azure\]/);
+      assert.match(toml, /type = "openai"/);
+      assert.match(toml, new RegExp(`base_url = "${AZURE_BASE_URL.replace(/[.]/g, "\\.")}"`));
+      assert.match(toml, /\[models\."fireworks-azure\/FW-MiniMax-M2\.5"\]/);
+      assert.match(toml, /model = "FW-MiniMax-M2\.5"/);
+      assert.match(toml, /api_key = "azure-test-key-1234567890"/);
+      assert.doesNotMatch(toml, /accounts\/fireworks/);
+    });
+  });
+
+  it("bakes a literal api_key when the key comes from the environment", async () => {
+    await withHome(async (home) => {
+      const configPath = kimiConfigPath(home);
+      const result = await runFireconnect(
+        ["kimi", "on", "--azure", "--base-url", AZURE_ENDPOINT],
+        { HOME: home, AZURE_API_KEY: AZURE_KEY },
+      );
+      assert.equal(result.code, 0, result.stderr);
+      const toml = await readFile(configPath, "utf8");
+      assert.match(toml, /api_key = "azure-test-key-1234567890"/);
+      assert.doesNotMatch(toml, /api_key_env/);
+    });
+  });
+
+  it("fails without a base URL", async () => {
+    await withHome(async (home) => {
+      const result = await runFireconnect(
+        ["kimi", "on", "--azure", "--api-key", AZURE_KEY],
+        { HOME: home },
+      );
+      assert.notEqual(result.code, 0);
+      assert.match(result.stderr, /No Azure endpoint/);
+    });
+  });
+
+  it("on/off round-trip restores the original config byte-for-byte", async () => {
+    await withHome(async (home) => {
+      const configPath = kimiConfigPath(home);
+      const original = [
+        'default_model = "kimi-code/k3"',
+        "",
+        "[tui]",
+        'theme = "dark"',
+        "",
+      ].join("\n");
+      await writeFile(configPath, original);
+
+      const on = await runFireconnect(
+        ["kimi", "on", "--azure", "--base-url", AZURE_ENDPOINT, "--api-key", AZURE_KEY],
+        { HOME: home },
+      );
+      assert.equal(on.code, 0, on.stderr);
+
+      const off = await runFireconnect(["kimi", "off"], { HOME: home });
+      assert.equal(off.code, 0, off.stderr);
+
+      const restored = await readFile(configPath, "utf8");
+      assert.equal(restored, original);
+    });
+  });
+
+  it("status reports the azure provider and endpoint", async () => {
+    await withHome(async (home) => {
+      await runFireconnect(
+        ["kimi", "on", "--azure", "--base-url", AZURE_ENDPOINT, "--api-key", AZURE_KEY],
+        { HOME: home },
+      );
+      const status = await runFireconnect(["kimi", "status", "--json"], { HOME: home });
+      assert.equal(status.code, 0, status.stderr);
+      const payload = JSON.parse(status.stdout);
+      assert.equal(payload.provider, "azure");
+      assert.equal(payload.baseUrl, AZURE_BASE_URL);
+      assert.equal(payload.modelProvider, "fireworks-azure");
+      assert.equal(payload.hasAuthToken, true);
+      assert.equal(payload.current.main, "FW-GLM-5.2");
+
+      const human = await runFireconnect(["kimi", "status"], { HOME: home });
+      assert.equal(human.code, 0, human.stderr);
+      assert.match(human.stdout, /Auth: stored in config/);
+    });
+  });
+
+  it("re-on without --base-url reuses the stored endpoint and applies --model", async () => {
+    await withHome(async (home) => {
+      const configPath = kimiConfigPath(home);
+      assert.equal(
+        (await runFireconnect(
+          ["kimi", "on", "--azure", "--base-url", AZURE_ENDPOINT, "--api-key", AZURE_KEY],
+          { HOME: home },
+        )).code,
+        0,
+      );
+
+      const reon = await runFireconnect(
+        ["kimi", "on", "--azure", "--model", "FW-MiniMax-M2.5"],
+        { HOME: home },
+      );
+      assert.equal(reon.code, 0, reon.stderr);
+
+      const toml = await readFile(configPath, "utf8");
+      assert.match(toml, new RegExp(`base_url = "${AZURE_BASE_URL.replace(/[.]/g, "\\.")}"`));
+      assert.match(toml, /default_model = "fireworks-azure\/FW-MiniMax-M2\.5"/);
+    });
+  });
+
+  it("switching from the Fireworks gateway to Azure does not inherit the gateway model", async () => {
+    await withHome(async (home) => {
+      const configPath = kimiConfigPath(home);
+      const fwOn = await runFireconnect(
+        ["kimi", "on", "--api-key", "fw_test_key_12345", "--model", "glm-5p1"],
+        { HOME: home, FIREWORKS_API_KEY: "" },
+      );
+      assert.equal(fwOn.code, 0, fwOn.stderr);
+
+      const azOn = await runFireconnect(
+        ["kimi", "on", "--azure", "--base-url", AZURE_ENDPOINT, "--api-key", AZURE_KEY],
+        { HOME: home },
+      );
+      assert.equal(azOn.code, 0, azOn.stderr);
+
+      const toml = await readFile(configPath, "utf8");
+      assert.match(toml, /default_model = "fireworks-azure\/FW-GLM-5\.2"/);
+      assert.doesNotMatch(toml, /glm-5p1/);
+    });
+  });
+
+  it("switching from Azure back to the gateway replaces the provider and drops the azure key", async () => {
+    await withHome(async (home) => {
+      const configPath = kimiConfigPath(home);
+      await runFireconnect(
+        ["kimi", "on", "--azure", "--base-url", AZURE_ENDPOINT, "--api-key", "az-secret-xyz-999"],
+        { HOME: home },
+      );
+      const fwOn = await runFireconnect(
+        ["kimi", "on"],
+        { HOME: home, FIREWORKS_API_KEY: "fw_env_key_12345" },
+      );
+      assert.equal(fwOn.code, 0, fwOn.stderr);
+
+      const toml = await readFile(configPath, "utf8");
+      assert.doesNotMatch(toml, /\[providers\.fireworks-azure\]/);
+      assert.doesNotMatch(toml, /az-secret-xyz-999/);
+      assert.match(toml, /api_key = "fw_env_key_12345"/);
+      assert.match(toml, /default_model = "fireworks\/kimi-fast-latest"/);
+      assert.doesNotMatch(toml, /FW-GLM-5\.2/);
+    });
+  });
+});

--- a/packages/setup-cli/test/harnesses/kimi/kimi-harness.test.mjs
+++ b/packages/setup-cli/test/harnesses/kimi/kimi-harness.test.mjs
@@ -1,0 +1,362 @@
+import { mkdtemp, readFile, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { createServer } from "node:http";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  kimiBackupPath,
+  kimiConfigPath,
+  kimiDataDir,
+  kimiCurrentModelId,
+  readKimiTomlIfExists,
+  refreshKimiGatewayKey,
+} from "../../../lib/harnesses/kimi/core.mjs";
+import { FIREWORKS_API_KEY_KEYCHAIN_REF, globalConfigPath } from "../../../lib/config/global-config.mjs";
+import { readJsonIfExists } from "../../../lib/io/json.mjs";
+import {
+  FPK_KEY,
+  runFireconnect,
+  seedKeychainConfig,
+  withoutEnvFireworksKey,
+} from "../../helpers.mjs";
+
+describe("kimi harness integration", () => {
+  it("firerouter is rejected for Fire Pass keys", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-firerouter-firepass-"));
+    const result = await runFireconnect(
+      ["kimi", "on", "--api-key", FPK_KEY, "--model", "firerouter"],
+      { HOME: home, FIREWORKS_API_KEY: "" },
+    );
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /FireRouter is not available for Fire Pass keys/);
+  });
+
+  it("firerouter is allowed when workspace BYOK is enabled", async () => {
+    const gateway = await new Promise((resolve) => {
+      const server = createServer((req, res) => {
+        if (req.url === "/verifyApiKey") {
+          res.writeHead(200, {
+            "x-fireworks-account-id": "acct-workspace-byok",
+          });
+          res.end();
+          return;
+        }
+        if (/^\/v1\/accounts\/[^/]+\/featureFlags$/.test(req.url ?? "")) {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({
+            featureFlags: [{
+              name: "accounts/acct-workspace-byok/featureFlags/enable-workspace-byok",
+              value: "true",
+            }],
+          }));
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+      server.listen(0, "127.0.0.1", () => resolve({ server, url: `http://127.0.0.1:${server.address().port}` }));
+    });
+    try {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-firerouter-workspace-byok-"));
+      await mkdir(path.join(home, ".kimi-code"), { recursive: true });
+      const result = await runFireconnect(
+        [
+          "kimi", "on",
+          "--api-key", "fw_test_key_12345",
+          "--model", "firerouter",
+        ],
+        {
+          HOME: home,
+          FIREWORKS_API_KEY: "",
+          FIRECONNECT_GATEWAY_URL: gateway.url,
+          FIRECONNECT_GATEWAY_GRPC_WEB_URL: `${gateway.url}/grpc`,
+        },
+      );
+      assert.equal(result.code, 0, result.stderr);
+      const configPath = kimiConfigPath(home);
+      const config = await readFile(configPath, "utf8");
+      assert.match(config, /default_model = "fireworks\/firerouter"/);
+      const { doc } = await readKimiTomlIfExists(configPath);
+      assert.equal(kimiCurrentModelId(doc), "firerouter");
+      assert.match(result.stdout, /FireRouter is on/);
+    } finally {
+      gateway.server.close();
+    }
+  });
+
+  it("on/off round-trip restores config.toml byte-for-byte", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-"));
+    await mkdir(path.join(home, ".kimi-code"), { recursive: true });
+    const configPath = kimiConfigPath(home);
+    const original = [
+      'default_model = "kimi-code/k3"',
+      "",
+      "[providers.custom]",
+      'type = "openai"',
+      'base_url = "https://my-gateway.example/v1"',
+      'api_key = "user-key"',
+      "",
+    ].join("\n");
+    await writeFile(configPath, original);
+
+    const onResult = await runFireconnect(
+      ["kimi", "on", "--api-key", "fw_test_key_12345"],
+      { HOME: home, FIREWORKS_API_KEY: "" },
+    );
+    assert.equal(onResult.code, 0, onResult.stderr);
+
+    const enabled = await readFile(configPath, "utf8");
+    assert.match(enabled, /default_model = "fireworks\/kimi-fast-latest"/);
+    assert.match(enabled, /\[providers\.fireworks\]/);
+    assert.match(enabled, /type = "openai"/);
+    assert.match(enabled, /base_url = "https:\/\/api\.fireworks\.ai\/inference\/v1"/);
+    assert.match(enabled, /api_key = "fw_test_key_12345"/);
+    assert.match(enabled, /\[models\."fireworks\/kimi-fast-latest"\]/);
+    assert.match(enabled, /provider = "fireworks"/);
+    assert.match(enabled, /model = "kimi-fast-latest"/);
+    assert.match(enabled, /max_context_size = \d+/);
+    assert.match(enabled, /capabilities = \["image_in", "tool_use", "thinking"\]/);
+    assert.match(enabled, /\[providers\.custom\]/);
+    assert.doesNotMatch(enabled, /default_model = "kimi-code\/k3"/);
+
+    const globalConfig = await readJsonIfExists(globalConfigPath(home));
+    assert.equal(globalConfig.apiKey, FIREWORKS_API_KEY_KEYCHAIN_REF);
+
+    const offResult = await runFireconnect(["kimi", "off"], { HOME: home });
+    assert.equal(offResult.code, 0);
+    assert.match(offResult.stdout, /restored to your previous setup/);
+
+    const restored = await readFile(configPath, "utf8");
+    assert.equal(restored, original);
+  });
+
+  it("on resolves API key from keychain when env is unset", async () => {
+    await withoutEnvFireworksKey(async () => {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-keychain-"));
+      await mkdir(path.join(home, ".kimi-code"), { recursive: true });
+      await seedKeychainConfig(home, "fw_test_key_12345");
+
+      const onResult = await runFireconnect(["kimi", "on"], { HOME: home, FIREWORKS_API_KEY: "" });
+      assert.equal(onResult.code, 0);
+      assert.match(onResult.stdout, /Kimi Code → Fireworks · kimi-fast-latest/);
+
+      const config = await readFile(kimiConfigPath(home), "utf8");
+      assert.match(config, /api_key = "fw_test_key_12345"/);
+    });
+  });
+
+  it("on with env only writes a literal api_key", async () => {
+    await withoutEnvFireworksKey(async () => {
+      const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-env-"));
+      await mkdir(path.join(home, ".kimi-code"), { recursive: true });
+
+      const env = { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" };
+      const onResult = await runFireconnect(["kimi", "on"], env);
+      assert.equal(onResult.code, 0);
+
+      const config = await readFile(kimiConfigPath(home), "utf8");
+      assert.match(config, /api_key = "fw_test_key_12345"/);
+    });
+  });
+
+  it("on with --model writes that model's alias and entry", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-model-"));
+    await mkdir(path.join(home, ".kimi-code"), { recursive: true });
+
+    const onResult = await runFireconnect(
+      ["kimi", "on", "--api-key", "fw_test_key_12345", "--model", "accounts/fireworks/models/deepseek-v4-flash"],
+      { HOME: home, FIREWORKS_API_KEY: "" },
+    );
+    assert.equal(onResult.code, 0, onResult.stderr);
+
+    const configPath = kimiConfigPath(home);
+    const config = await readFile(configPath, "utf8");
+    assert.match(config, /default_model = "fireworks\/deepseek-v4-flash"/);
+    assert.match(config, /\[models\."fireworks\/deepseek-v4-flash"\]/);
+    const { doc } = await readKimiTomlIfExists(configPath);
+    assert.equal(kimiCurrentModelId(doc), "deepseek-v4-flash");
+  });
+
+  it("re-on of a managed config without backup strips on off", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-managed-"));
+    const configPath = kimiConfigPath(home);
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(configPath, [
+      'default_model = "fireworks/glm-5p2-fast"',
+      "",
+      "[providers.fireworks]",
+      'type = "openai"',
+      'base_url = "https://api.fireworks.ai/inference/v1"',
+      'api_key = "fw_old_key_12345"',
+      "",
+      '[models."fireworks/glm-5p2-fast"]',
+      'provider = "fireworks"',
+      'model = "glm-5p2-fast"',
+      "max_context_size = 128000",
+      'capabilities = ["tool_use"]',
+      "",
+    ].join("\n"));
+
+    const on = await runFireconnect(
+      ["kimi", "on", "--api-key", "fw_test_key_12345"],
+      { HOME: home, FIREWORKS_API_KEY: "" },
+    );
+    assert.equal(on.code, 0, on.stderr);
+    const reenabled = await readFile(configPath, "utf8");
+    assert.match(reenabled, /default_model = "fireworks\/glm-5p2-fast"/);
+    assert.match(reenabled, /api_key = "fw_test_key_12345"/);
+    const backupPath = kimiBackupPath(kimiDataDir(home), configPath);
+    assert.equal((await readJsonIfExists(backupPath)).snapshot, undefined);
+
+    const off = await runFireconnect(["kimi", "off"], { HOME: home });
+    assert.equal(off.code, 0, off.stderr);
+    const stripped = await readFile(configPath, "utf8");
+    assert.doesNotMatch(stripped, /fireworks/);
+  });
+
+  it("repeated on leaves the config unchanged", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-idempotent-"));
+    const configPath = kimiConfigPath(home);
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(configPath, '# header comment\ndefault_model = "kimi-code/k3"\n\n[tui]\ntheme = "dark"\n');
+
+    const snapshots = [];
+    for (let i = 0; i < 3; i += 1) {
+      const result = await runFireconnect(
+        ["kimi", "on", "--api-key", "fw_test_key_12345"],
+        { HOME: home, FIREWORKS_API_KEY: "" },
+      );
+      assert.equal(result.code, 0, result.stderr);
+      snapshots.push(await readFile(configPath, "utf8"));
+    }
+    assert.equal(snapshots[1], snapshots[0]);
+    assert.equal(snapshots[2], snapshots[0]);
+  });
+
+  it("switching models replaces the previous model entry", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-switch-"));
+    await mkdir(path.join(home, ".kimi-code"), { recursive: true });
+    const configPath = kimiConfigPath(home);
+
+    for (const model of ["glm-5p2-fast", "deepseek-v4-flash"]) {
+      const result = await runFireconnect(
+        ["kimi", "on", "--api-key", "fw_test_key_12345", "--model", model],
+        { HOME: home, FIREWORKS_API_KEY: "" },
+      );
+      assert.equal(result.code, 0, result.stderr);
+    }
+
+    const config = await readFile(configPath, "utf8");
+    assert.doesNotMatch(config, /glm-5p2-fast/);
+    assert.equal((config.match(/^default_model/gm) || []).length, 1);
+    assert.equal((config.match(/^\[providers\.fireworks\]$/gm) || []).length, 1);
+    assert.equal((config.match(/^\[models\./gm) || []).length, 1);
+  });
+
+  it("on keeps a config with root-level multiline arrays parseable", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-root-array-"));
+    const configPath = kimiConfigPath(home);
+    await mkdir(path.dirname(configPath), { recursive: true });
+    const original = [
+      "skills = [",
+      '  "code-review",',
+      '  "docs",',
+      "]",
+      'default_model = "kimi-code/k3"',
+      "",
+      "[tui]",
+      'theme = "dark"',
+      "",
+    ].join("\n");
+    await writeFile(configPath, original);
+
+    const onResult = await runFireconnect(
+      ["kimi", "on", "--api-key", "fw_test_key_12345"],
+      { HOME: home, FIREWORKS_API_KEY: "" },
+    );
+    assert.equal(onResult.code, 0, onResult.stderr);
+
+    const { doc } = await readKimiTomlIfExists(configPath);
+    assert.equal(doc.root.default_model, "fireworks/kimi-fast-latest");
+    assert.deepEqual(doc.root.skills, ["code-review", "docs"]);
+    assert.equal(kimiCurrentModelId(doc), "kimi-fast-latest");
+
+    const offResult = await runFireconnect(["kimi", "off"], { HOME: home });
+    assert.equal(offResult.code, 0, offResult.stderr);
+    assert.equal(await readFile(configPath, "utf8"), original);
+  });
+
+  it("refreshKimiGatewayKey replaces only the stored api_key", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-refresh-"));
+    const configPath = kimiConfigPath(home);
+    await mkdir(path.dirname(configPath), { recursive: true });
+    const managed = [
+      'default_model = "fireworks/kimi-fast-latest"',
+      "",
+      "[providers.fireworks]",
+      'type = "openai"',
+      'base_url = "https://api.fireworks.ai/inference/v1"',
+      'api_key = "fw_old_key_12345"',
+      "",
+      '[models."fireworks/kimi-fast-latest"]',
+      'provider = "fireworks"',
+      'model = "kimi-fast-latest"',
+      "max_context_size = 1048576",
+      'capabilities = ["image_in", "tool_use"]',
+      "",
+    ].join("\n");
+    await writeFile(configPath, managed);
+
+    const updated = await refreshKimiGatewayKey({ configPath, fireworksKey: "fw_new_key_67890" });
+    assert.equal(updated, true);
+    const refreshed = await readFile(configPath, "utf8");
+    assert.equal(refreshed, managed.replace("fw_old_key_12345", "fw_new_key_67890"));
+
+    assert.equal(
+      await refreshKimiGatewayKey({ configPath, fireworksKey: "fw_new_key_67890" }),
+      false,
+    );
+  });
+
+  it("off without a prior on changes nothing", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-noop-"));
+    const off = await runFireconnect(["kimi", "off"], { HOME: home });
+    assert.equal(off.code, 0, off.stderr);
+    assert.match(off.stdout, /was not connected; nothing changed/);
+  });
+
+  it("status reports fireworks provider after on", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-kimi-status-"));
+    await mkdir(path.join(home, ".kimi-code"), { recursive: true });
+
+    const onResult = await runFireconnect(
+      ["kimi", "on", "--api-key", "fw_test_key_12345"],
+      { HOME: home, FIREWORKS_API_KEY: "" },
+    );
+    assert.equal(onResult.code, 0);
+
+    const statusResult = await runFireconnect(
+      ["kimi", "status", "--json"],
+      { HOME: home, FIREWORKS_API_KEY: "fw_test_key_12345" },
+    );
+    assert.equal(statusResult.code, 0);
+    const payload = JSON.parse(statusResult.stdout);
+    assert.equal(payload.harness, "kimi");
+    assert.equal(payload.provider, "fireworks");
+    assert.equal(payload.apiKeyMode, "literal");
+    assert.equal(payload.current.main, "kimi-fast-latest");
+
+    const off = await runFireconnect(["kimi", "off"], {
+      HOME: home,
+      FIREWORKS_API_KEY: "fw_test_key_12345",
+    });
+    assert.equal(off.code, 0, off.stderr);
+    const after = await runFireconnect(["kimi", "status", "--json"], {
+      HOME: home,
+      FIREWORKS_API_KEY: "fw_test_key_12345",
+    });
+    assert.equal(after.code, 0, after.stderr);
+    assert.equal(JSON.parse(after.stdout).provider, "default");
+  });
+});

--- a/packages/setup-cli/test/harnesses/kimi/kimi-toml.test.mjs
+++ b/packages/setup-cli/test/harnesses/kimi/kimi-toml.test.mjs
@@ -1,0 +1,229 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  patchFireconnectAzureRoutingRaw,
+  patchFireconnectRoutingRaw,
+  stripFireconnectRoutingRaw,
+  upsertProviderApiKeyRaw,
+} from "../../../lib/harnesses/kimi/toml-patch.mjs";
+import { parseToml } from "../../../lib/harnesses/codex/toml.mjs";
+import {
+  fireconnectManagedVariant,
+  kimiAuthMode,
+  kimiCurrentModelId,
+  kimiProviderStatus,
+} from "../../../lib/harnesses/kimi/core.mjs";
+
+const GATEWAY_PATCH = {
+  alias: "fireworks/kimi-fast-latest",
+  modelId: "kimi-fast-latest",
+  baseUrl: "https://api.fireworks.ai/inference/v1",
+  apiKey: "fw_test_key_12345",
+  maxContextSize: 262000,
+  capabilities: ["image_in", "tool_use"],
+};
+
+const MANAGED_RAW = patchFireconnectRoutingRaw("", GATEWAY_PATCH);
+
+function assertTomllibParses(raw) {
+  const result = spawnSync("python3", ["-c", "import tomllib, sys; tomllib.loads(sys.stdin.read())"], {
+    input: raw,
+    encoding: "utf8",
+  });
+  assert.equal(
+    result.status,
+    0,
+    result.stderr || "expected config.toml to parse with stdlib tomllib",
+  );
+}
+
+describe("kimi-toml-patch", () => {
+  it("patches routing into an empty config", () => {
+    assertTomllibParses(MANAGED_RAW);
+    const doc = parseToml(MANAGED_RAW);
+    assert.equal(doc.root.default_model, "fireworks/kimi-fast-latest");
+    assert.equal(doc.tables["providers.fireworks"].type, "openai");
+    assert.equal(doc.tables["providers.fireworks"].api_key, "fw_test_key_12345");
+    assert.equal(doc.tables["models.fireworks/kimi-fast-latest"].max_context_size, 262000);
+    assert.deepEqual(
+      doc.tables["models.fireworks/kimi-fast-latest"].capabilities,
+      ["image_in", "tool_use"],
+    );
+  });
+
+  it("replaces the user's default_model and preserves unrelated content", () => {
+    const raw = [
+      'default_model = "kimi-code/k3"',
+      "",
+      "[tui]",
+      'theme = "dark"',
+      "",
+    ].join("\n");
+    const next = patchFireconnectRoutingRaw(raw, GATEWAY_PATCH);
+    assertTomllibParses(next);
+    assert.equal((next.match(/^default_model/gm) || []).length, 1);
+    assert.equal(parseToml(next).tables.tui.theme, "dark");
+  });
+
+  it("removes the user's default_model after an array closed by a commented line", () => {
+    const raw = [
+      "skills = [",
+      '  "a",',
+      "] # end of skills",
+      'default_model = "kimi-code/k3"',
+      "",
+    ].join("\n");
+    const next = patchFireconnectRoutingRaw(raw, GATEWAY_PATCH);
+    assertTomllibParses(next);
+    assert.equal((next.match(/^default_model/gm) || []).length, 1);
+    assert.equal(parseToml(next).root.default_model, "fireworks/kimi-fast-latest");
+  });
+
+  it("is not confused by a root comment containing an unmatched bracket", () => {
+    const raw = [
+      "# see [docs for details",
+      'default_model = "kimi-code/k3"',
+      "",
+    ].join("\n");
+    const next = patchFireconnectRoutingRaw(raw, GATEWAY_PATCH);
+    assertTomllibParses(next);
+    assert.equal((next.match(/^default_model/gm) || []).length, 1);
+  });
+
+  it("removes the user's default_model after an array closed on its last element line", () => {
+    const raw = [
+      "skills = [",
+      '  "a",',
+      '  "b"]',
+      'default_model = "kimi-code/k3"',
+      "",
+    ].join("\n");
+    const next = patchFireconnectRoutingRaw(raw, GATEWAY_PATCH);
+    assertTomllibParses(next);
+    assert.equal((next.match(/^default_model/gm) || []).length, 1);
+    assert.equal(parseToml(next).root.default_model, "fireworks/kimi-fast-latest");
+  });
+
+  it("is not confused by a root string value containing an unmatched bracket", () => {
+    const raw = [
+      'banner = "see [notes"',
+      'default_model = "kimi-code/k3"',
+      "",
+    ].join("\n");
+    const next = patchFireconnectRoutingRaw(raw, GATEWAY_PATCH);
+    assertTomllibParses(next);
+    assert.equal((next.match(/^default_model/gm) || []).length, 1);
+    assert.equal(parseToml(next).root.default_model, "fireworks/kimi-fast-latest");
+  });
+
+  it("removes the user's default_model after a nested multiline array", () => {
+    const raw = [
+      "matrix = [",
+      "  [1, 2],",
+      "  [3, 4]",
+      "]",
+      'default_model = "kimi-code/k3"',
+      "",
+    ].join("\n");
+    const next = patchFireconnectRoutingRaw(raw, GATEWAY_PATCH);
+    assertTomllibParses(next);
+    assert.equal((next.match(/^default_model/gm) || []).length, 1);
+    assert.equal(parseToml(next).root.default_model, "fireworks/kimi-fast-latest");
+  });
+
+  it("removes a default_model written as a multiline string without orphaning its closer", () => {
+    const raw = [
+      'default_model = """',
+      'kimi-code/k3"""',
+      "[tui]",
+      'theme = "dark"',
+      "",
+    ].join("\n");
+    const next = patchFireconnectRoutingRaw(raw, GATEWAY_PATCH);
+    assertTomllibParses(next);
+    const doc = parseToml(next);
+    assert.equal(doc.root.default_model, "fireworks/kimi-fast-latest");
+    assert.equal(doc.tables.tui.theme, "dark");
+    assert.doesNotMatch(next, /kimi-code\/k3/);
+  });
+
+  it("leaves a default_model line inside a multiline string intact", () => {
+    const raw = [
+      'notes = """',
+      'default_model = "kimi-code/k3"',
+      '"""',
+      'default_model = "kimi-code/k3"',
+      "",
+    ].join("\n");
+    const next = patchFireconnectRoutingRaw(raw, GATEWAY_PATCH);
+    assertTomllibParses(next);
+    const doc = parseToml(next);
+    assert.equal(doc.root.default_model, "fireworks/kimi-fast-latest");
+    assert.match(next, /notes = """\ndefault_model = "kimi-code\/k3"\n"""/);
+  });
+
+  it("azure patch replaces managed gateway routing entirely", () => {
+    const next = patchFireconnectAzureRoutingRaw(MANAGED_RAW, {
+      alias: "fireworks-azure/FW-GLM-5.2",
+      modelId: "FW-GLM-5.2",
+      baseUrl: "https://r.services.ai.azure.com/openai/v1",
+      apiKey: "azure-key",
+      maxContextSize: 128000,
+      capabilities: ["tool_use"],
+    });
+    assertTomllibParses(next);
+    const doc = parseToml(next);
+    assert.equal(doc.root.default_model, "fireworks-azure/FW-GLM-5.2");
+    assert.equal(doc.tables["providers.fireworks"], undefined);
+    assert.equal(doc.tables["models.fireworks/kimi-fast-latest"], undefined);
+  });
+
+  it("strip removes managed routing and preserves unrelated content", () => {
+    const next = patchFireconnectRoutingRaw('[tui]\ntheme = "dark"\n', GATEWAY_PATCH);
+    const stripped = stripFireconnectRoutingRaw(next);
+    assertTomllibParses(stripped);
+    assert.doesNotMatch(stripped, /default_model|providers\.fireworks|models\."fireworks/);
+    assert.equal(parseToml(stripped).tables.tui.theme, "dark");
+  });
+
+  it("strip leaves the user's own default_model intact", () => {
+    const raw = 'default_model = "kimi-code/k3"\n';
+    assert.equal(stripFireconnectRoutingRaw(raw), raw);
+  });
+
+  it("upsertProviderApiKeyRaw replaces only the api_key line", () => {
+    const next = upsertProviderApiKeyRaw(MANAGED_RAW, "fw_rotated_key_67890");
+    assert.equal(next, MANAGED_RAW.replace("fw_test_key_12345", "fw_rotated_key_67890"));
+  });
+});
+
+describe("kimi managed-config detection", () => {
+  it("detects the managed gateway variant", () => {
+    const doc = parseToml(MANAGED_RAW);
+    assert.equal(fireconnectManagedVariant(doc), "fireworks");
+    assert.equal(kimiProviderStatus(doc), "fireworks");
+    assert.equal(kimiCurrentModelId(doc), "kimi-fast-latest");
+    assert.equal(kimiAuthMode(doc), "literal");
+  });
+
+  it("reports a foreign fireworks provider as custom", () => {
+    const doc = parseToml([
+      "[providers.fireworks]",
+      'type = "openai"',
+      'base_url = "https://my-own.example/v1"',
+      'api_key = "user-key"',
+      "",
+    ].join("\n"));
+    assert.equal(fireconnectManagedVariant(doc), null);
+    assert.equal(kimiProviderStatus(doc), "custom");
+    assert.equal(kimiCurrentModelId(doc), null);
+  });
+
+  it("reports an untouched config as default", () => {
+    const doc = parseToml('default_model = "kimi-code/k3"\n');
+    assert.equal(fireconnectManagedVariant(doc), null);
+    assert.equal(kimiProviderStatus(doc), "default");
+    assert.equal(kimiAuthMode(doc), "missing");
+  });
+});


### PR DESCRIPTION
Adds MoonshotAI's Kimi Code as a first-class harness: `fireconnect kimi on|off|status` routes ~/.kimi-code/config.toml through the Fireworks gateway (root default_model + [providers.fireworks] + a managed [models."fireworks/<slug>"] entry with context window and image_in/tool_use/thinking capabilities), with byte-for-byte restore from a snapshot, Azure/Foundry support, login key rotation, auto-detection, and --config-path override. Surgical TOML patching is quote/comment/multiline-aware so hostile-but-valid user configs survive round-trips; 37 tests validate outputs against stdlib tomllib.