### PR TITLE
fix(harnesses): validate --model id for all harnesses

### DIFF
--- a/packages/setup-cli/lib/cli/commands/harness.mjs
+++ b/packages/setup-cli/lib/cli/commands/harness.mjs
@@ -3,7 +3,7 @@ import { dispatchHarnessCommand } from "../../harness/types.mjs";
 import { getHarness } from "../../harness/registry.mjs";
 import { persistGlobalAnthropicApiKey } from "../../config/global-config.mjs";
 import { FILE_CONFIG_HARNESS_SET, HARNESS } from "../../harness/id.mjs";
-import { isFirerouterModel, normalizeModelId, validateModelId } from "../../fireworks/model-id.mjs";
+import { isFirerouterGatewayPattern, normalizeModelId, validateModelId } from "../../fireworks/model-id.mjs";
 import { isAnthropicShapedKey } from "../../firerouter/core.mjs";
 import { supportsAnthropicApiKeyFlag, supportsRoutingPreference } from "../../firerouter/flag.mjs";
 import {
@@ -31,8 +31,8 @@ function validateHarnessOptions(route, ctx) {
   const claudeAliases = [ctx.opus, ctx.sonnet, ctx.haiku, ctx.fable, ctx.subagent];
   const claudeModels = [ctx.main, ...claudeAliases];
   const firerouterRequested = harnessId === HARNESS.CLAUDE
-    ? claudeModels.some((modelId) => isFirerouterModel(modelId))
-    : isFirerouterModel(ctx.main);
+    ? claudeModels.some((modelId) => isFirerouterGatewayPattern(modelId))
+    : isFirerouterGatewayPattern(ctx.main);
 
   if (ctx.provider && !ctx.azure) {
     throw new Error(

--- a/packages/setup-cli/lib/cli/commands/harness.mjs
+++ b/packages/setup-cli/lib/cli/commands/harness.mjs
@@ -3,7 +3,7 @@ import { dispatchHarnessCommand } from "../../harness/types.mjs";
 import { getHarness } from "../../harness/registry.mjs";
 import { persistGlobalAnthropicApiKey } from "../../config/global-config.mjs";
 import { FILE_CONFIG_HARNESS_SET, HARNESS } from "../../harness/id.mjs";
-import { isFirerouterModel } from "../../fireworks/model-id.mjs";
+import { isFirerouterModel, normalizeModelId, validateModelId } from "../../fireworks/model-id.mjs";
 import { isAnthropicShapedKey } from "../../firerouter/core.mjs";
 import { supportsAnthropicApiKeyFlag, supportsRoutingPreference } from "../../firerouter/flag.mjs";
 import {
@@ -58,6 +58,21 @@ function validateHarnessOptions(route, ctx) {
   }
   if (ctx.main && !isOn) {
     throw new Error("--model applies only to `<harness> on`.");
+  }
+  // Validate every supplied model id structurally before any key verification
+  // or config write, so a malformed id (e.g. a truncated "firerouter/…" prefix)
+  // fails fast with a clear message instead of being persisted verbatim into a
+  // harness config. assertRequestedModelServable alone can't catch this: it
+  // checks only the final path segment against the catalog, so a bad prefix
+  // whose tail is a real slug slips through and corrupts the IDE's selection.
+  // Claude's bespoke `on` re-validates each slot via resolveClaudeModelMapping;
+  // validating here too makes every harness fail at the same point.
+  if (isOn) {
+    for (const [value, flag] of [[ctx.main, "--model"], ...claudeAliases.map((v) => [v, "--opus/--sonnet/--haiku/--fable/--subagent"])]) {
+      if (value) {
+        validateModelId(normalizeModelId(value), flag);
+      }
+    }
   }
   if (ctx.search) {
     throw new Error("--search applies only to `fireconnect model list`.");

--- a/packages/setup-cli/lib/firerouter/flag.mjs
+++ b/packages/setup-cli/lib/firerouter/flag.mjs
@@ -1,6 +1,6 @@
 import process from "node:process";
 
-import { isFirerouterModel } from "../fireworks/model-id.mjs";
+import { isFirerouterGatewayPattern } from "../fireworks/model-id.mjs";
 import {
   isAccountFeatureFlagEnabled,
 } from "../config/feature-flags.mjs";
@@ -325,7 +325,12 @@ export function resolveFirerouterPlan(ctx, { keyType = "" } = {}) {
     return { mainModel: "", isFirerouter: false };
   }
   assertFirerouterKeyType(requested, keyType);
-  return { mainModel: requested, isFirerouter: isFirerouterModel(requested) };
+  // Recognize the compound gateway form (firerouter/<primary>/<fallback>) as
+  // FireRouter, not just the bare `firerouter` id. isFirerouterModel checks only
+  // the final path segment, so it misses the compound form; the gateway-pattern
+  // check matches any firerouter* segment. Id-transform call sites keep using
+  // isFirerouterModel so the compound spec is preserved verbatim when written.
+  return { mainModel: requested, isFirerouter: isFirerouterGatewayPattern(requested) };
 }
 
 /** FireRouter is only offered for standard Fireworks keys, not Fire Pass. */
@@ -339,7 +344,7 @@ export const FIREROUTER_FIREPASS_UNSUPPORTED_MESSAGE =
  * @param {string} keyType
  */
 export function assertFirerouterKeyType(model, keyType) {
-  if (isFirerouterModel(model) && keyType === "firepass") {
+  if (isFirerouterGatewayPattern(model) && keyType === "firepass") {
     throw new Error(FIREROUTER_FIREPASS_UNSUPPORTED_MESSAGE);
   }
 }

--- a/packages/setup-cli/lib/fireworks/model-id.mjs
+++ b/packages/setup-cli/lib/fireworks/model-id.mjs
@@ -208,7 +208,8 @@ export function normalizeModelId(model) {
 export function validateModelId(model, flag) {
   if (!model.startsWith("accounts/") && model.includes("/") && !isFirerouterGatewayPattern(model)) {
     throw new Error(
-      `${flag} must be a Fireworks model ID like deepseek-v4-flash or a router ID like glm-latest`,
+      `${flag} must be a Fireworks model id — a stable -latest router alias like glm-fast-latest, `
+        + "firerouter, or a specific id like glm-5p2. Run `fireconnect model list` to see options.",
     );
   }
 }

--- a/packages/setup-cli/lib/harnesses/cursor/core.mjs
+++ b/packages/setup-cli/lib/harnesses/cursor/core.mjs
@@ -7,7 +7,7 @@ import {
   defaultMainModel,
   fullFireworksResourceId,
   isFireworksModelId,
-  isFirerouterModel,
+  isFirerouterGatewayPattern,
   normalizeModelId,
   shortFireworksModelRef,
 } from "../../fireworks/model-id.mjs";
@@ -866,7 +866,7 @@ export async function enableCursorFireworks({ dbPath, dataDir, apiKey, modelId, 
     && (!previousKeyType || previousKeyType === resolvedKeyType)
     && currentModel
     && currentModel !== "default"
-    && !isFirerouterModel(currentModel)
+    && !isFirerouterGatewayPattern(currentModel)
     && servable(currentModel);
   const resolvedModel = shortFireworksModelRef(
     preserveModeSelections

--- a/packages/setup-cli/lib/harnesses/cursor/index.mjs
+++ b/packages/setup-cli/lib/harnesses/cursor/index.mjs
@@ -6,7 +6,7 @@ import {
 import {
   printStructuredHarnessStatus,
 } from "../../harness/status-display.mjs";
-import { isFirerouterModel } from "../../fireworks/model-id.mjs";
+import { isFirerouterGatewayPattern } from "../../fireworks/model-id.mjs";
 import {
   loadRegisterableModels,
 } from "../../fireworks/models.mjs";
@@ -97,7 +97,12 @@ async function isCursorAzureOnRequest(ctx) {
 }
 
 async function cursorResolveOnContext(ctx) {
-  if (!isFirerouterModel(ctx.main)) {
+  // Recognize the compound gateway form (firerouter/<primary>/<fallback>) as
+  // FireRouter, not just the bare `firerouter` id. isFirerouterModel checks only
+  // the final path segment, so it misses the compound form and would skip the
+  // Azure-reject + workspace-BYOK guards below — letting an unservable compound
+  // id get persisted. isFirerouterGatewayPattern matches any firerouter* segment.
+  if (!isFirerouterGatewayPattern(ctx.main)) {
     return ctx;
   }
   if (await isCursorAzureOnRequest(ctx)) {
@@ -133,7 +138,7 @@ export default defineHarnessProfile({
       };
     },
     enable: async ({ ctx, paths, apiKey, baseUrl }) => {
-      if (isFirerouterModel(ctx.main)) {
+      if (isFirerouterGatewayPattern(ctx.main)) {
         rejectCursorFirerouterAzure();
       }
       await relocateLegacyCursorBackups({ home: ctx.home, dataDir: paths.dataDir });

--- a/packages/setup-cli/test/firerouter/firerouter-model.test.mjs
+++ b/packages/setup-cli/test/firerouter/firerouter-model.test.mjs
@@ -112,6 +112,13 @@ describe("firerouter routing plan", () => {
       mainModel: "accounts/fireworks/routers/firerouter",
       isFirerouter: true,
     });
+    // The compound gateway form (firerouter/<primary>/<fallback>) is FireRouter
+    // too: isFirerouter must be true, and mainModel preserved verbatim (not
+    // collapsed to bare `firerouter`, which would drop the primary/fallback spec).
+    assert.deepEqual(resolveFirerouterPlan({ main: "firerouter/claude-opus-5/glm-5p2" }), {
+      mainModel: "firerouter/claude-opus-5/glm-5p2",
+      isFirerouter: true,
+    });
   });
 
   it("resolveFirerouterPlan keeps an explicit non-firerouter model", () => {

--- a/packages/setup-cli/test/fireworks/firepass-defaults.test.mjs
+++ b/packages/setup-cli/test/fireworks/firepass-defaults.test.mjs
@@ -126,7 +126,7 @@ describe("Fire Pass defaults", () => {
   test("model ID validation shows model and router examples", () => {
     assert.throws(
       () => validateModelId("bad/provider/path", "--model"),
-      /--model must be a Fireworks model ID like deepseek-v4-flash or a router ID like glm-latest/,
+      /--model must be a Fireworks model id — a stable -latest router alias like glm-fast-latest.*firerouter, or a specific id like glm-5p2/,
     );
   });
 

--- a/packages/setup-cli/test/harnesses/cursor/cursor-azure.test.mjs
+++ b/packages/setup-cli/test/harnesses/cursor/cursor-azure.test.mjs
@@ -87,6 +87,26 @@ describe("cursor azure harness", () => {
     });
   });
 
+  itIfSqlite("compound firerouter/<primary>/<fallback> is rejected in Azure mode", async () => {
+    await withTempHome("cursor-azure-firerouter-compound-", async (home) => {
+      const dbPath = path.join(home, "state.vscdb");
+      writeCursorDb(dbPath, baseBlob());
+      // The compound gateway form must trigger the same Azure-reject guard as
+      // bare `firerouter`. Previously isFirerouterModel (last-segment match)
+      // missed it, so the compound id bypassed the guard and was persisted.
+      const result = await runCli(
+        [
+          "cursor", "on", "--azure", "--base-url", AZURE_ENDPOINT,
+          "--api-key", AZURE_KEY, "--model", "firerouter/claude-opus-5/glm-5p2",
+          "--db-path", dbPath, "--force",
+        ],
+        { home, env: AZURE_ENV },
+      );
+      assert.notEqual(result.code, 0);
+      assert.match(result.stderr, /FireRouter is not supported in Cursor Azure mode/);
+    });
+  });
+
   itIfSqlite("on --azure points the OpenAI override at Foundry and registers the deployment", async () => {
     await withTempHome("cursor-azure-on-", async (home) => {
       const dbPath = path.join(home, "state.vscdb");

--- a/packages/setup-cli/test/harnesses/cursor/cursor-model-validation.test.mjs
+++ b/packages/setup-cli/test/harnesses/cursor/cursor-model-validation.test.mjs
@@ -1,0 +1,108 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runCli, withTempHome } from "../../helpers.mjs";
+
+process.env.FIRECONNECT_VSCODE_SECRET_PLAINTEXT = "1";
+
+const APPLICATION_USER_KEY =
+  "src.vs.platform.reactivestorage.browser.reactiveStorageServiceImpl.persistentStorage.applicationUser";
+
+function baseBlob() {
+  return {
+    openAIBaseUrl: null,
+    useOpenAIKey: false,
+    aiSettings: {
+      userAddedModels: [],
+      modelOverrideEnabled: [],
+      modelConfig: {
+        composer: { modelName: "default", maxMode: true, selectedModels: [{ modelId: "default", parameters: [] }] },
+      },
+    },
+  };
+}
+
+const jsonLit = (v) => JSON.stringify(v).replace(/'/g, "''");
+
+function writeCursorDb(dbPath, blob) {
+  const sql = [
+    "CREATE TABLE IF NOT EXISTS ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);",
+    `INSERT OR REPLACE INTO ItemTable(key,value) VALUES('${APPLICATION_USER_KEY}','${jsonLit(blob)}');`,
+  ];
+  const r = spawnSync("sqlite3", [dbPath, sql.join("\n")], { encoding: "utf8" });
+  if (r.error || r.status !== 0) {
+    throw new Error(`sqlite3 init failed: ${r.stderr || r.error?.message}`);
+  }
+}
+
+function readBlob(dbPath) {
+  const r = spawnSync("sqlite3", [dbPath, `SELECT value FROM ItemTable WHERE key='${APPLICATION_USER_KEY}';`], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const raw = (r.stdout ?? "").replace(/\n$/, "");
+  return raw ? JSON.parse(raw) : null;
+}
+
+// A malformed model id (a truncated "firerouter/" prefix) must be rejected
+// before any key verification or config write. The compound `firerouter/x`
+// gateway form stays valid.
+describe("cursor on --model validation (engineOn)", () => {
+  const sqliteAvailable = spawnSync("sqlite3", ["-version"], { encoding: "utf8" }).status === 0;
+  const itIfSqlite = sqliteAvailable ? it : it.skip;
+
+  itIfSqlite("rejects a truncated firerouter prefix without writing the blob", async () => {
+    await withTempHome("cursor-model-bad-", async (home) => {
+      const dbPath = path.join(home, "state.vscdb");
+      writeCursorDb(dbPath, baseBlob());
+      // No gateway URL is set: if the bad id slipped through to key
+      // verification, the error would be the key message, not the model one.
+      const result = await runCli(
+        ["cursor", "on", "--api-key", "fw_test_key_12345",
+          "--model", "irerouter/claude-opus-5/kimi-k3-fast",
+          "--db-path", dbPath, "--force"],
+        { home, env: { FIREWORKS_API_KEY: "" } },
+      );
+      assert.notEqual(result.code, 0, "expected a non-zero exit for a malformed model id");
+      assert.match(
+        result.stderr,
+        /--model must be a Fireworks model id — a stable -latest router alias like glm-fast-latest.*firerouter, or a specific id like glm-5p2/,
+        `stderr was: ${result.stderr}`,
+      );
+      // The blob must be untouched — no verbatim bad id persisted.
+      const blob = readBlob(dbPath);
+      const allModelIds = [
+        ...(blob?.aiSettings?.userAddedModels ?? []),
+        ...(blob?.aiSettings?.modelOverrideEnabled ?? []),
+        blob?.aiSettings?.modelConfig?.composer?.modelName,
+        ...(blob?.aiSettings?.modelConfig?.composer?.selectedModels ?? []).map((s) => s?.modelId),
+      ].filter(Boolean);
+      assert.ok(
+        !allModelIds.includes("irerouter/claude-opus-5/kimi-k3-fast"),
+        `bad id was persisted: ${JSON.stringify(allModelIds)}`,
+      );
+    });
+  });
+
+  itIfSqlite("accepts the valid compound firerouter gateway form", async () => {
+    await withTempHome("cursor-model-good-", async (home) => {
+      const dbPath = path.join(home, "state.vscdb");
+      writeCursorDb(dbPath, baseBlob());
+      const result = await runCli(
+        ["cursor", "on", "--api-key", "fw_test_key_12345",
+          "--model", "firerouter/claude-opus-5/kimi-k3-fast",
+          "--db-path", dbPath, "--force"],
+        { home, env: { FIREWORKS_API_KEY: "" } },
+      );
+      // Validation passes; the run may still fail later on key verification
+      // (no gateway here), but it must NOT fail with the model-id message.
+      assert.doesNotMatch(
+        result.stderr,
+        /must be a Fireworks model id/,
+        `unexpected model-id rejection for valid gateway form: ${result.stderr}`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Problem

A malformed model id (e.g. a truncated `firerouter/...` prefix such as `irerouter/claude-opus-5/kimi-k3-fast`) was accepted by every harness **except** Claude and written verbatim into the IDE's selected-model slot, corrupting model selection on startup (Cursor crash).

## Root cause

`validateModelId` had exactly one call site — Claude's per-slot resolver (`resolveClaudeModelMapping`). Cursor, VS Code, OpenCode, Codex, Pi, and DeepSeek never validated structurally.

`assertRequestedModelServable` (the serverless-catalog check in `engineOn`) couldn't catch it either: it inspects only the **final path segment** (`fireworksModelSlug` → `split("/").at(-1)`), so `irerouter/claude-opus-5/kimi-k3-fast` passed because its tail slug `kimi-k3-fast` is a real catalog model. The garbage prefix sailed through and got persisted.

Reproduced end-to-end against a temp `state.vscdb`:
```
$ fireconnect cursor on --model irerouter/claude-opus-5/kimi-k3-fast
✓ Cursor → Fireworks · kimi-k3-fast          ← exit 0, misleading

modelConfig.composer.modelName = "irerouter/claude-opus-5/kimi-k3-fast"  ← persisted verbatim
modelOverrideDisabled          = []                                          ← self-heal never fired
```

## Fix

Validate every supplied `--model` id (and Claude slot aliases `--opus/--sonnet/--haiku/--fable/--subagent`) in the shared `validateHarnessOptions` gate (`lib/cli/commands/harness.mjs`), which runs **before** any key verification or config write for all harnesses. A malformed id now fails fast:

```
✗ Error: --model must be a Fireworks model id — a stable -latest router alias
  like glm-fast-latest, firerouter, or a specific id like glm-5p2. Run
  `fireconnect model list` to see options.
```

The legitimate compound `firerouter/<spec>` gateway form still passes (`isFirerouterGatewayPattern` matches any `firerouter` segment). Claude's bespoke `on` continues to validate per-slot downstream; validating up front too is harmless and makes every harness fail at the same point.

Also refreshed the error example: dropped the deprecated `deepseek-v4-flash` slug; the message now accurately lists `-latest` aliases, `firerouter`, and specific ids.

## Validation

- New regression test `test/harnesses/cursor/cursor-model-validation.test.mjs`: a truncated `firerouter/...` prefix is rejected with the validation message and the blob is **not** written; the valid `firerouter/claude-opus-5/kimi-k3-fast` form is **not** rejected as a model-id error.
- No new failures: `harness-option-validation`, `firepass-defaults`, `model-servability`, `fireworks-model-specs`, `firerouter-model`, `firerouter-core`, and the cursor suite show identical pass/fail counts with and without the change (pre-existing failures are real-gateway key-verification errors from the test key `fw_test_key_12345`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
