### PR TITLE
Release FireConnect v0.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,11 @@ fireconnect claude       # first run opens the model mapping wizard
 ```text
 ✓ Claude Code → Fireworks
 Model mapping
-  Fable     → kimi-fast-latest
-  Main      → Claude default
+  Fable     → glm-flash-latest
   Opus      → firerouter
-  Sonnet    → glm-fast-latest
+  Sonnet    → deepseek-pro-latest
   Haiku     → deepseek-flash-latest
-  Subagents → Claude default
+  Subagents → deepseek-flash-latest
 
 ✓ Web search → fireworks-websearch (installed)
 
@@ -67,8 +66,8 @@ Model mapping:
 ```
 
 `claude status` lists only overrides — unpinned native slots and slots still on the
-default Fireworks mapping are omitted. After Mix with the recommended fast profile,
-the mapping section may be empty until you pin a slot.
+default Fireworks mapping are omitted. With the recommended defaults, the mapping
+section may be empty until you pin a slot.
 
 Swap `claude` for any harness: `opencode`, `codex`, `pi`, `cursor`, `vscode`, `deepseek`.
 Run `fireconnect help` or `fireconnect <harness> help` for every option.
@@ -97,7 +96,7 @@ mkdir -p ~/.fireconnect && git clone git@github.com:fw-ai/fireconnect.git ~/.fir
 | Harness | Command | Config it writes | Key storage | Before `on` / `off` |
 |---------|---------|------------------|-------------|---------------------|
 | [Claude Code](#claude-code) | `fireconnect claude` | `~/.claude/settings.json` | Baked header literal (`0600`) | Restart after |
-| [Codex](#codex) | `fireconnect codex` | `~/.codex/config.toml` | Baked bearer literal (`0600`) | Restart after |
+| [Codex](#codex) | `fireconnect codex` / `fireconnect chatgpt` | `~/.codex/config.toml` | Baked bearer literal (`0600`) | Restart after |
 | [OpenCode](#opencode) | `fireconnect opencode` | `~/.config/opencode/opencode.json` | Baked literal (`0600`) | Restart after |
 | [Pi](#pi) | `fireconnect pi` | `~/.pi/agent/{settings,models,auth}.json` | Baked literal (`0600`) | Restart after |
 | [Cursor](#cursor) | `fireconnect cursor` | `state.vscdb` (SQLite) | IDE `safeStorage` | **Quit Cursor first** |
@@ -112,11 +111,12 @@ and the IDEs by removing only what FireConnect registered.
 
 | Slot / harness | Default |
 |----------------|---------|
-| Claude `opus` | `firerouter` on first connect when FireRouter auth is available; otherwise `kimi-fast-latest` |
-| Claude `sonnet` | `glm-fast-latest` |
-| Claude `fable` | `kimi-fast-latest` when FireRouter takes Opus; otherwise `deepseek-pro-latest` |
-| Claude `haiku` | `deepseek-flash-latest` |
-| Claude `subagent` | `deepseek-flash-latest` |
+| Claude `main` | Claude default (unpinned) |
+| Claude `opus` | `firerouter` on first connect with a standard key; otherwise `glm-latest` |
+| Claude `sonnet` | `deepseek-pro-latest` |
+| Claude `fable` | `glm-flash-latest` (vision) |
+| Claude `haiku` | `deepseek-flash-latest` (text-only) |
+| Claude `subagent` | `deepseek-flash-latest` (text-only; tool runner) |
 | OpenCode, Codex, Pi, Cursor, VS Code, DeepSeek Harness | `kimi-fast-latest` |
 | Fire Pass (`fpk_...`) | `kimi-fast-latest` everywhere |
 
@@ -134,8 +134,17 @@ fireconnect claude usage                 # pick session → live meter (Tab agen
 fireconnect claude usage --days 7        # widen the session list's lookback (default 3)
 fireconnect claude usage --session <id>  # start on one session; Esc still opens the list
 fireconnect claude usage --plain         # one-shot snapshot, no interactive picker
+fireconnect claude live                  # tmux split: Claude Code left, live usage meter right
 fireconnect claude demo                  # race two models on a prompt (requires routing on)
 fireconnect claude off
+```
+
+Scripting and cost reporting — `status` and `usage` both emit machine-readable JSON:
+
+```bash
+fireconnect claude status --json         # provider, auth, mapping
+fireconnect claude usage --last-n 5 --json  # snapshot the 5 latest sessions
+fireconnect claude usage --verbose       # request-level rows and per-request rates
 ```
 
 Settings apply per session: to pick up a new mapping, exit and resume with
@@ -160,8 +169,7 @@ fireconnect claude --non-interactive
 ```
 
 `--interactive` opens the wizard at any time, not just on first connect. It is Fable-first,
-toggles between the recommended fast profile and a non-fast profile, and needs a terminal —
-use the flags above in CI.
+shows every slot on one screen, and needs a terminal — use the flags above in CI.
 
 | Flag | Writes |
 |------|--------|
@@ -178,35 +186,47 @@ fireconnect claude --opus native --sonnet native   # native Opus/Sonnet
 fireconnect claude --model claude-sonnet-4-5       # pin a specific Anthropic model
 ```
 
-On first connect, the wizard asks Fireworks-only vs Mix (recommended). Re-running `fireconnect claude` without model flags preserves the current main when
-FireConnect is already active (including `/model` changes made inside Claude Code), and
-otherwise restores your saved key-scoped mapping.
+On first connect, the wizard opens on a single Fable-first mapping screen. Re-running
+`fireconnect claude` without model flags preserves the current main when FireConnect is
+already active (including `/model` changes made inside Claude Code), and otherwise
+restores your saved key-scoped mapping.
 
 ### What gets written
 
 Claude authenticates with a static `X-Fireworks-Api-Key` custom header
-(`ANTHROPIC_CUSTOM_HEADERS`), **not** `apiKeyHelper`. `main` and `subagent` stay native
-(Claude-default — Claude Code's own defaults), so neither is pinned; the alias slots are
-pinned in `env`. With FireRouter auth present, `opus` is `firerouter` and `fable` is
-`kimi-fast-latest`:
+(`ANTHROPIC_CUSTOM_HEADERS`), **not** `apiKeyHelper`. `main` stays native (unpinned).
+Every other slot is pinned in `env` to a Fireworks router alias unless you pick
+`native` or `claude-default` for that slot in the wizard.
+
+Baseline pinned slots (before any first-connect FireRouter auto-pin on Opus):
+
+| Slot | Default |
+|------|---------|
+| Opus | `glm-latest` |
+| Sonnet | `deepseek-pro-latest` |
+| Fable | `glm-flash-latest` |
+| Haiku | `deepseek-flash-latest` |
+| Subagents | `deepseek-flash-latest` |
+
+On **first connect** with a standard `fw_` key and FireRouter auth, Opus is auto-pinned to
+`firerouter` and Sonnet to `glm-latest` (GLM moves off the Opus slot). Example settings after
+that first connect:
 
 ```json
 {
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.fireworks.ai/inference",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "firerouter[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-fast-latest[1m]",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-latest[1m]",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-flash-latest[1m]",
-    "ANTHROPIC_DEFAULT_FABLE_MODEL": "kimi-fast-latest[1m]",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL": "glm-flash-latest[1m]",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-flash-latest",
     "ANTHROPIC_CUSTOM_HEADERS": "X-Fireworks-Api-Key: fw_..."
   }
 }
 ```
 
-Without FireRouter auth, `opus` falls back to `kimi-fast-latest[1m]` and `fable` to
-`deepseek-pro-latest[1m]`.
-
-When FireRouter is auto-selected on first connect, `model` is `firerouter[1m]` instead.
+When FireRouter is not selected, `opus` uses `glm-latest[1m]`. `main` remains unpinned.
 
 **Why the custom header?** The gateway authenticates via `X-Fireworks-Api-Key`, which wins over
 any `x-api-key` / `Authorization` a stray `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` would
@@ -223,6 +243,8 @@ first launch.
   your account is entitled to Fireworks web search, a `fireworks-websearch` MCP server is
   installed as the working replacement, with `Authorization: Bearer <key>` baked into
   `~/.claude.json` (same shape as `claude mcp add --header`).
+- Installs a `statusLine` showing the routed model and Fireworks-rate session cost (see
+  [Status line](#status-line)). An existing `statusLine` of your own is never replaced.
 - Sends privacy-safe attribution headers where the harness supports them: `X-Title: <harness>`
   and `HTTP-Referer: fireconnect/v<version>`. `User-Agent` is never overridden, and these carry
   no user, account, path, repo, prompt, session, or credential data. Cursor and DeepSeek Harness
@@ -258,6 +280,60 @@ bill. Use `fireconnect claude status` and `fireconnect model list` for Fireworks
 [serverless pricing](https://docs.fireworks.ai/serverless/pricing), and see the
 [billing dashboard](https://app.fireworks.ai/account/billing) for actual spend.
 
+### Status line
+
+`on` installs a `statusLine` in `settings.json` that shows the models actually serving the session
+and its cost at Fireworks rates:
+
+```text
+━━━━━━━━━━━━ ━ ━ · $70.39
+━ Claude Opus 5 $62.91 98% cache · ━ GLM 5.2 $7.35 96% cache · ━ DeepSeek V4 Flash $0.13 87% cache
+```
+
+The first line is a **multi-color bar of where the money went** — one colored segment per backend
+model, sized by its share of the session's spend — followed by the session total. FireRouter routes
+each call dynamically, so rather than naming only the latest model the bar shows the whole mix at a
+glance, weighted by what each one actually cost. Above, Opus 5 takes 47% of the calls but nearly the
+whole bar, because it is 89% of the bill; that gap is the thing worth seeing, and a bar drawn by
+call count would have hidden it. The bar carries no text on purpose: spend share is the one figure
+without a natural unit, so printing it as a bare `%` beside the cache percentages made the line
+ambiguous. Width says "how much of the spend"; the legend below names the models in the same order
+with the exact dollars.
+
+The line deliberately carries **no context-window figure**. Everything on it is something only
+FireConnect can tell you — the model actually serving each call, its cost at Fireworks rates, its
+cache hit rate. Context usage is Claude Code's own number, which it already surfaces through
+`/context` and its auto-compact warnings, so repeating it here spent columns to say nothing new.
+
+The second line attributes **spend and cache-hit rate per model**, each entry led by a swatch in its
+bar segment's color. An entry reads `<model> <its cost> <its cache hit>`, and every figure carries
+its unit (`$`, `% cache`) so nothing has to be inferred. That split is the point a single total
+hides: above, Opus 5 takes 47% of the calls but 89% of the bill, and the subagent model's 87% cache
+rate is a different story from the main thread's 96–98%. Cache is computed per model with the same
+helpers as the live meter's `cache%` column, so the two always agree. Before the first call lands
+there is no transcript to break down, so the bar is replaced by the slot alias.
+`fireconnect claude usage` has the full per-model token table.
+
+**Color carries identity only.** The swatches and bar segments are the sole colored elements; every
+label and number stays in the terminal's own foreground so the line inherits your theme and the
+figures read at one weight. The series hues are the validated dark-surface categorical steps — they
+clear the lightness band, chroma floor, colorblind separation (worst adjacent ΔE 8.4), and 3:1
+contrast against the surface — and segments are separated by a blank cell so neighbouring models are
+distinguishable without relying on hue. `NO_COLOR` strips to plain text.
+
+The cost is **not** Claude Code's own figure — that one prices every call against Anthropic's
+list, so on a Fireworks gateway it reports a number you are never billed. FireConnect recomputes
+it from the session transcript with the same engine behind `fireconnect claude usage`, which
+prices each call by the model that actually served it. A session that switched slots mid-flight
+(or a FireRouter session that sent hard turns to Claude) totals correctly, and subagent calls are
+included. A `~` prefix means some model in the session had no published rate and fell back to a
+reference price. `97% cache` is the cumulative prompt-cache hit share — the same figure the live
+usage meter prints.
+
+Rates come from the catalog cache `on` writes, so the line needs no network. `off` removes it.
+**If you already have a `statusLine`, FireConnect leaves it alone** — delete yours and re-run
+`fireconnect claude` to opt in.
+
 ## Codex
 
 Routes [OpenAI Codex CLI](https://developers.openai.com/codex) through Fireworks via the
@@ -286,6 +362,22 @@ fireconnect codex off
 
 `config.toml` updates immediately; exit Codex and `codex resume <id>` (or start a new session)
 to pick up the change. Use `--config-path <path>` for a non-default config.
+
+> **Resuming a prior session requires the matching provider to be on.**
+> `codex resume` resolves the session's recorded `model_provider` against the live
+> `config.toml`, so force the provider or it falls back to OpenAI:
+>
+> ```bash
+> codex resume <id> -c model_provider="fireworks-ai"        # Fireworks gateway
+> codex resume <id> -c model_provider="fireworks-azure"     # Azure/Foundry
+> ```
+>
+> The provider table is removed by `fireconnect codex off`, so resume only
+> resolves while the matching route is on.
+
+`fireconnect chatgpt` is an alias for the same harness — `codex` and `chatgpt` share
+`~/.codex`, so one command routes both the Codex CLI and the ChatGPT desktop app. Like the
+IDEs, it asks you to quit the app first; `--force` writes anyway (not recommended).
 
 ## OpenCode
 
@@ -347,6 +439,7 @@ Cursor stores AI settings in SQLite (`state.vscdb`), so FireConnect writes there
 fireconnect cursor --api-key fw_...      # quit Cursor first
 fireconnect cursor status                # read-only; safe while Cursor is open
 fireconnect cursor --model glm-fast-latest
+fireconnect cursor --db-path <path>      # non-default state.vscdb (e.g. Cursor Insiders)
 fireconnect cursor off
 ```
 
@@ -373,6 +466,7 @@ FireConnect adds a `Fireworks` provider to `chatLanguageModels.json` (vendor `cu
 fireconnect vscode --api-key fw_...       # quit VS Code first
 fireconnect vscode status                 # read-only; safe while VS Code is open
 fireconnect vscode --model deepseek-flash-latest
+fireconnect vscode --vscode-path <path>   # non-default chatLanguageModels.json
 fireconnect vscode off
 ```
 
@@ -417,8 +511,9 @@ Use `--config-path <path>` for a non-default `settings.yaml` (credentials stay b
 
 ## FireRouter
 
-FireRouter is a judge-model router: simpler requests go to cheaper models, harder ones pass
-through. It's a normal **`firerouter` model** on the Fireworks gateway — not a separate mode.
+FireRouter routes each request between Claude and Fireworks open models — simpler work stays on
+open models, harder work can use Claude when you have BYOK. It's a normal **`firerouter` model**
+on the Fireworks gateway — not a separate mode.
 Select it like any other model.
 
 ```bash
@@ -431,7 +526,7 @@ fireconnect claude --opus firerouter           # or a single Claude slot
 | **Keys** | Standard Fireworks (`fw_...`) only — not Fire Pass |
 | **Catalog** | Always in `fireconnect model list` for a standard key |
 | **Pickers** | Auto-included with workspace BYOK (`enable-workspace-byok`), or a forwardable `sk-ant-...` `ANTHROPIC_API_KEY` on harnesses that can attach one |
-| **Auto default** | Claude Code `main` only — first connect, FireRouter auth present, no explicit model flags |
+| **Auto default** | Claude Code `opus` only — first connect with a standard key and no explicit model flags |
 | **No Anthropic key** | Still routes among Fireworks models |
 
 **BYOK for Anthropic frontier models.** With workspace BYOK, your Anthropic key is used
@@ -440,7 +535,7 @@ server-side — no extra flags. Otherwise pass `--anthropic-api-key sk-ant-...` 
 
 | Harness | Local Anthropic BYOK | `--routing-preference` | Notes |
 |---------|----------------------|------------------------|-------|
-| Claude Code | Header value | Yes | Fireworks header still wins for gateway auth; only harness that can auto-default `main` |
+| Claude Code | Header value | Yes | Fireworks header still wins for gateway auth; only harness that can auto-default Opus to FireRouter |
 | OpenCode | Header value | Yes | `--model firerouter` registers only that model |
 | Pi | Header value | Yes | Same Fireworks provider as other Pi models |
 | VS Code | Header value | Yes | Same provider (`apiType: chat-completions`) |
@@ -464,13 +559,30 @@ More detail: [FireRouter overview](https://docs.fireworks.ai/ecosystem/fireroute
 ```bash
 fireconnect model list
 fireconnect model list --search glm
+fireconnect model list --refresh
 fireconnect model list --json
 ```
 
 Fetches coding-tagged serverless models (`GET /v1/serverless/models?use_cases=coding`), adds the
 per-model fast routers the API reports, and merges version-tracking aliases whose targets are
-present: `glm-latest`, `glm-fast-latest`, `kimi-latest`, `kimi-fast-latest`, `minimax-latest`,
-`qwen-plus-latest`. Every row is tagged `serverless`.
+present: `glm-latest`, `glm-flash-latest`, `glm-fast-latest`, `kimi-latest`,
+`kimi-fast-latest`, `minimax-latest`, `qwen-plus-latest`. Every row is tagged `serverless`.
+The catalog is cached for **1 hour**; `fireconnect model list --refresh` bypasses that TTL
+and refetches. If the network is unavailable, FireConnect keeps showing the last cached
+catalog instead of deleting it.
+
+US-only serverless routers are listed in their own section and accept short IDs:
+
+```bash
+fireconnect claude on --model kimi-k3-us
+fireconnect opencode on --model glm-5p2-fast-us
+fireconnect claude on --model glm-5p3-flash-us
+```
+
+US-only endpoints launched from September 1, 2026 are priced at a 50% premium over the
+matching global row (`glm-5p3-flash-us`). Earlier routers keep their launch rates:
+`kimi-k3-us` at a 10% premium, `glm-5p2-fast-us` at parity with global GLM 5.2 Fast. See
+[US-only Serverless](https://docs.fireworks.ai/serverless/us-only-serverless).
 
 Key resolution order: `--api-key` → `FIREWORKS_API_KEY` → stored credential. Standard keys
 include `firerouter`; Fire Pass keys show only Fire Pass-supported routers (`glm-latest`,
@@ -552,6 +664,7 @@ Harness-first: `fireconnect <harness> <command>`, plus a few global commands.
 fireconnect <harness> on           Route the harness through Fireworks (default if no command).
 fireconnect <harness> off          Restore your previous provider/config.
 fireconnect <harness> status       Show the provider, auth, and model mapping.
+fireconnect <harness> status --json  Machine-readable state (CI checks).
 fireconnect <harness> help         Show help for that harness.
 ```
 
@@ -575,10 +688,12 @@ fireconnect help                   Show help.
 `login` asks one question: create an API key for this machine, or paste one you already have.
 Create opens the browser, mints `fireconnect-{hostname}`, and stores it in the OS keychain —
 confirming the account and where the key went. Paste masks input, validates live, and stores
-only on success. `--paste` skips the chooser; `--with-token` reads from stdin (CI).
+only on success. `--paste` skips the chooser; `--with-token` reads from stdin (CI);
+`--account <id>` signs into an enterprise SSO account. Already signed in? `login` asks before
+replacing the key — `--force` skips that confirmation for key rotation.
 
-`logout` removes the local key and offers to revoke the machine key server-side (`--revoke` /
-`--keep-key` skip the question). You don't have to start with `login` — `fireconnect claude`
+`logout` removes the local key and offers to revoke the machine key server-side — `--revoke`
+skips the question and revokes. You don't have to start with `login` — `fireconnect claude`
 runs the same sign-in inline when a key is needed.
 
 ## Keys and storage
@@ -587,6 +702,9 @@ runs the same sign-in inline when a key is needed.
   literal key. Legacy installs may still have `{env:FIREWORKS_API_KEY}`.
 - The key itself lives in the OS keychain, or an encrypted-file / plaintext fallback tier when
   no secret service is available (`fireconnect status` reports which).
+- `--home <path>` overrides HOME for config resolution and `--data-dir <path>` moves the
+  backup/state directory — useful for sandboxed runs and tests that must not touch your real
+  harness configs.
 - Harness configs hold **baked literals** for Claude's custom header, Codex, OpenCode, Pi, and
   DeepSeek Harness; Cursor and VS Code use IDE `safeStorage`.
 - Claude websearch MCP no longer uses a shell hook — the Bearer token is baked into
@@ -629,9 +747,18 @@ Interactive terminals also offer an upgrade prompt when a newer version is cache
 
 Upgrading from **before 0.9.0** with Claude Code connected asks before temporarily restoring
 your original settings, then tells you to reconnect with `fireconnect claude`. From **0.9.0**
-onward, reinstall and upgrade leave harness settings alone. Other harness settings and your
-stored API key are preserved either way.
+onward, reinstall and upgrade leave harness settings alone apart from key rebaking and small
+forward migrations (currently: VS Code's provider `apiType`, and adding `ENABLE_TOOL_SEARCH` to
+managed Claude Code settings). Other harness settings and your stored API key are preserved
+either way.
+
+After updating the checkout, `fireconnect upgrade` runs its finalizer in a fresh process so
+migrations are loaded from the new version rather than the old process's module cache. For the
+transition from older upgraders, the changed package lock makes their existing upgrade path run
+`npm install`; a durable-install-only postinstall hook runs that same new finalizer. Repository
+and global npm installs do not match the durable layout and skip the hook.
 
 ```bash
 fireconnect uninstall    # restores every harness, then removes ~/.fireconnect and the launcher
+fireconnect uninstall --force   # no prompts — force-restore everything (CI / scripts)
 ```

--- a/install.sh
+++ b/install.sh
@@ -275,8 +275,6 @@ const isFireworksModelMapping = (value) => {
 const hasFireworksMapping = mappingKeys.some(
   (key) => isFireworksModelMapping(env[key]),
 );
-const hasManagedPreset = env.CLAUDE_CODE_ATTRIBUTION_HEADER === "0"
-  && env.CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING === "1";
 const fireworksHeader = header("x-fireworks-api-key");
 const currentHelper = typeof settings.apiKeyHelper === "string" ? settings.apiKeyHelper : "";
 const hasManagedHelper = (
@@ -295,9 +293,8 @@ const hasManagedEvidence = Object.hasOwn(backup, "snapshot")
   || hasTelemetry
   || (
     (fireworksHeader.startsWith("fw_") || fireworksHeader.startsWith("fpk_"))
-    && (hasFireworksMapping || hasManagedPreset)
-  )
-  || (hasFireworksMapping && hasManagedPreset);
+    && hasFireworksMapping
+  );
 
 process.exit(hasManagedEvidence ? 0 : 1);
 NODE
@@ -436,7 +433,8 @@ ensure_dependencies() {
   # npm's "added N packages in Xms" summary prints to stdout regardless of
   # --loglevel, which clutters the install output with a stray line between our
   # `→` steps. Discard stdout (errors still surface on stderr) unless verbose.
-  if ! (cd "${setup_dir}" && npm install --omit=dev --no-fund --no-audit --loglevel="${npm_loglevel}" 1>"${npm_stdout}"); then
+  if ! (cd "${setup_dir}" && FIRECONNECT_SKIP_POSTINSTALL_FINALIZE=1 \
+    npm install --omit=dev --no-fund --no-audit --loglevel="${npm_loglevel}" 1>"${npm_stdout}"); then
     echo "Failed to install FireConnect dependencies." >&2
     exit 1
   fi

--- a/packages/setup-cli/bin/claude-statusline.mjs
+++ b/packages/setup-cli/bin/claude-statusline.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Code `statusLine` helper. Reads the status line JSON on stdin and
+ * prints one line: the routed Fireworks model and the session's Fireworks cost.
+ *
+ * Never exits non-zero and never writes to stderr on a bad payload: Claude Code
+ * blanks the status line on failure and logs stderr to the debug log, so a
+ * transient unreadable transcript would flicker the line away. Anything we
+ * cannot render is simply omitted.
+ */
+
+import process from "node:process";
+
+/*
+ * A 'warning' listener must be installed before the imports that can emit one,
+ * and must be persistent: process.emitWarning defers to process.nextTick, so a
+ * suppress-then-restore window around an import always restores too early.
+ * Node's default printer is itself a listener and is not replaced by adding
+ * one, hence removeAllListeners first. Status line stderr goes to Claude Code's
+ * debug log, so warnings are dropped rather than reprinted.
+ */
+process.removeAllListeners("warning");
+process.on("warning", () => {});
+
+async function readStdin() {
+  // Claude Code always writes the payload, but guard against a spawn with no
+  // stdin (e.g. someone running the helper by hand) rather than hanging.
+  if (process.stdin.isTTY) {
+    return "";
+  }
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main() {
+  const raw = await readStdin();
+  let input;
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  if (!input || typeof input !== "object") {
+    return;
+  }
+  const { renderClaudeStatusLine } = await import("../lib/harnesses/claude/statusline.mjs");
+  const line = await renderClaudeStatusLine(input);
+  if (line) {
+    process.stdout.write(`${line}\n`);
+  }
+}
+
+main().catch(() => {
+  // Silent: an empty status line is better than a broken one.
+});

--- a/packages/setup-cli/lib/cli/commands/global.mjs
+++ b/packages/setup-cli/lib/cli/commands/global.mjs
@@ -17,7 +17,7 @@ import {
 } from "../../harnesses/codex/core.mjs";
 import {
   DEEPSEEK_DATA_RELATIVE_DIR,
-} from "../../harnesses/deepseek/core.mjs";
+} from "../../harnesses/deepseek/constants.mjs";
 import {
   PI_DATA_RELATIVE_DIR,
 } from "../../harnesses/pi/core.mjs";
@@ -39,6 +39,8 @@ import { readLocalVersion } from "../../system/version.mjs";
 import { removeShellEnvHook } from "../../io/shell-env-hook.mjs";
 import { runClaudeUpgradePreflight } from "../../system/upgrade.mjs";
 import { finalizeInstallOrUpgrade } from "../../system/finalize-install.mjs";
+import { runUpgradeFinalize } from "../../system/upgrade-finalize.mjs";
+import { runtimeDepsInstalled } from "../../system/ensure-cli-deps.mjs";
 import { deleteSecret } from "../../keys/secret-store.mjs";
 import { demoHelpText } from "../../demo/help.mjs";
 import { info, printBanner, success } from "../../ui/index.mjs";
@@ -165,12 +167,15 @@ function claudeHelp() {
   );
 }
 
-function configHarnessHelp(id, label, { configPath, configPathNote = "", codexNote = "" } = {}) {
+function configHarnessHelp(id, label, { configPath, configPathNote = "", codexNote = "", displayId = id, force = false } = {}) {
   const onOpts = standardOnOpts({
     azure: Boolean(getHarness(id).azure),
     firerouter: getHarness(id).firerouter,
     modelNote: id === "deepseek" ? "use firerouter for FireRouter" : id === "codex" ? "use firerouter for FireRouter" : "",
   });
+  if (force) {
+    onOpts.push(["--force", "Write while the ChatGPT app is running (not recommended)."]);
+  }
   const allOpts = [
     OPT_HOME,
     [configPath, configPathNote || "Explicit config file path."],
@@ -178,9 +183,9 @@ function configHarnessHelp(id, label, { configPath, configPathNote = "", codexNo
   ].filter((row) => row[0]);
 
   return helpLines(
-    `Usage: ${CLI_NAME} ${id} [command] [options]`,
+    `Usage: ${CLI_NAME} ${displayId} [command] [options]`,
     "",
-    `Route ${label} through Fireworks. Bare \`${CLI_NAME} ${id}\` runs on.`,
+    `Route ${label} through Fireworks. Bare \`${CLI_NAME} ${displayId}\` runs on.`,
     codexNote ? `\n${codexNote}` : "",
     "",
     cmdBlock("Commands", [
@@ -243,7 +248,8 @@ export function mainCommandsHelp() {
     cmdBlock("Harnesses", [
       ["claude", "Claude Code"],
       ["opencode", "OpenCode"],
-      ["codex", "Codex CLI"],
+      ["codex", "Codex CLI & ChatGPT app"],
+      ["chatgpt", "Codex CLI & ChatGPT app"],
       ["pi", "Pi"],
       ["cursor", "Cursor IDE"],
       ["vscode", "VS Code Chat"],
@@ -272,18 +278,23 @@ export function printHelp(topic = "") {
     return;
   }
 
+  const codexHelpOpts = {
+    configPath: "--config-path <path>",
+    configPathNote: "Explicit ~/.codex/config.toml path.",
+    codexNote: "Firerouter BYOK reads ANTHROPIC_API_KEY from your shell. "
+      + "Pass --anthropic-api-key with codex on (or configure), then source your shell config.",
+    force: true,
+  };
   const harnessHelp = {
     claude: claudeHelp(),
     opencode: configHarnessHelp("opencode", "OpenCode", {
       configPath: "--config-path <path>",
       configPathNote: "Explicit opencode.json path.",
     }),
-    codex: configHarnessHelp("codex", "Codex CLI", {
-      configPath: "--config-path <path>",
-      configPathNote: "Explicit ~/.codex/config.toml path.",
-      codexNote: "Firerouter BYOK reads ANTHROPIC_API_KEY from your shell. "
-        + "Pass --anthropic-api-key with codex on (or configure), then source your shell config.",
-    }),
+    codex: configHarnessHelp("codex", "Codex CLI & ChatGPT app", codexHelpOpts),
+    // `chatgpt` is an alias for the codex harness (shared ~/.codex config); show
+    // the same help but with the typed name in the usage line.
+    chatgpt: configHarnessHelp("codex", "Codex CLI & ChatGPT app", { ...codexHelpOpts, displayId: "chatgpt" }),
     pi: helpLines(
       configHarnessHelp("pi", "Pi", {
         configPath: "--settings-path <path>",
@@ -379,7 +390,8 @@ export function printHelp(topic = "") {
     cmdBlock("Harnesses", [
       ["claude", "Claude Code"],
       ["opencode", "OpenCode"],
-      ["codex", "Codex CLI"],
+      ["codex", "Codex CLI & ChatGPT app"],
+      ["chatgpt", "Codex CLI & ChatGPT app"],
       ["pi", "Pi"],
       ["cursor", "Cursor IDE"],
       ["vscode", "VS Code Chat"],
@@ -410,6 +422,7 @@ export function printHelp(topic = "") {
     optBlock("Global options", [
       ["--version, -V", "Print CLI version (--json for machine-readable)."],
       ["--search <q>", "Filter model list."],
+      ["--refresh", "Bypass the 1-hour cache and refetch (keeps cached data if offline)."],
       ["--json", "Machine-readable model list output."],
     ]),
     "",
@@ -444,17 +457,6 @@ export function runVersionCommand(ctx) {
 }
 
 /**
- * Shared post-bootstrap finalize used by `fireconnect upgrade` and
- * `install.sh` (via hidden `finalize-install`). See finalize-install.mjs.
- *
- * @param {string} home
- * @param {string} installDir
- */
-async function finalizeUpgradeKeyStorage(home, installDir) {
-  await finalizeInstallOrUpgrade({ home, installDir });
-}
-
-/**
  * Hidden easter-egg entry point — not listed in help. Use for local preview;
  * install.sh uses bin/fireconnect-banner.mjs directly.
  */
@@ -464,7 +466,7 @@ export function runBannerCommand() {
 
 /**
  * Hidden install.sh entry point — not listed in help. Same body as upgrade
- * finalize (deps, key-storage probe, harness + websearch MCP rebake).
+ * finalize (deps, key-storage probe, harness migrations, key rebake).
  *
  * @param {{ home?: string }} [ctx]
  */
@@ -483,7 +485,7 @@ export async function runFinalizeInstallCommand(ctx = {}) {
  *   execFile?: typeof execFileSync,
  *   exists?: typeof existsSync,
  *   readVersion?: typeof readInstalledVersion,
- *   finalize?: typeof finalizeUpgradeKeyStorage,
+ *   finalize?: typeof runUpgradeFinalize,
  *   printNotes?: typeof printReleaseNotesAfterUpgrade,
  *   preflight?: typeof runClaudeUpgradePreflight,
  *   getClaudeAdapter?: () => { off: (ctx: object) => Promise<void> },
@@ -492,6 +494,7 @@ export async function runFinalizeInstallCommand(ctx = {}) {
  *   infoFn?: typeof info,
  *   successFn?: typeof success,
  *   log?: (...args: unknown[]) => void,
+ *   runtimeDepsPresent?: (setupDir: string) => boolean,
  * }} [dependencies]
  */
 export async function runUpgradeCommand({
@@ -499,7 +502,7 @@ export async function runUpgradeCommand({
   execFile = execFileSync,
   exists = existsSync,
   readVersion = readInstalledVersion,
-  finalize = finalizeUpgradeKeyStorage,
+  finalize = runUpgradeFinalize,
   printNotes = printReleaseNotesAfterUpgrade,
   preflight = runClaudeUpgradePreflight,
   getClaudeAdapter = () => getHarness(HARNESS.CLAUDE),
@@ -508,6 +511,7 @@ export async function runUpgradeCommand({
   infoFn = info,
   successFn = success,
   log = console.log,
+  runtimeDepsPresent = runtimeDepsInstalled,
 } = {}) {
   if (!home) {
     throw new Error("HOME is not set; upgrade requires HOME to be set.");
@@ -551,8 +555,30 @@ export async function runUpgradeCommand({
     throw new Error("Upgrade failed: unable to determine the fetched revision.");
   }
 
+  const setupDir = path.join(installDir, "packages/setup-cli");
+  const installRuntimeDeps = (lockfileChanged) => {
+    // Reinstall after a lockfile change, and also when package.json deps are
+    // missing (e.g. yaml added while git still reports no lockfile diff, or an
+    // already-current checkout whose node_modules lagged a previous pull).
+    const missing = exists(setupDir) && !runtimeDepsPresent(setupDir);
+    if ((!lockfileChanged && !missing) || !exists(setupDir)) {
+      return;
+    }
+    const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
+    try {
+      execFile(npmBin, ["install", "--omit=dev", "--no-fund", "--no-audit"], {
+        cwd: setupDir,
+        env: { ...process.env, FIRECONNECT_SKIP_POSTINSTALL_FINALIZE: "1" },
+        stdio: "inherit",
+      });
+    } catch (error) {
+      throw new Error(`Upgrade failed: could not install dependencies (${error.message}). Re-run the installer.`);
+    }
+  };
+
   if (beforeHash && beforeHash === targetHash) {
     infoFn(`Already up to date${before ? ` (v${before})` : ""}.`);
+    installRuntimeDeps(false);
     await printNotes({
       home,
       fromVersion: "",
@@ -589,10 +615,8 @@ export async function runUpgradeCommand({
   const after = await readVersion(installDir);
 
   // Reinstall runtime dependencies after the pull — a new release may have
-  // added/changed deps (e.g. cross-keychain). Without this, upgraded installs
-  // can hit "OS keychain is unavailable" if the dep was missing. Skip the npm
-  // resolution when the lockfile is unchanged between commits (code-only
-  // releases), to avoid ~300-800ms of overhead on every upgrade.
+  // added/changed deps (e.g. yaml). Skip npm when the lockfile is unchanged
+  // *and* every package.json dependency is already on disk.
   const lockfileRel = "packages/setup-cli/package-lock.json";
   let depsChanged = true;
   if (beforeHash && afterHash) {
@@ -603,21 +627,7 @@ export async function runUpgradeCommand({
       depsChanged = true; // non-zero => diff (or git error) => install
     }
   }
-
-  const setupDir = path.join(installDir, "packages/setup-cli");
-  if (depsChanged && exists(setupDir)) {
-    // npm is npm.cmd on Windows; execFileSync without shell:true doesn't resolve
-    // .cmd shims, so pick the right binary name per platform.
-    const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
-    try {
-      execFile(npmBin, ["install", "--omit=dev", "--no-fund", "--no-audit"], {
-        cwd: setupDir,
-        stdio: "inherit",
-      });
-    } catch (error) {
-      throw new Error(`Upgrade failed: could not install dependencies (${error.message}). Re-run the installer.`);
-    }
-  }
+  installRuntimeDeps(depsChanged);
 
   if (!claudePreflight.restored) {
     if (before && after && before !== after) {

--- a/packages/setup-cli/lib/cli/commands/harness.mjs
+++ b/packages/setup-cli/lib/cli/commands/harness.mjs
@@ -3,7 +3,7 @@ import { dispatchHarnessCommand } from "../../harness/types.mjs";
 import { getHarness } from "../../harness/registry.mjs";
 import { persistGlobalAnthropicApiKey } from "../../config/global-config.mjs";
 import { FILE_CONFIG_HARNESS_SET, HARNESS } from "../../harness/id.mjs";
-import { isFirerouterModel } from "../../fireworks/model-id.mjs";
+import { isFirerouterModelPattern } from "../../fireworks/model-id.mjs";
 import { isAnthropicShapedKey } from "../../firerouter/core.mjs";
 import { supportsAnthropicApiKeyFlag, supportsRoutingPreference } from "../../firerouter/flag.mjs";
 import {
@@ -14,8 +14,9 @@ import {
   persistApiKeyFromFlag,
   persistApiKeyToKeychain,
 } from "../../keys/api-key.mjs";
+import { shouldSkipEnvKeyAutoPersist } from "../../config/secret-storage-policy.mjs";
 
-const IDE_HARNESSES = new Set([HARNESS.CURSOR, HARNESS.VSCODE]);
+const IDE_HARNESSES = new Set([HARNESS.CURSOR, HARNESS.VSCODE, HARNESS.CODEX]);
 
 /**
  * Fail on parsed flags the selected harness/command cannot use. The parser is
@@ -31,8 +32,8 @@ function validateHarnessOptions(route, ctx) {
   const claudeAliases = [ctx.opus, ctx.sonnet, ctx.haiku, ctx.fable, ctx.subagent];
   const claudeModels = [ctx.main, ...claudeAliases];
   const firerouterRequested = harnessId === HARNESS.CLAUDE
-    ? claudeModels.some((modelId) => isFirerouterModel(modelId))
-    : isFirerouterModel(ctx.main);
+    ? claudeModels.some((modelId) => isFirerouterModelPattern(modelId))
+    : isFirerouterModelPattern(ctx.main);
 
   if (ctx.provider && !ctx.azure) {
     throw new Error(
@@ -47,7 +48,7 @@ function validateHarnessOptions(route, ctx) {
     throw new Error("--base-url on this harness requires --azure.");
   }
   if (ctx.force && !IDE_HARNESSES.has(harnessId)) {
-    throw new Error("--force is only supported for Cursor and VS Code.");
+    throw new Error("--force is only supported for Cursor, VS Code, and Codex.");
   }
   if (onboardingMode !== "auto" && !(harnessId === HARNESS.CLAUDE && isOn)) {
     const flag = onboardingMode === "prompt" ? "--interactive" : "--non-interactive";
@@ -61,6 +62,9 @@ function validateHarnessOptions(route, ctx) {
   }
   if (ctx.search) {
     throw new Error("--search applies only to `fireconnect model list`.");
+  }
+  if (ctx.refresh) {
+    throw new Error("--refresh applies only to `fireconnect model list`.");
   }
   // `--session` is shared by `claude usage` (report) and `claude live` (resume +
   // meter that session in the split); the report-only flags stay usage-only.
@@ -195,7 +199,11 @@ export async function runHarnessCommand(route, ctx) {
       }
     } else if (!azureMode && process.env.FIREWORKS_API_KEY?.trim()) {
       const envKey = assertFireworksKeyShape(process.env.FIREWORKS_API_KEY);
-      if (FILE_CONFIG_HARNESS_SET.has(route.harnessId) && await canPersistApiKeyToKeychain(home)) {
+      if (
+        FILE_CONFIG_HARNESS_SET.has(route.harnessId)
+        && await canPersistApiKeyToKeychain(home)
+        && !shouldSkipEnvKeyAutoPersist()
+      ) {
         await persistApiKeyToKeychain(home, envKey);
       }
     }

--- a/packages/setup-cli/lib/cli/messages.mjs
+++ b/packages/setup-cli/lib/cli/messages.mjs
@@ -6,6 +6,7 @@ import {
   routingPreferenceOptionsList,
 } from "../firerouter/core.mjs";
 import { supportsRoutingPreference } from "../firerouter/flag.mjs";
+import { isFirerouterModelPattern, isFirerouterModel } from "../fireworks/model-id.mjs";
 
 export const FIREROUTER_DOCS_URL =
   "https://docs.fireworks.ai/ecosystem/firerouter/overview";
@@ -17,9 +18,15 @@ const FIREROUTER_HARNESS_LABELS = {
 };
 
 function displayModel(model) {
-  return typeof model === "string"
-    ? model.replace(/\[1m\]$/, "").split("/").at(-1)
-    : "";
+  if (typeof model !== "string") {
+    return "";
+  }
+  const stripped = model.replace(/\[1m\]$/, "");
+  // Keep the firerouter/... routing prefix for compound slugs; collapse others to last segment.
+  if (isFirerouterModelPattern(stripped) && !isFirerouterModel(stripped)) {
+    return stripped.replace(/^accounts\/fireworks\/(?:models|routers)\//i, "");
+  }
+  return stripped.split("/").at(-1);
 }
 
 function firerouterOnCommand(harnessId) {
@@ -322,8 +329,27 @@ export function printClaudeModelActivationHint() {
   printSessionRestartHint("Claude Code");
 }
 
-export function printCodexRestartHint() {
-  printSessionRestartHint("Codex");
+export function printCodexRestartHint({ resume = true, providerId = "fireworks-ai", providerLabel = "Fireworks" } = {}) {
+  // The app caches the model catalog at boot (see codex/ide-running.mjs); reopen
+  // it to pick up the new provider/models. `on`/`off` block while it runs, so
+  // this is the matching "reopen it now" nudge. Applies to both on and off.
+  printRestartHint("Quit & reopen the ChatGPT app (if you use it) for the change to take effect in its model dropdown.");
+
+  // `codex resume` resolves a session's recorded `model_provider` against the
+  // live config.toml; the rollout only stores the provider name, not its
+  // definition. The provider table only exists while FireConnect routes that
+  // provider, so resuming without forcing the provider falls back to OpenAI
+  // (or 400s if the session used a ChatGPT account). The resume command only
+  // applies after an `on` for that provider; after `off` the table is gone, so
+  // that path prints a plain restart hint instead.
+  if (!resume) {
+    printSessionRestartHint("Codex");
+    return;
+  }
+  printRestartHint(
+    `To resume existing Codex sessions with ${providerLabel}:\n`
+      + `  codex resume <id> -c model_provider="${providerId}"`,
+  );
 }
 
 export function printPiRestartHint() {

--- a/packages/setup-cli/lib/cli/parse-args.mjs
+++ b/packages/setup-cli/lib/cli/parse-args.mjs
@@ -1,7 +1,7 @@
 import process from "node:process";
 import { FIREWORKS_BASE_URL } from "../fireworks/model-id.mjs";
 import { ROUTING_PREFERENCE_LEVELS, normalizeRoutingPreference } from "../firerouter/core.mjs";
-import { HARNESSES } from "../harness/id.mjs";
+import { HARNESSES, HARNESS_ALIASES, resolveHarnessAlias } from "../harness/id.mjs";
 import { parseDemoArgs, findDemoInvocation } from "../demo/parse-demo-args.mjs";
 import { withSuggestion } from "../ui.mjs";
 
@@ -36,7 +36,7 @@ const KNOWN_FLAGS = [
   "--help", "--version", "--json", "--home", "--settings-path", "--config-path",
   "--data-dir", "--api-key", "--base-url", "--azure", "--provider",
   "--anthropic-api-key", "--model", "--opus",
-  "--sonnet", "--haiku", "--fable", "--subagent", "--search",
+  "--sonnet", "--haiku", "--fable", "--subagent", "--search", "--refresh",
   "--db-path", "--vscode-path", "--force", "--stored-only",
   "--last-n", "--plain", "--verbose", "--routing-preference", "--session", "--days",
   "--account", "--anthropic", "--paste", "--revoke", "--with-token",
@@ -53,8 +53,11 @@ function withContextualHelp(message, positionals = []) {
   if (message.includes("Run: fireconnect")) {
     return message;
   }
-  const harnessId = HARNESSES.includes(positionals[0]) ? positionals[0] : "";
-  return `${message} ${helpHint(harnessId)}`;
+  // Echo the typed name (e.g. `chatgpt`) for the help hint when it is a harness
+  // or a known alias of one, so alias errors route to the right harness help.
+  const token = positionals[0] ?? "";
+  const isHarnessOrAlias = HARNESSES.includes(token) || resolveHarnessAlias(token) !== token;
+  return `${message} ${helpHint(isHarnessOrAlias ? token : "")}`;
 }
 
 /**
@@ -87,6 +90,7 @@ export function createBaseContext() {
     fable: "",
     subagent: "",
     search: "",
+    refresh: false,
     session: "",
     days: 0,
     lastN: "",
@@ -193,6 +197,7 @@ export function applyGlobalFlag(ctx, arg, next) {
     case "--fable": ctx.fable = requireValue(arg, next); return true;
     case "--subagent": ctx.subagent = requireValue(arg, next); return true;
     case "--search": ctx.search = requireValue(arg, next); return true;
+    case "--refresh": ctx.refresh = true; return false;
     case "--session": ctx.session = requireValue(arg, next); return true;
     case "--days": ctx.days = requireDays(arg, next); return true;
     case "--last-n": ctx.lastN = requireValue(arg, next); return true;
@@ -312,6 +317,8 @@ export function parseCli(argv) {
   }
 
   if (help) {
+    // Keep the raw typed token (e.g. `chatgpt`) so per-harness help echoes the
+    // name the user typed; printHelp resolves aliases to the canonical help.
     return { kind: "global", command: "help", ctx, helpTopic };
   }
 
@@ -325,7 +332,7 @@ export function parseCli(argv) {
     return { kind: "global", command: "launcher", ctx };
   }
 
-  const first = positional[0];
+  const first = resolveHarnessAlias(positional[0]);
   const rest = positional.slice(1);
 
   if (first === "help") {
@@ -371,7 +378,8 @@ export function parseCli(argv) {
 
   if (HARNESSES.includes(first)) {
     if (rest[0] === "help") {
-      return { kind: "global", command: "help", ctx, helpTopic: first };
+      // Echo the typed name (e.g. `chatgpt`) in the help, not the canonical id.
+      return { kind: "global", command: "help", ctx, helpTopic: positional[0] };
     }
     return { kind: "harness", route: parseHarnessRoute(first, rest), ctx };
   }
@@ -379,6 +387,8 @@ export function parseCli(argv) {
   throw new Error(`${withSuggestion(
     `Unknown command: ${first}.`,
     first,
-    [...GLOBAL_COMMANDS, ...HARNESSES],
+    // Aliases are advertised in help as top-level commands, so typo recovery
+    // must know them too (`chatgtp` -> `chatgpt`).
+    [...GLOBAL_COMMANDS, ...HARNESSES, ...Object.keys(HARNESS_ALIASES)],
   )} ${helpHint()}`);
 }

--- a/packages/setup-cli/lib/config/secret-storage-policy.mjs
+++ b/packages/setup-cli/lib/config/secret-storage-policy.mjs
@@ -1,0 +1,49 @@
+import process from "node:process";
+import { isRemoteContext } from "./remote-context.mjs";
+import { readKeyStorageOverride } from "../keys/storage-env.mjs";
+
+/**
+ * Central policy for secret storage in remote / SSH / WSL sessions.
+ * Keys, harness, and environment detection should all consult this module
+ * instead of re-deriving overlapping predicates.
+ */
+
+/**
+ * On Linux SSH/WSL, prefer encrypted-file storage over libsecret. Secret
+ * Service is often detected (secret-tool installed) but unusable without an
+ * unlocked session keyring.
+ *
+ * @returns {boolean}
+ */
+export function shouldPreferFileBackendOnLinux() {
+  if (process.platform !== "linux") {
+    return false;
+  }
+  if (readKeyStorageOverride()) {
+    return false;
+  }
+  return isRemoteContext();
+}
+
+/**
+ * Skip automatic env-key → keychain persistence (harness `on` paths). Remote
+ * sessions often lack a working OS keychain; persisting would block or fail.
+ *
+ * @returns {boolean}
+ */
+export function shouldSkipEnvKeyAutoPersist() {
+  return isRemoteContext();
+}
+
+/**
+ * Human-readable detail for `detectSecretStorage()` when file backend is chosen
+ * due to remote context.
+ *
+ * @returns {string | undefined}
+ */
+export function remoteSecretStorageDetail() {
+  if (!shouldPreferFileBackendOnLinux()) {
+    return undefined;
+  }
+  return "SSH/remote session — using encrypted-file storage instead of the OS keychain";
+}

--- a/packages/setup-cli/lib/demo/browser.mjs
+++ b/packages/setup-cli/lib/demo/browser.mjs
@@ -83,10 +83,13 @@ export function buildCompareHtml({
   // were rebased above).
   // Only a run where both sides finished yields an honest comparison. On a
   // partial run, the strip states what happened instead of asserting a winner.
+  const costComparison = Number.isFinite(costFraction)
+    ? `<div class="item">Cost: <b>${delta}</b> on ${costSide}</div>
+  <div class="item extrap">At 1,000 generations: ${formatUsd(inc1k)} → ${formatUsd(fw1k)} <span class="badge" style="margin-left:6px">linear extrapolation</span></div>`
+    : `<div class="item">Cost: <b>not comparable</b> — pricing unavailable</div>`;
   const stripInner = bothOk
     ? `<div class="item">Speed: <b>${ratio}</b> on ${speedSide}</div>
-  <div class="item">Cost: <b>${delta}</b> on ${costSide}</div>
-  <div class="item extrap">At 1,000 generations: ${formatUsd(inc1k)} → ${formatUsd(fw1k)} <span class="badge" style="margin-left:6px">linear extrapolation</span></div>`
+  ${costComparison}`
     : `<div class="item">Run incomplete — ${escapeHtml(!inc.ok ? incumbentLabel : fireworksLabel)} didn't finish, so no speed/cost comparison is shown.</div>`;
 
   const payload = {
@@ -235,7 +238,9 @@ function debugHtml(run) {
     ["cache write 5m", fmtNum(run.cacheWrite5mTokens)],
     ["cache read", fmtNum(run.cacheReadTokens)],
     ["output tokens", fmtNum(run.outputTokens)],
-    ["rate in / out", `$${r.inputPerMillion ?? 0} / $${r.outputPerMillion ?? 0} per Mtok`],
+    ["rate in / out", Number.isFinite(r.inputPerMillion) && Number.isFinite(r.outputPerMillion)
+      ? `$${r.inputPerMillion} / $${r.outputPerMillion} per Mtok`
+      : "n/a (priced from resolved model after run)"],
     ["rate cache w1h / w5m / read", `$${r.cacheWrite1hPerMillion ?? 0} / $${r.cacheWrite5mPerMillion ?? 0} / $${r.cacheReadPerMillion ?? 0} per Mtok`],
     ["estimated pricing", r.estimated ? "yes" : "no"],
     ["cost", typeof run.cost === "number" ? `$${run.cost.toFixed(6)}` : ""],

--- a/packages/setup-cli/lib/demo/claude-runner.mjs
+++ b/packages/setup-cli/lib/demo/claude-runner.mjs
@@ -11,7 +11,8 @@ import readline from "node:readline";
 import { FIRST_TOKEN_TIMEOUT_MS, HARD_RUN_CAP_MS } from "./constants.mjs";
 import { FIREWORKS_ENV_KEYS } from "../harnesses/claude/core.mjs";
 import { CLAUDE_FIREROUTER_ENV_KEYS } from "../firerouter/core.mjs";
-import { computeClaudeUsageCost } from "../harnesses/claude/usage/report.mjs";
+import { computeClaudeUsageCost } from "../harnesses/claude/usage/pricing.mjs";
+import { isFirerouterModelPattern } from "../fireworks/model-specs.mjs";
 import { lookupFireworksPricing } from "../fireworks/pricing.mjs";
 import { stripClaudeCodeContextSuffix } from "../harnesses/claude/code-context.mjs";
 
@@ -171,16 +172,12 @@ export function parseStreamJson(obj) {
       // without splitting write/read and pricing each at its own rate, cost is
       // computed from a near-zero input count and wildly understated.
       Object.assign(out, extractCacheTokens(u));
-      // Keep the raw usage so the runner can compute a fallback cost via the
-      // shared computeClaudeUsageCost (same function `claude usage`/`claude live`
-      // use) when Claude Code doesn't report its own total_cost_usd.
+      // Keep raw usage so the runner can price it with the same canonical
+      // provider-rate engine as transcript reports and statusline.
       out.usage = u;
     }
-    // Claude Code reports its own authoritative cost (computed from its internal
-    // model→price table, including for firerouter where the underlying routed
-    // model is opaque to us). Prefer this over our rate-table estimate so the
-    // demo's cost column reflects what was actually charged. total_cost_usd is
-    // the whole-run total; modelUsage[*].costUSD is the per-model breakdown.
+    // Preserve Claude Code's own estimate for diagnostics. It can apply
+    // Anthropic rates to Fireworks models, so it never drives demo pricing.
     if (typeof obj.total_cost_usd === "number" && obj.total_cost_usd > 0) {
       out.costUsd = obj.total_cost_usd;
     } else {
@@ -317,7 +314,7 @@ function toolFileContentSoFar(json) {
  * Split Anthropic prompt-caching usage into priced buckets. `cache_creation`
  * carries the per-TTL write breakdown (ephemeral_1h / ephemeral_5m); when absent,
  * fall back to the aggregate `cache_creation_input_tokens` and assume 5m (the
- * cheaper, safer default — matches `computeClaudeUsageCost` in usage/report.mjs
+ * cheaper, safer default — matches `computeClaudeUsageCost` in usage/pricing.mjs
  * so the demo and `claude usage` agree on identical session data). 1h writes
  * bill at a premium over 5m, so assuming 1h would overprice a flat-shape run.
  * `cache_read_input_tokens` is the read/hit bucket.
@@ -348,6 +345,29 @@ function extractCacheTokens(u) {
 }
 
 /**
+ * Price demo usage with the same engine as transcript reports/statusline.
+ *
+ * Prefer a priced requested router because the router identifies the serving
+ * tier. Otherwise use the backend model Claude Code recorded.
+ */
+export function priceClaudeUsage({ model, resolvedModel = "", usage }) {
+  const requested = stripClaudeCodeContextSuffix(String(model || ""));
+  const requestedIsPriced = requested
+    ? Boolean(lookupFireworksPricing(requested))
+    : false;
+  // FireRouter delegates to a backend per call, so its own catalog row (if one
+  // exists) cannot replace the model that actually served this usage. Stable
+  // tier routers are different: their requested id carries the fast/standard
+  // tier that a resolved base-model id loses.
+  const priceModel = resolvedModel && isFirerouterModelPattern(requested)
+    ? resolvedModel
+    : (requestedIsPriced ? requested : (resolvedModel || model));
+  return priceModel && usage
+    ? computeClaudeUsageCost(priceModel, usage)
+    : null;
+}
+
+/**
  * @typedef {Object} ClaudeRunResult
  * @property {boolean} ok
  * @property {string} text
@@ -356,8 +376,8 @@ function extractCacheTokens(u) {
  * @property {number | null} cacheWrite5mTokens 5m prompt-cache write tokens (billed at a premium)
  * @property {number | null} cacheReadTokens prompt-cache read/hit tokens (billed at a discount)
  * @property {number | null} outputTokens
- * @property {number | null} costUsd Claude Code's own cost (total_cost_usd) — authoritative when present
- * @property {number | null} estimatedCostUsd shared computeClaudeUsageCost estimate — fallback when costUsd is absent
+ * @property {number | null} costUsd Claude Code's own diagnostic total_cost_usd; never used for Fireworks pricing
+ * @property {ReturnType<typeof computeClaudeUsageCost> | null} usagePricing canonical provider pricing for the final usage
  * @property {number} seconds
  * @property {{ t: number, text: string }[]} tokenLog
  * @property {string} [error]
@@ -422,7 +442,7 @@ export async function runClaude({
   let resultCacheWrite5m = null;
   let resultCacheRead = null;
   let resultCostUsd = null;
-  let resultEstimatedCostUsd = null;
+  let usagePricing = null;
   let resultOutput = null;
   let text = "";
   let resultText = "";
@@ -658,16 +678,7 @@ export async function runClaude({
       // fast router silently gets billed at standard rates. Only fall back to
       // the resolved model when the request was an opaque router with no price
       // of its own (firerouter), where the backend it picked is the only key.
-      const requested = stripClaudeCodeContextSuffix(String(model || ""));
-      const requestedIsPriced = requested ? Boolean(lookupFireworksPricing(requested)) : false;
-      const priceModel = requestedIsPriced ? requested : (resolvedModel || model);
-      if (parsed.usage && priceModel) {
-        try {
-          resultEstimatedCostUsd = computeClaudeUsageCost(priceModel, parsed.usage).cost;
-        } catch {
-          resultEstimatedCostUsd = null;
-        }
-      }
+      usagePricing = priceClaudeUsage({ model, resolvedModel, usage: parsed.usage });
       // The result event's totals are authoritative — surface them to the live
       // meter so the cost reflects real usage as soon as the run finishes.
       onTokens?.({
@@ -735,10 +746,33 @@ export async function runClaude({
   const cacheWrite5mTokens = resultCacheWrite5m ?? (sumCacheWrite5m || null);
   const cacheReadTokens = resultCacheRead ?? (sumCacheRead || null);
   const outputTokens = resultOutput ?? (accOutput || null);
-  // Claude Code's own cost (from total_cost_usd) — authoritative when present.
+  // Keep Claude Code's own total for diagnostics only. It prices Fireworks
+  // models from Anthropic tables and must never drive the demo comparison.
   const costUsd = resultCostUsd;
-  // Shared computeClaudeUsageCost estimate — fallback when costUsd is absent.
-  const estimatedCostUsd = resultEstimatedCostUsd;
+  // Older event streams can omit the result-level usage object while still
+  // carrying per-message token totals. Price that aggregate through the same
+  // canonical engine rather than duplicating rate math in the demo.
+  if (!usagePricing && [
+    inputTokens,
+    cacheWrite1hTokens,
+    cacheWrite5mTokens,
+    cacheReadTokens,
+    outputTokens,
+  ].some((value) => value != null)) {
+    usagePricing = priceClaudeUsage({
+      model,
+      resolvedModel,
+      usage: {
+        input_tokens: inputTokens ?? 0,
+        cache_creation: {
+          ephemeral_1h_input_tokens: cacheWrite1hTokens ?? 0,
+          ephemeral_5m_input_tokens: cacheWrite5mTokens ?? 0,
+        },
+        cache_read_input_tokens: cacheReadTokens ?? 0,
+        output_tokens: outputTokens ?? 0,
+      },
+    });
+  }
 
   if (timedOut && !gotResult) {
     const which = firstDeltaAt ? "run cap" : "first token";
@@ -748,7 +782,7 @@ export async function runClaude({
       : `no tokens after ${Math.round(limitMs / 1000)}s — connection stalled or no content deltas.`;
     const msg = `claude timed out (${which}) ${stalled}`;
     const result = {
-      ok: false, text, inputTokens, cacheWrite1hTokens, cacheWrite5mTokens, cacheReadTokens, outputTokens, costUsd, estimatedCostUsd, resolvedModel, sessionId, seconds, tokenLog,
+      ok: false, text, inputTokens, cacheWrite1hTokens, cacheWrite5mTokens, cacheReadTokens, outputTokens, costUsd, usagePricing, resolvedModel, sessionId, seconds, tokenLog,
       error: msg, httpStatus: 0, errorBody: stderrTail,
     };
     onError?.(result);
@@ -759,7 +793,7 @@ export async function runClaude({
   // process exited 0 with a result event — surface it instead of claiming ok.
   if (streamError) {
     const result = {
-      ok: false, text, inputTokens, cacheWrite1hTokens, cacheWrite5mTokens, cacheReadTokens, outputTokens, costUsd, estimatedCostUsd, resolvedModel, sessionId, seconds, tokenLog,
+      ok: false, text, inputTokens, cacheWrite1hTokens, cacheWrite5mTokens, cacheReadTokens, outputTokens, costUsd, usagePricing, resolvedModel, sessionId, seconds, tokenLog,
       error: streamError, httpStatus: 0, errorBody: stderrTail || streamError,
     };
     onError?.(result);
@@ -776,7 +810,7 @@ export async function runClaude({
       cacheReadTokens,
       outputTokens,
       costUsd,
-      estimatedCostUsd,
+      usagePricing,
       resolvedModel,
       sessionId,
       seconds,

--- a/packages/setup-cli/lib/demo/command.mjs
+++ b/packages/setup-cli/lib/demo/command.mjs
@@ -11,7 +11,7 @@ import os from "node:os";
 import { HARNESS } from "../harness/id.mjs";
 import { getHeadlessRunner, SUPPORTED_HARNESS_IDS } from "./harness-runners.mjs";
 import { extractHtml, looksRunnable } from "./html-extract.mjs";
-import { buildResult, runCost, formatSpeedRatio, formatUsd, formatSeconds } from "./measurement.mjs";
+import { buildResult, formatSpeedRatio, formatUsd, formatSeconds } from "./measurement.mjs";
 import {
   prepareOutputDir, writeStreamLog, writeAppHtml, writeResultJson, writeCompareHtml,
   readBestHtmlFromDir,
@@ -276,7 +276,7 @@ export async function runDemoCommand(ctx) {
       cacheReadTokens: r.cacheReadTokens ?? 0,
       outputTokens: r.outputTokens ?? 0,
       seconds: r.seconds ?? 0,
-      cost: 0,
+      cost: r.usagePricing?.cost ?? null,
     });
     // Freeze each side's clock the instant ITS OWN runner resolves — not after
     // both finish — so the faster side stops ticking at its real finish time and
@@ -300,7 +300,7 @@ export async function runDemoCommand(ctx) {
         raceSide(rightRunner, "fireworks"),
       ]);
       await finalizeBoth({
-        incResult, fwResult, incRates: leftRates, fwRates: rightRates,
+        incResult, fwResult,
         setIncHtml: (h) => { incumbentAppHtml = h; }, setFwHtml: (h) => { fireworksAppHtml = h; },
         incRunProto, fwRunProto, incCwd, fwCwd,
       });
@@ -315,7 +315,7 @@ export async function runDemoCommand(ctx) {
       leftRunner({ signal: abort.signal }),
       rightRunner({ signal: abort.signal }),
     ]);
-    await finalizeBoth({ incResult, fwResult, incRates: leftRates, fwRates: rightRates,
+    await finalizeBoth({ incResult, fwResult,
       setIncHtml: (h) => { incumbentAppHtml = h; }, setFwHtml: (h) => { fireworksAppHtml = h; },
       incRunProto, fwRunProto, incCwd, fwCwd });
   }
@@ -488,12 +488,12 @@ function makeSideProto(side, modelId, rates) {
   };
 }
 
-async function finalizeBoth({ incResult, fwResult, incRates, fwRates, setIncHtml, setFwHtml, incRunProto, fwRunProto, incCwd, fwCwd }) {
-  await finalizeSide("fireworks", fwRunProto, fwResult, fwRates, setFwHtml, { cwd: fwCwd });
-  await finalizeSide("incumbent", incRunProto, incResult, incRates, setIncHtml, { cwd: incCwd });
+async function finalizeBoth({ incResult, fwResult, setIncHtml, setFwHtml, incRunProto, fwRunProto, incCwd, fwCwd }) {
+  await finalizeSide(fwRunProto, fwResult, setFwHtml, { cwd: fwCwd });
+  await finalizeSide(incRunProto, incResult, setIncHtml, { cwd: incCwd });
 }
 
-async function finalizeSide(side, proto, result, rates, setHtml, { cwd = null } = {}) {
+async function finalizeSide(proto, result, setHtml, { cwd = null } = {}) {
   if (!result?.ok) {
     proto.ok = false;
     proto.error = result?.error || "generation failed";
@@ -503,11 +503,12 @@ async function finalizeSide(side, proto, result, rates, setHtml, { cwd = null } 
     proto.debug = {
       sessionId: result?.sessionId || "",
       resolvedModel: result?.resolvedModel || "",
+      pricedModel: result?.usagePricing?.model || "",
       cwd: cwd || "",
     };
     proto.inputTokens = result?.inputTokens ?? 0;
     proto.outputTokens = result?.outputTokens ?? 0;
-    proto.cost = 0;
+    proto.cost = result?.usagePricing?.cost ?? null;
     proto.appRunnable = false;
     setHtml(result?.text ? extractHtml(result.text).html : "");
     return;
@@ -532,40 +533,14 @@ async function finalizeSide(side, proto, result, rates, setHtml, { cwd = null } 
   proto.cacheReadTokens = result.cacheReadTokens ?? 0;
   proto.outputTokens = result.outputTokens ?? 0;
   proto.seconds = result.seconds;
-  // Cost comes from computeClaudeUsageCost (the same function `claude usage` /
-  // `claude live` use), NOT from Claude Code's total_cost_usd.
-  //
-  // Claude Code has no Fireworks price table: for a gateway-routed Fireworks
-  // model its modelUsage reports provider "firstParty" and it prices the run
-  // with its own ANTHROPIC rates. Measured, exactly: a glm-fast-latest run of
-  // 126360 in / 10861 cache-read / 2715 out was reported as $0.705106, which is
-  // that token mix at Opus rates ($5/$0.50/$25) to six decimals — 2.5x its real
-  // Fireworks cost of $0.285556. Trusting total_cost_usd therefore inflates the
-  // Fireworks side and inverts the comparison the demo exists to make.
-  //
-  // computeClaudeUsageCost resolves Fireworks pricing first and falls back to the
-  // Anthropic list table, so it is right for BOTH sides — and for a real
-  // Anthropic model it agrees with Claude Code exactly (claude-opus-5 measured
-  // at $0.880210 both ways). costUsd is kept only as a last resort.
-  // Final fallback: the estimate is only produced when the result event carried a
-  // `usage` block. When it doesn't, token totals still come from the per-message
-  // accumulators, so pricing them here keeps a successful run from reporting real
-  // tokens against a $0 cost.
-  const fromTokens = () => runCost({
-    inputTokens: proto.inputTokens,
-    cacheWrite1hTokens: proto.cacheWrite1hTokens,
-    cacheWrite5mTokens: proto.cacheWrite5mTokens,
-    cacheReadTokens: proto.cacheReadTokens,
-    outputTokens: proto.outputTokens,
-    inputPerMillion: rates.inputPerMillion,
-    cacheWrite1hPerMillion: rates.cacheWrite1hPerMillion,
-    cacheWrite5mPerMillion: rates.cacheWrite5mPerMillion,
-    cacheReadPerMillion: rates.cacheReadPerMillion,
-    outputPerMillion: rates.outputPerMillion,
-  });
-  proto.cost = (typeof result.estimatedCostUsd === "number" && result.estimatedCostUsd > 0)
-    ? result.estimatedCostUsd
-    : (result.costUsd || fromTokens());
+  // The runner already prices the authoritative result usage (or its final
+  // per-message aggregate) through the same canonical engine as statusline.
+  // Claude Code's own `costUsd` is diagnostic only: it applies Anthropic rates
+  // to Fireworks models whose cost basis it does not know.
+  proto.cost = result.usagePricing?.cost ?? null;
+  if (result.usagePricing?.rates) {
+    proto.rates = rateShape(result.usagePricing.rates, proto.provider);
+  }
   proto.appRunnable = runnable;
   // Session id + cwd locate this run's Claude Code transcript at
   // ~/.claude/projects/<slugified-cwd>/<sessionId>.jsonl; resolvedModel records
@@ -573,6 +548,7 @@ async function finalizeSide(side, proto, result, rates, setHtml, { cwd = null } 
   proto.debug = {
     sessionId: result.sessionId || "",
     resolvedModel: result.resolvedModel || "",
+    pricedModel: result.usagePricing?.model || "",
     cwd: cwd || "",
   };
   setHtml(html);
@@ -727,6 +703,14 @@ function buildCopySummary(result, leftLabel, rightLabel) {
   }
   const speedPart = verdictSpeedText(result, left, right);
   const cf = result.summary.costSavedFraction;
+  if (!Number.isFinite(cf)) {
+    const bothRunnable = result.incumbent.appRunnable && result.fireworks.appRunnable;
+    const appPart = bothRunnable ? ", working app" : ", one build didn't run";
+    return (
+      `Raced ${left} vs ${right} on the same ${result.promptTitle} prompt. `
+      + `${speedPart}, cost not comparable${appPart}. Built with \`fireconnect claude demo\`.`
+    );
+  }
   // Rebase to match the compare.html strip and terminal verdict (same race,
   // one percentage) — incumbent-relative |costSavedFraction| inflates savings.
   let frac = cf;
@@ -741,7 +725,7 @@ function buildCopySummary(result, leftLabel, rightLabel) {
     cheaperCost = result.incumbent.cost;
     pricierCost = result.fireworks.cost;
   }
-  const pct = Number.isFinite(frac) ? Math.round(frac * 100) : 0;
+  const pct = Math.round(frac * 100);
   const costs = `${formatUsd(cheaperCost)} vs ${formatUsd(pricierCost)}`;
   const costPart = pct > 0
     ? `${cheaperLabel} ${pct}% cheaper (${costs})`

--- a/packages/setup-cli/lib/demo/demo-models.mjs
+++ b/packages/setup-cli/lib/demo/demo-models.mjs
@@ -8,7 +8,7 @@
 
 import {
   FIREROUTER_ROUTER_ID,
-  isFirerouterModel,
+  isFirerouterModelPattern,
 } from "../fireworks/model-id.mjs";
 import {
   FIREWORKS_MODEL_SPECS,
@@ -25,6 +25,7 @@ import {
 import { lookupFireworksPricing } from "../fireworks/pricing.mjs";
 import {
   firerouterCatalogEntry,
+  firerouterDisplayName,
   preferLatestAliases,
 } from "../fireworks/models.mjs";
 import { prettyClaudeLabel, providerListPricing } from "./incumbent-detect.mjs";
@@ -129,7 +130,7 @@ export function demoFireworksPickerIds() {
 
 /** @param {string} id */
 function demoFireworksKind(id) {
-  return id === "firerouter" || isFirerouterModel(id) ? "firerouter" : "fireworks";
+  return id === "firerouter" || isFirerouterModelPattern(id) ? "firerouter" : "fireworks";
 }
 
 /**
@@ -182,8 +183,8 @@ export function demoModelLabel(id) {
   if (resolved) {
     return resolved;
   }
-  if (bare === "firerouter") {
-    return FIREWORKS_MODEL_SPECS.firerouter?.label ?? "FireRouter";
+  if (isFirerouterModelPattern(bare)) {
+    return firerouterDisplayName(bare);
   }
   return FIREWORKS_MODEL_SPECS[bare]?.label ?? bare;
 }
@@ -200,11 +201,11 @@ function hasLiveCachedPricing(modelRef) {
 
 /**
  * @param {NonNullable<ReturnType<typeof lookupFireworksPricing>>} pricing
- * @param {{ label: string, pricingRef: string, forceEstimated?: boolean }} opts
+ * @param {{ label: string, pricingRef: string }} opts
  */
-function toDemoRateShape(pricing, { label, pricingRef, forceEstimated = false }) {
+function toDemoRateShape(pricing, { label, pricingRef }) {
   const live = hasLiveCachedPricing(pricingRef);
-  const estimated = forceEstimated || !live;
+  const estimated = !live;
   return {
     inputPerMillion: pricing.input,
     outputPerMillion: pricing.output,
@@ -218,15 +219,15 @@ function toDemoRateShape(pricing, { label, pricingRef, forceEstimated = false })
 
 /**
  * Resolve FireRouter pricing. FireRouter is a delegating router with no
- * per-token price of its own, so it has no spec/catalog entry; fall back to a
- * stable priced router (`glm-5p2-fast`) as an estimate when neither the live
- * serverless catalog nor the static specs carry a rate for it.
+ * per-token price of its own. If the catalog does not publish a rate for the
+ * selected router, leave the pre-run rate unavailable; the demo runner prices
+ * the backend model that actually served the request once usage arrives.
  *
  * Shared by the top-level `firerouter` demo id and by Anthropic slots whose
  * pinned backend is FireRouter (e.g. `opus` -> `firerouter[1m]`).
  * @param {string} id
  * @param {string} labelPrefix Optional "Claude Opus (via …)" prefix for slots.
- * @returns {{ inputPerMillion: number, outputPerMillion: number, cachedInputPerMillion: number, tier: string, source: string, label: string, estimated?: boolean } | null}
+ * @returns {{ inputPerMillion: number | null, outputPerMillion: number | null, cachedInputPerMillion: number | null, cacheWrite1hPerMillion: number | null, cacheWrite5mPerMillion: number | null, cacheReadPerMillion: number | null, tier: string, source: string, label: string, estimated: boolean } | null}
  */
 function firerouterRates(id, labelPrefix = null) {
   const p = lookupFireworksPricing(id)
@@ -237,23 +238,26 @@ function firerouterRates(id, labelPrefix = null) {
       pricingRef: id,
     });
   }
-  const fallback = lookupFireworksPricing("glm-5p2-fast");
-  if (!fallback) {
-    return null;
-  }
-  return toDemoRateShape(fallback, {
+  return {
+    inputPerMillion: null,
+    outputPerMillion: null,
+    cachedInputPerMillion: null,
+    cacheWrite1hPerMillion: null,
+    cacheWrite5mPerMillion: null,
+    cacheReadPerMillion: null,
+    tier: "unpriced",
+    source: "",
     label: labelPrefix
-      ? `${labelPrefix} (via ${demoModelLabel(id)}, estimate)`
-      : `${demoModelLabel(id)} (estimate)`,
-    pricingRef: "glm-5p2-fast",
-    forceEstimated: true,
-  });
+      ? `${labelPrefix} (via ${demoModelLabel(id)})`
+      : demoModelLabel(id),
+    estimated: true,
+  };
 }
 
 /**
  * Rate table shape used by measurement / TUI.
  * @param {string} id
- * @returns {{ inputPerMillion: number, outputPerMillion: number, cachedInputPerMillion: number, tier: string, source: string, label: string, estimated?: boolean } | null}
+ * @returns {{ inputPerMillion: number | null, outputPerMillion: number | null, cachedInputPerMillion: number | null, cacheWrite1hPerMillion?: number | null, cacheWrite5mPerMillion?: number | null, cacheReadPerMillion?: number | null, tier: string, source: string, label: string, estimated?: boolean } | null}
  */
 export function demoModelRates(id, keyType = "fireworks", slotMapping = null) {
   if (isAnthropicSlotModel(id)) {
@@ -284,7 +288,7 @@ export function demoModelRates(id, keyType = "fireworks", slotMapping = null) {
       ...(list.estimated ? { estimated: true } : {}),
     };
   }
-  if (id === "firerouter" || isFirerouterModel(id)) {
+  if (id === "firerouter" || isFirerouterModelPattern(id)) {
     return firerouterRates(id);
   }
   const p = lookupFireworksPricing(id);
@@ -295,6 +299,12 @@ export function demoModelRates(id, keyType = "fireworks", slotMapping = null) {
     label: p.label,
     pricingRef: id,
   });
+}
+
+/** Whether a demo rate shape carries concrete input and output prices. */
+export function hasDemoTokenRates(rates) {
+  return Number.isFinite(rates?.inputPerMillion)
+    && Number.isFinite(rates?.outputPerMillion);
 }
 
 export function defaultLeftModel() {
@@ -310,7 +320,7 @@ export function demoSideDisplayLabel(id) {
   if (isAnthropicSlotModel(id)) {
     return `Anthropic · ${demoModelLabel(id)}`;
   }
-  if (isFirerouterModel(id) || id === "firerouter") {
+  if (isFirerouterModelPattern(id) || id === "firerouter") {
     return `Fireworks · ${demoModelLabel(id)}`;
   }
   return `Fireworks · ${demoModelLabel(id)}`;

--- a/packages/setup-cli/lib/demo/incumbent-detect.mjs
+++ b/packages/setup-cli/lib/demo/incumbent-detect.mjs
@@ -43,6 +43,7 @@ import { cursorStateDbPath } from "../harnesses/cursor/core.mjs";
 import { piSettingsPath } from "../harnesses/pi/core.mjs";
 import { existsSync } from "node:fs";
 import { prettyModelName } from "../fireworks/models.mjs";
+import { providerListPricing } from "./list-pricing.mjs";
 
 const PROBE_ORDER = [
   HARNESS.CLAUDE,
@@ -439,112 +440,11 @@ export function prettyClaudeLabel(modelId) {
 
 // ── reference list pricing ───────────────────────────────────────────────────
 
-const ANTHROPIC_PRICING_URL = "https://www.anthropic.com/pricing";
-const OPENAI_PRICING_URL = "https://openai.com/api/pricing/";
-
-/** USD per 1M tokens, list price. Embedded reference — verify at the source URL.
- * Verified 2026-08-19 against https://platform.claude.com/docs/en/about-claude/pricing.
- * cacheWrite1h / cacheWrite5m are prompt-cache WRITE rates (billed at a premium
- * over base input); cacheRead is the cache HIT/read rate (steep discount). */
-const ANTHROPIC_LIST_RATES = {
-  // Current flagship (API tab). Sonnet 5 is $2/$10; Anthropic made the launch
-  // intro rate permanent on 2026-08-10 (the planned $3/$15 increase was canceled).
-  "claude-sonnet-5": { input: 2, cacheWrite5m: 2.5, cacheWrite1h: 4, cacheRead: 0.2, output: 10, label: "Claude Sonnet 5" },
-  "claude-sonnet-4-6": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15, label: "Claude Sonnet 4.6" },
-  "claude-sonnet-4-5": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15, label: "Claude Sonnet 4.5" },
-  "claude-sonnet": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15, label: "Claude Sonnet" },
-  // Opus 4.5–4.8 and Opus 5 are all $5/$25. The old $15/$75 was Opus 4.1 / 4 only.
-  "claude-opus-5": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 5" },
-  "claude-opus-4-8": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 4.8" },
-  "claude-opus-4-7": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 4.7" },
-  "claude-opus-4-6": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 4.6" },
-  "claude-opus-4-5": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 4.5" },
-  "claude-opus-4-1": { input: 15, cacheWrite5m: 18.75, cacheWrite1h: 30, cacheRead: 1.5, output: 75, label: "Claude Opus 4.1" },
-  "claude-opus-4": { input: 15, cacheWrite5m: 18.75, cacheWrite1h: 30, cacheRead: 1.5, output: 75, label: "Claude Opus 4" },
-  "claude-opus": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus" },
-  "claude-haiku-4-5": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku 4.5" },
-  "claude-haiku-3-5": { input: 0.8, cacheWrite5m: 1, cacheWrite1h: 1.6, cacheRead: 0.08, output: 4, label: "Claude Haiku 3.5" },
-  "claude-haiku": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku" },
-  // Fable 5 (next-gen long-running agents).
-  "claude-fable-5": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable 5" },
-  "claude-fable": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable" },
-  // Bare `/model` aliases (settings.json `model` may be just "opus"/"sonnet"/"haiku").
-  "opus": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus" },
-  "sonnet": { input: 2, cacheWrite5m: 2.5, cacheWrite1h: 4, cacheRead: 0.2, output: 10, label: "Claude Sonnet" },
-  "haiku": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku" },
-  "fable": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable" },
-};
-
-/** USD per 1M tokens, list price. Embedded reference — verify at the source URL.
- * Verified 2026-07-06 against https://openai.com/api/pricing/. */
-const OPENAI_LIST_RATES = {
-  // Current flagships.
-  "gpt-5.5": { input: 5, output: 30, label: "GPT-5.5" },
-  "gpt-5.4": { input: 2.5, output: 15, label: "GPT-5.4" },
-  "gpt-5.4-mini": { input: 0.75, output: 4.5, label: "GPT-5.4 mini" },
-  "gpt-5": { input: 1.25, output: 10, label: "GPT-5" },
-  "gpt-4o": { input: 2.5, output: 10, label: "GPT-4o" },
-  "gpt-4.1": { input: 2, output: 8, label: "GPT-4.1" },
-  "gpt-4o-mini": { input: 0.15, output: 0.6, label: "GPT-4o mini" },
-  "o3": { input: 2, output: 8, label: "o3" },
-};
-
-const DEFAULT_ANTHROPIC_RATE = { input: 2, output: 10, label: "Claude Sonnet (reference)" };
-const DEFAULT_OPENAI_RATE = { input: 2.5, output: 10, label: "GPT-4o (reference)" };
-
-/**
- * Pick the most-specific rate-table key that the model id contains. Substring
- * matching by insertion order would let a shorter key shadow a longer one
- * (e.g. `gpt-4o` matching `gpt-4o-mini` before `gpt-4o-mini` is tried), so we
- * sort candidates by descending length and take the first hit.
- * @param {string} id lowercased model id
- * @param {Record<string, any>} table
- * @returns {string | undefined}
- */
-function longestMatchKey(id, table) {
-  const keys = Object.keys(table).filter((k) => id.includes(k));
-  if (keys.length === 0) return undefined;
-  keys.sort((a, b) => b.length - a.length);
-  return keys[0];
-}
-
-/**
- * Look up list pricing for a provider + model id. Shared by incumbent detection
- * (harness-swap mode), so it derives cost the
- * same way. `provider` is "anthropic" | "openai"; anything else returns the
- * not-per-token subscription shape.
- *
- * @param {{ provider: string, modelId: string }} args
- * @returns {{ inputPerMillion: number, outputPerMillion: number, cachedInputPerMillion: number, tier: string, source: string, label: string, estimated: boolean }}
- */
-export function providerListPricing({ provider, modelId }) {
-  if (provider === "anthropic") {
-    const id = String(modelId).toLowerCase();
-    const rate = ANTHROPIC_LIST_RATES[id] ?? ANTHROPIC_LIST_RATES[longestMatchKey(id, ANTHROPIC_LIST_RATES)];
-    if (rate) {
-      return toRateShape(rate, ANTHROPIC_PRICING_URL, rate.cacheRead ?? rate.input * 0.1, false);
-    }
-    return toRateShape(DEFAULT_ANTHROPIC_RATE, ANTHROPIC_PRICING_URL, 0.2, true);
-  }
-  if (provider === "openai") {
-    const id = String(modelId).toLowerCase();
-    const rate = OPENAI_LIST_RATES[id] ?? OPENAI_LIST_RATES[longestMatchKey(id, OPENAI_LIST_RATES)];
-    if (rate) {
-      return toRateShape(rate, OPENAI_PRICING_URL, rate.input * 0.5, false);
-    }
-    return toRateShape(DEFAULT_OPENAI_RATE, OPENAI_PRICING_URL, 1.25, true);
-  }
-  // cursor / unknown: not per-token comparable.
-  return {
-    inputPerMillion: 0,
-    outputPerMillion: 0,
-    cachedInputPerMillion: 0,
-    tier: "subscription",
-    source: "",
-    label: "subscription (not per-token)",
-    estimated: true,
-  };
-}
+// The rate tables live in list-pricing.mjs so callers that only need a price —
+// the Claude cost engine and the status line — do not pull in this module's
+// per-harness config readers (and their optional npm dependencies). Re-exported
+// here so existing importers of this module keep working.
+export { providerListPricing };
 
 /**
  * Look up incumbent list pricing for a detected model.
@@ -553,23 +453,4 @@ export function providerListPricing({ provider, modelId }) {
  */
 export function incumbentPricing(incumbent) {
   return providerListPricing({ provider: incumbent.kind, modelId: incumbent.modelId });
-}
-
-function toRateShape(rate, source, cachedInput, estimated) {
-  return {
-    inputPerMillion: rate.input,
-    outputPerMillion: rate.output,
-    cachedInputPerMillion: cachedInput,
-    // Anthropic prompt-cache rates (USD/Mtok). Writes are billed at a premium
-    // over base input and differ by TTL; reads at a steep discount. Fireworks
-    // rates don't carry these (serverless models don't bill cache writes), so
-    // they default to 0 via the demo rate shape's ?? 0 fallbacks.
-    cacheWrite1hPerMillion: rate.cacheWrite1h ?? 0,
-    cacheWrite5mPerMillion: rate.cacheWrite5m ?? 0,
-    cacheReadPerMillion: rate.cacheRead ?? cachedInput ?? 0,
-    tier: "list",
-    source,
-    label: rate.label,
-    estimated,
-  };
 }

--- a/packages/setup-cli/lib/demo/list-pricing.mjs
+++ b/packages/setup-cli/lib/demo/list-pricing.mjs
@@ -1,0 +1,149 @@
+/**
+ * Reference list pricing for non-Fireworks providers (USD per 1M tokens).
+ *
+ * Deliberately dependency-free. These tables were part of incumbent-detect.mjs,
+ * which imports every harness's config reader (Codex TOML, Cursor SQLite, VS
+ * Code, OpenCode, Pi) — so anything wanting a rate lookup pulled that whole
+ * graph in, including optional npm packages. The Claude cost engine and the
+ * status line only need the table, so it lives here on its own; incumbent
+ * detection re-exports it for its existing callers.
+ */
+
+const ANTHROPIC_PRICING_URL = "https://www.anthropic.com/pricing";
+const OPENAI_PRICING_URL = "https://openai.com/api/pricing/";
+
+/** USD per 1M tokens, list price. Embedded reference — verify at the source URL.
+ * Verified 2026-08-30 against https://platform.claude.com/docs/en/about-claude/pricing
+ * and https://platform.claude.com/docs/en/build-with-claude/fast-mode.
+ * cacheWrite1h / cacheWrite5m are prompt-cache WRITE rates (billed at a premium
+ * over base input); cacheRead is the cache HIT/read rate (steep discount). */
+const ANTHROPIC_LIST_RATES = {
+  // Current flagship (API tab). Sonnet 5 is $2/$10; Anthropic made the launch
+  // intro rate permanent on 2026-08-10 (the planned $3/$15 increase was canceled).
+  "claude-sonnet-5": { input: 2, cacheWrite5m: 2.5, cacheWrite1h: 4, cacheRead: 0.2, output: 10, label: "Claude Sonnet 5" },
+  "claude-sonnet-4-6": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15, label: "Claude Sonnet 4.6" },
+  "claude-sonnet-4-5": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15, label: "Claude Sonnet 4.5" },
+  "claude-sonnet": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15, label: "Claude Sonnet" },
+  // Opus 4.5–4.8 and Opus 5 are all $5/$25. The old $15/$75 was Opus 4.1 / 4 only.
+  "claude-opus-5": {
+    input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 5",
+    fast: { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50 },
+  },
+  "claude-opus-4-8": {
+    input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 4.8",
+    fast: { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50 },
+  },
+  "claude-opus-4-7": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 4.7" },
+  "claude-opus-4-6": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 4.6" },
+  "claude-opus-4-5": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus 4.5" },
+  "claude-opus-4-1": { input: 15, cacheWrite5m: 18.75, cacheWrite1h: 30, cacheRead: 1.5, output: 75, label: "Claude Opus 4.1" },
+  "claude-opus-4": { input: 15, cacheWrite5m: 18.75, cacheWrite1h: 30, cacheRead: 1.5, output: 75, label: "Claude Opus 4" },
+  "claude-opus": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus" },
+  "claude-haiku-4-5": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku 4.5" },
+  "claude-haiku-3-5": { input: 0.8, cacheWrite5m: 1, cacheWrite1h: 1.6, cacheRead: 0.08, output: 4, label: "Claude Haiku 3.5" },
+  "claude-haiku": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku" },
+  // Fable 5 (next-gen long-running agents).
+  "claude-fable-5": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable 5" },
+  "claude-fable": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable" },
+  // Bare `/model` aliases (settings.json `model` may be just "opus"/"sonnet"/"haiku").
+  "opus": {
+    input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25, label: "Claude Opus",
+    fast: { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50 },
+  },
+  "sonnet": { input: 2, cacheWrite5m: 2.5, cacheWrite1h: 4, cacheRead: 0.2, output: 10, label: "Claude Sonnet" },
+  "haiku": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku" },
+  "fable": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable" },
+};
+
+/** USD per 1M tokens, list price. Embedded reference — verify at the source URL.
+ * Verified 2026-07-06 against https://openai.com/api/pricing/. */
+const OPENAI_LIST_RATES = {
+  // Current flagships.
+  "gpt-5.5": { input: 5, output: 30, label: "GPT-5.5" },
+  "gpt-5.4": { input: 2.5, output: 15, label: "GPT-5.4" },
+  "gpt-5.4-mini": { input: 0.75, output: 4.5, label: "GPT-5.4 mini" },
+  "gpt-5": { input: 1.25, output: 10, label: "GPT-5" },
+  "gpt-4o": { input: 2.5, output: 10, label: "GPT-4o" },
+  "gpt-4.1": { input: 2, output: 8, label: "GPT-4.1" },
+  "gpt-4o-mini": { input: 0.15, output: 0.6, label: "GPT-4o mini" },
+  "o3": { input: 2, output: 8, label: "o3" },
+};
+
+const DEFAULT_ANTHROPIC_RATE = { input: 2, output: 10, label: "Claude Sonnet (reference)" };
+const DEFAULT_OPENAI_RATE = { input: 2.5, output: 10, label: "GPT-4o (reference)" };
+
+/**
+ * Pick the most-specific rate-table key that the model id contains. Substring
+ * matching by insertion order would let a shorter key shadow a longer one
+ * (e.g. `gpt-4o` matching `gpt-4o-mini` before `gpt-4o-mini` is tried), so we
+ * sort candidates by descending length and take the first hit.
+ * @param {string} id lowercased model id
+ * @param {Record<string, any>} table
+ * @returns {string | undefined}
+ */
+function longestMatchKey(id, table) {
+  const keys = Object.keys(table).filter((k) => id.includes(k));
+  if (keys.length === 0) return undefined;
+  keys.sort((a, b) => b.length - a.length);
+  return keys[0];
+}
+
+/**
+ * Look up list pricing for a provider + model id. Shared by incumbent detection
+ * (harness-swap mode) and the Claude cost engine, so both derive cost the
+ * same way. `provider` is "anthropic" | "openai"; anything else returns the
+ * not-per-token subscription shape.
+ *
+ * @param {{ provider: string, modelId: string, speed?: string }} args
+ * @returns {{ inputPerMillion: number, outputPerMillion: number, cachedInputPerMillion: number, tier: string, source: string, label: string, estimated: boolean }}
+ */
+export function providerListPricing({ provider, modelId, speed = "standard" }) {
+  if (provider === "anthropic") {
+    const id = String(modelId).toLowerCase();
+    const rate = ANTHROPIC_LIST_RATES[id] ?? ANTHROPIC_LIST_RATES[longestMatchKey(id, ANTHROPIC_LIST_RATES)];
+    if (rate) {
+      const selected = speed === "fast" && rate.fast
+        ? { ...rate, ...rate.fast }
+        : rate;
+      return toRateShape(selected, ANTHROPIC_PRICING_URL, selected.cacheRead, false);
+    }
+    return toRateShape(DEFAULT_ANTHROPIC_RATE, ANTHROPIC_PRICING_URL, 0.2, true);
+  }
+  if (provider === "openai") {
+    const id = String(modelId).toLowerCase();
+    const rate = OPENAI_LIST_RATES[id] ?? OPENAI_LIST_RATES[longestMatchKey(id, OPENAI_LIST_RATES)];
+    if (rate) {
+      return toRateShape(rate, OPENAI_PRICING_URL, rate.input * 0.5, false);
+    }
+    return toRateShape(DEFAULT_OPENAI_RATE, OPENAI_PRICING_URL, 1.25, true);
+  }
+  // cursor / unknown: not per-token comparable.
+  return {
+    inputPerMillion: 0,
+    outputPerMillion: 0,
+    cachedInputPerMillion: 0,
+    tier: "subscription",
+    source: "",
+    label: "subscription (not per-token)",
+    estimated: true,
+  };
+}
+
+function toRateShape(rate, source, cachedInput, estimated) {
+  return {
+    inputPerMillion: rate.input,
+    outputPerMillion: rate.output,
+    cachedInputPerMillion: cachedInput,
+    // Anthropic prompt-cache rates (USD/Mtok). Writes are billed at a premium
+    // over base input and differ by TTL; reads at a steep discount. Fireworks
+    // rates don't carry these (serverless models don't bill cache writes), so
+    // they default to 0 via the demo rate shape's ?? 0 fallbacks.
+    cacheWrite1hPerMillion: rate.cacheWrite1h ?? 0,
+    cacheWrite5mPerMillion: rate.cacheWrite5m ?? 0,
+    cacheReadPerMillion: rate.cacheRead ?? cachedInput ?? 0,
+    tier: "list",
+    source,
+    label: rate.label,
+    estimated,
+  };
+}

--- a/packages/setup-cli/lib/demo/measurement.mjs
+++ b/packages/setup-cli/lib/demo/measurement.mjs
@@ -66,12 +66,15 @@ export function speedRatio({ incumbentSeconds, fireworksSeconds }) {
  *   1 - (fireworks_cost / incumbent_cost)
  * Returns a fraction (0.5 == 50% cheaper). >0 means Fireworks was cheaper.
  *
- * @param {{ incumbentCost: number, fireworksCost: number }} args
+ * @param {{ incumbentCost: number | null, fireworksCost: number | null }} args
  * @returns {number}
  */
 export function costSavedFraction({ incumbentCost, fireworksCost }) {
-  const inc = num(incumbentCost);
-  const fw = num(fireworksCost);
+  if (!Number.isFinite(incumbentCost) || !Number.isFinite(fireworksCost)) {
+    return Number.NaN;
+  }
+  const inc = incumbentCost;
+  const fw = fireworksCost;
   if (inc <= 0) {
     return 0;
   }
@@ -82,10 +85,13 @@ export function costSavedFraction({ incumbentCost, fireworksCost }) {
  * Linear extrapolation: cost per N generations (default 1000). Clearly linear;
  * the caller labels it as such.
  *
- * @param {{ cost: number, generations?: number }} args
- * @returns {number}
+ * @param {{ cost: number | null, generations?: number }} args
+ * @returns {number | null}
  */
 export function costPerGenerations({ cost, generations = 1000 }) {
+  if (!Number.isFinite(cost)) {
+    return null;
+  }
   return num(cost) * num(generations);
 }
 
@@ -113,7 +119,7 @@ export function costPerGenerations({ cost, generations = 1000 }) {
  * @property {number} cacheReadTokens prompt-cache read/hit tokens
  * @property {number} outputTokens
  * @property {number} seconds wall-clock request-sent -> stream-complete
- * @property {number} cost USD
+ * @property {number | null} cost USD, or null when no real rate is available
  * @property {{ inputPerMillion: number, outputPerMillion: number, cachedInputPerMillion?: number, cacheWrite1hPerMillion?: number, cacheWrite5mPerMillion?: number, cacheReadPerMillion?: number, tier?: string, source: string }} rates
  * @property {boolean} ok whether generation succeeded
  * @property {string} [error] failure message when !ok

--- a/packages/setup-cli/lib/demo/presets.mjs
+++ b/packages/setup-cli/lib/demo/presets.mjs
@@ -67,6 +67,11 @@ export const DEMO_PRESETS = Object.freeze({
 export const DEFAULT_DEMO_PRESET = "tetris";
 export const CUSTOM_DEMO_PROMPT_ID = "custom";
 
+/** Wizard game-picker options, in display order. @returns {string[]} */
+export function demoPromptOptionIds() {
+  return [...Object.keys(DEMO_PRESETS), CUSTOM_DEMO_PROMPT_ID];
+}
+
 /** Short UX hints for the demo wizard game picker. */
 export const DEMO_PRESET_HINTS = Object.freeze({
   tetris: "~2–4 min · playable Tetris",

--- a/packages/setup-cli/lib/demo/setup-form.mjs
+++ b/packages/setup-cli/lib/demo/setup-form.mjs
@@ -7,11 +7,17 @@ import {
   HIDE_CURSOR, SHOW_CURSOR, HOME_CURSOR, CLEAR_SCREEN, moveTo, CLEAR_LINE,
   padRight,
 } from "./ansi.mjs";
-import { CUSTOM_DEMO_PROMPT_ID, DEMO_PRESETS, DEMO_PRESET_HINTS } from "./presets.mjs";
+import {
+  CUSTOM_DEMO_PROMPT_ID,
+  DEMO_PRESETS,
+  DEMO_PRESET_HINTS,
+  demoPromptOptionIds,
+} from "./presets.mjs";
 import {
   demoModelCatalog,
   demoModelLabel,
   demoModelRates,
+  hasDemoTokenRates,
 } from "./demo-models.mjs";
 import {
   CUSTOM_MATCHUP_ID,
@@ -20,7 +26,7 @@ import {
 } from "./demo-matchups.mjs";
 import { DEMO_CANCELLED_MSG } from "./demo-readiness.mjs";
 
-const PROMPT_OPTION_IDS = [...Object.keys(DEMO_PRESETS), CUSTOM_DEMO_PROMPT_ID];
+const PROMPT_OPTION_IDS = demoPromptOptionIds();
 const MATCHUP_OPTION_IDS = demoMatchupOptionIds();
 const CUSTOM_PROMPT_ALLOWED = /[\x20-\x7e]/;
 const WIZARD_STEPS = 3;
@@ -265,7 +271,7 @@ export function applyKey(state, key) {
 export function estimateRaceCost(leftModel, rightModel, slotMapping = null) {
   const leftRates = demoModelRates(leftModel, "fireworks", slotMapping);
   const rightRates = demoModelRates(rightModel, "fireworks", slotMapping);
-  if (!leftRates || !rightRates) {
+  if (!hasDemoTokenRates(leftRates) || !hasDemoTokenRates(rightRates)) {
     return null;
   }
   const sideCost = (rates) => (
@@ -329,9 +335,9 @@ function renderModelValue(field, slotMapping = null) {
   const cur = demoModelLabel(field.options[field.index]);
   const head = `◂ ${REVERSE}${BOLD}${cur}${RESET} ▸ ${DIM}[${field.index + 1}/${field.options.length}]${RESET}`;
   const rates = demoModelRates(field.options[field.index], "fireworks", slotMapping);
-  return rates
+  return hasDemoTokenRates(rates)
     ? `${head}  ${DIM}$${rates.inputPerMillion} / $${rates.outputPerMillion} per Mtok${RESET}`
-    : head;
+    : `${head}  ${DIM}pricing after route${RESET}`;
 }
 
 function renderMatchupStep(state, labelWidth) {

--- a/packages/setup-cli/lib/demo/tui.mjs
+++ b/packages/setup-cli/lib/demo/tui.mjs
@@ -43,7 +43,7 @@ export function isTtyCapable() {
  * @property {string} provider
  * @property {string} model
  * @property {string} costLabel  "list price" | "serverless"
- * @property {{ inputPerMillion: number, outputPerMillion: number, cacheWrite1hPerMillion: number, cacheWrite5mPerMillion: number, cacheReadPerMillion: number }} rates
+ * @property {{ inputPerMillion: number | null, outputPerMillion: number | null, cacheWrite1hPerMillion: number | null, cacheWrite5mPerMillion: number | null, cacheReadPerMillion: number | null }} rates
  */
 
 /**
@@ -91,6 +91,10 @@ export class SplitPaneRenderer {
     this.stdout.write(HIDE_CURSOR);
     this.render();
     this.timer = setInterval(() => this.render(), RENDER_INTERVAL_MS);
+    // Redrawing is never a reason to keep the process alive — the race is. An
+    // unref'd timer means a renderer that is never stopped (a thrown error
+    // between start() and stop()) surfaces that error instead of hanging.
+    this.timer.unref?.();
   }
 
   /** @param {"incumbent" | "fireworks"} side @param {string} text */
@@ -370,13 +374,17 @@ export class SplitPaneRenderer {
     // Cache tokens are only known once the result event arrives (also when
     // costFinalized flips), so the mid-stream estimate uses 0 for them until
     // then — same as outputTokens falling back to chars/4. After finish, the
-    // authoritative cost (costUsd) is used, so the estimate never needs to
+    // canonical provider-priced cost is used, so the estimate never needs to
     // guess cache tokens before they're reported.
     const estCacheWrite1h = s.cacheWrite1hTokens ?? 0;
     const estCacheWrite5m = s.cacheWrite5mTokens ?? 0;
     const estCacheRead = s.cacheReadTokens ?? 0;
     if (s.costFinalized) {
       cost = s.cost;
+    } else if (!Number.isFinite(inRate) || !Number.isFinite(outRate)) {
+      // A delegating router has no honest pre-run rate. Wait for the result's
+      // resolved backend model rather than drawing a proxy dollar amount.
+      cost = null;
     } else {
       // Keep estimating through freeze() — done is set when the runner resolves,
       // but finish() (reconciled cost) only runs after finalizeBoth().

--- a/packages/setup-cli/lib/firerouter/core.mjs
+++ b/packages/setup-cli/lib/firerouter/core.mjs
@@ -1,5 +1,5 @@
 import {
-  isFirerouterModel,
+  isFirerouterModelPattern,
 } from "../fireworks/model-id.mjs";
 import { stdin as input } from "node:process";
 import {
@@ -15,8 +15,7 @@ import {
 
 export const FIREROUTER_FIREWORKS_HEADER = "X-Fireworks-Api-Key";
 export const FIREROUTER_TAGLINE =
-  "Picks a model for each request based on the task.";
-export const LEGACY_FIREROUTER_FIREWORKS_HEADER = "X-FireRouter-Fireworks-Key";
+  "Routes each request between Claude and open models.";
 // Outbound routing preference FireRouter reads to trade capability vs cost
 // (1 = max intelligence … 5 = max savings). Set via `--routing-preference`;
 // omitted entirely when unset so FireRouter applies its own default. Re-running
@@ -122,7 +121,7 @@ export const CLAUDE_FIREROUTER_MODEL_ENV_KEYS = [
  */
 export function firerouterStatusFromEnv(env) {
   const slotValues = CLAUDE_FIREROUTER_MODEL_ENV_KEYS.map((key) => env[key]);
-  return slotValues.some((modelId) => isFirerouterModel(modelId))
+  return slotValues.some((modelId) => isFirerouterModelPattern(modelId))
     ? "firerouter"
     : "other";
 }
@@ -134,7 +133,7 @@ function isFirerouterOwnedEnvEntry(key, value, env) {
   // FireConnect and is rebuilt together. Outside that state a user's own model
   // mapping is never stripped by this helper.
   if (CLAUDE_FIREROUTER_MODEL_ENV_KEYS.includes(key)) {
-    return isFirerouterModel(value) || firerouterStatusFromEnv(env) === "firerouter";
+    return isFirerouterModelPattern(value) || firerouterStatusFromEnv(env) === "firerouter";
   }
   if (firerouterStatusFromEnv(env) !== "firerouter") {
     return false;
@@ -209,10 +208,7 @@ export function customHeaderValue(value, headerNames) {
 }
 
 export function fireworksKeyFromCustomHeaders(value) {
-  return customHeaderValue(value, [
-    FIREROUTER_FIREWORKS_HEADER,
-    LEGACY_FIREROUTER_FIREWORKS_HEADER,
-  ]);
+  return customHeaderValue(value, [FIREROUTER_FIREWORKS_HEADER]);
 }
 
 /**
@@ -260,9 +256,9 @@ export function setFireworksKeyInCustomHeaders(value, fireworksKey) {
 }
 
 /**
- * Remove any Fireworks-key line(s) (current or legacy name) from an
- * ANTHROPIC_CUSTOM_HEADERS value, preserving all other lines. Returns "" when
- * nothing remains, so callers can drop the key entirely on teardown.
+ * Remove any Fireworks-key line(s) from an ANTHROPIC_CUSTOM_HEADERS value,
+ * preserving all other lines. Returns "" when nothing remains, so callers can
+ * drop the key entirely on teardown.
  * @param {unknown} value
  * @returns {string}
  */
@@ -270,10 +266,7 @@ export function stripFireworksKeyFromCustomHeaders(value) {
   if (typeof value !== "string") {
     return "";
   }
-  const names = [
-    FIREROUTER_FIREWORKS_HEADER.toLowerCase(),
-    LEGACY_FIREROUTER_FIREWORKS_HEADER.toLowerCase(),
-  ];
+  const names = [FIREROUTER_FIREWORKS_HEADER.toLowerCase()];
   return value
     .split("\n")
     .filter((line) => {
@@ -296,7 +289,6 @@ export const ANTHROPIC_BYOK_BODY_FIELD = "anthropic_api_key";
 /** Every ANTHROPIC_CUSTOM_HEADERS line FireConnect writes (auth + routing). */
 const MANAGED_CUSTOM_HEADER_NAMES = [
   FIREROUTER_FIREWORKS_HEADER,
-  LEGACY_FIREROUTER_FIREWORKS_HEADER,
   ANTHROPIC_BYOK_HEADER,
   ROUTING_PREFERENCE_HEADER,
   ...FIRECONNECT_TELEMETRY_HEADER_NAMES,
@@ -386,11 +378,10 @@ export function firerouterByokHeaders({ anthropicKey = "" } = {}) {
 
 /**
  * Swap the Fireworks key inside an ANTHROPIC_CUSTOM_HEADERS value while
- * preserving every other line (routing preference, user-added headers). A
- * legacy-named Fireworks header is rewritten under the current name, so the
- * swap also heals settings written before the header rename. Returns the
- * input unchanged (same reference) when it isn't FireRouter-shaped or there
- * is no key to swap in — callers use identity to mean "nothing to write".
+ * preserving every other line (routing preference, user-added headers).
+ * Returns the input unchanged (same reference) when it isn't FireRouter-shaped
+ * or there is no key to swap in; callers use identity to mean "nothing to
+ * write".
  * @param {unknown} value  current ANTHROPIC_CUSTOM_HEADERS
  * @param {string} fireworksKey
  */
@@ -398,10 +389,7 @@ export function replaceFireworksKeyInCustomHeaders(value, fireworksKey) {
   if (typeof value !== "string" || !fireworksKey?.trim()) {
     return value;
   }
-  const fireworksHeaderNames = [
-    FIREROUTER_FIREWORKS_HEADER.toLowerCase(),
-    LEGACY_FIREROUTER_FIREWORKS_HEADER.toLowerCase(),
-  ];
+  const fireworksHeaderNames = [FIREROUTER_FIREWORKS_HEADER.toLowerCase()];
   let found = false;
   const lines = value.split("\n").map((line) => {
     const colon = line.indexOf(":");

--- a/packages/setup-cli/lib/firerouter/flag.mjs
+++ b/packages/setup-cli/lib/firerouter/flag.mjs
@@ -1,6 +1,9 @@
 import process from "node:process";
 
-import { isFirerouterModel } from "../fireworks/model-id.mjs";
+import {
+  isFirerouterModelPattern,
+  firerouterRequiresAnthropicKey,
+} from "../fireworks/model-id.mjs";
 import {
   isAccountFeatureFlagEnabled,
 } from "../config/feature-flags.mjs";
@@ -306,6 +309,9 @@ export async function resolveWorkspaceByok(apiKey, seams) {
  * @property {string}  mainModel     Model id to write to the harness's main slot
  *                                   ("" = keep the harness's normal Fireworks default).
  * @property {boolean} isFirerouter  Whether `mainModel` routes through FireRouter.
+ * @property {boolean} requiresAnthropicKey
+ *   Whether the selection needs an Anthropic credential (bare firerouter or a
+ *   Claude/Opus model in the path). Pure-Fireworks selections need none.
  */
 
 /**
@@ -322,10 +328,14 @@ export async function resolveWorkspaceByok(apiKey, seams) {
 export function resolveFirerouterPlan(ctx, { keyType = "" } = {}) {
   const requested = ctx.main?.trim() ?? "";
   if (!requested) {
-    return { mainModel: "", isFirerouter: false };
+    return { mainModel: "", isFirerouter: false, requiresAnthropicKey: false };
   }
   assertFirerouterKeyType(requested, keyType);
-  return { mainModel: requested, isFirerouter: isFirerouterModel(requested) };
+  return {
+    mainModel: requested,
+    isFirerouter: isFirerouterModelPattern(requested),
+    requiresAnthropicKey: firerouterRequiresAnthropicKey(requested),
+  };
 }
 
 /** FireRouter is only offered for standard Fireworks keys, not Fire Pass. */
@@ -333,13 +343,13 @@ export const FIREROUTER_FIREPASS_UNSUPPORTED_MESSAGE =
   "FireRouter is not available for Fire Pass keys (fpk_...). Use a standard Fireworks API key (fw_...).";
 
 /**
- * Throw when the `firerouter` model is requested with a Fire Pass key. Call after
+ * Throw when a FireRouter selection is requested with a Fire Pass key. Call after
  * the effective model + key type are known, before enabling.
  * @param {string} model
  * @param {string} keyType
  */
 export function assertFirerouterKeyType(model, keyType) {
-  if (isFirerouterModel(model) && keyType === "firepass") {
+  if (isFirerouterModelPattern(model) && keyType === "firepass") {
     throw new Error(FIREROUTER_FIREPASS_UNSUPPORTED_MESSAGE);
   }
 }
@@ -392,20 +402,25 @@ export async function resolveFirerouterByokHeaders({
   if (!plan.isFirerouter && !catalogFirerouter) {
     return {};
   }
-  const anthropicKey = preResolvedAnthropicKey !== undefined
-    ? preResolvedAnthropicKey
-    : (await resolveFirerouterByokKeys({
-      anthropicFlag: ctx.anthropicKeyFromFlag ? ctx.anthropicKey : "",
-      settingsEnv,
-      home: ctx.home,
-      explicit: true,
-      resolveWorkspaceByok: () => (
-        workspaceByokLookup === null
-          ? resolveWorkspaceByokStatus(apiKey)
-          : Promise.resolve(workspaceByokLookup)
-      ),
-    })).anthropicKey;
-  const headers = firerouterByokHeaders({ anthropicKey });
+  /** @type {Record<string, string>} */
+  const headers = {};
+  // Attach the Anthropic BYOK key only for Anthropic-requiring selections.
+  if (plan.requiresAnthropicKey || catalogFirerouter) {
+    const anthropicKey = preResolvedAnthropicKey !== undefined
+      ? preResolvedAnthropicKey
+      : (await resolveFirerouterByokKeys({
+        anthropicFlag: ctx.anthropicKeyFromFlag ? ctx.anthropicKey : "",
+        settingsEnv,
+        home: ctx.home,
+        explicit: true,
+        resolveWorkspaceByok: () => (
+          workspaceByokLookup === null
+            ? resolveWorkspaceByokStatus(apiKey)
+            : Promise.resolve(workspaceByokLookup)
+        ),
+      })).anthropicKey;
+    Object.assign(headers, firerouterByokHeaders({ anthropicKey }));
+  }
   const preference = normalizeRoutingPreference(ctx.routingPreference);
   if (preference !== null) {
     headers[ROUTING_PREFERENCE_HEADER] = String(preference);
@@ -416,13 +431,17 @@ export async function resolveFirerouterByokHeaders({
 /**
  * Env-reference BYOK header for Codex, which forwards the provider key by
  * env-var NAME (`env_http_headers`) rather than value. Returns the Anthropic env
- * ref when the plan routes through FireRouter; otherwise `{}`. Pure — reads only
- * the plan.
+ * ref when the selection needs an Anthropic credential (bare firerouter, or a
+ * Claude/Opus member in the slash path); otherwise `{}`. The routing-preference
+ * header is handled separately by the value-mode builder. Pure — reads only the plan.
  * @param {FirerouterPlan} plan
  * @returns {Record<string, string>}
  */
 export function firerouterByokEnvRefHeaders(plan, { catalogFirerouter = false } = {}) {
   if (!plan.isFirerouter && !catalogFirerouter) {
+    return {};
+  }
+  if (!plan.requiresAnthropicKey && !catalogFirerouter) {
     return {};
   }
   return {

--- a/packages/setup-cli/lib/fireworks/gateway-fetch.mjs
+++ b/packages/setup-cli/lib/fireworks/gateway-fetch.mjs
@@ -1,0 +1,9 @@
+/** Upper bound for gateway verify/catalog HTTP requests (no response → fail fast). */
+export const FIREWORKS_GATEWAY_FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * @returns {AbortSignal}
+ */
+export function fireworksGatewayFetchSignal() {
+  return AbortSignal.timeout(FIREWORKS_GATEWAY_FETCH_TIMEOUT_MS);
+}

--- a/packages/setup-cli/lib/fireworks/model-id.mjs
+++ b/packages/setup-cli/lib/fireworks/model-id.mjs
@@ -1,11 +1,23 @@
 import {
+  AUTO_INSTANT_MODEL_ID,
+  AUTO_MODEL_ID,
   FIREWORKS_MODEL_SPECS,
+  KNOWN_AUTO_MODEL_IDS,
   ROUTER_SPEC_ALIASES,
-  isFirerouterGatewayPattern,
+  canonicalAutoModelId,
+  isAutoModelId,
+  isFirerouterModelPattern,
   isRouterShortId,
 } from "./model-specs.mjs";
 
-export { isFirerouterGatewayPattern };
+export {
+  AUTO_INSTANT_MODEL_ID,
+  AUTO_MODEL_ID,
+  KNOWN_AUTO_MODEL_IDS,
+  canonicalAutoModelId,
+  isAutoModelId,
+  isFirerouterModelPattern,
+};
 
 export const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference";
 export const FIREROUTER_MODEL_ID = "firerouter";
@@ -48,6 +60,7 @@ const FIREWORKS_ROUTER_SHORT_IDS = new Set([
   "kimi-k2p6-turbo",
   "kimi-latest",
   "firerouter",
+  AUTO_MODEL_ID,
 ]);
 
 const KNOWN_FIREWORKS_SHORT_IDS = new Set([
@@ -96,6 +109,29 @@ export function isFirerouterModel(model) {
 }
 
 /**
+ * Whether a FireRouter selection requires an Anthropic credential: bare
+ * `firerouter` (primary is Claude Opus 5) or any Claude/Opus model in the slash
+ * path. Pure-Fireworks selections (firerouter/kimi-k3) need no Anthropic key.
+ * @param {string} model
+ * @returns {boolean}
+ */
+export function firerouterRequiresAnthropicKey(model) {
+  if (!isFirerouterModelPattern(model)) {
+    return false;
+  }
+  if (isFirerouterModel(model)) {
+    return true;
+  }
+  const stripped = stripContextSuffix(String(model ?? "").trim());
+  return stripped.split("/").some((part) => {
+    const seg = part.trim().toLowerCase();
+    return seg === "claude"
+      || seg.startsWith("claude-")
+      || CLAUDE_MODEL_ALIASES.has(seg);
+  });
+}
+
+/**
  * Whether a model reference is a real Anthropic model id (e.g. claude-sonnet-4-5).
  * Anthropic models are served on the Fireworks gateway even though they don't
  * appear in the public serverless catalog, so they're exempt from catalog
@@ -122,6 +158,22 @@ export function isClaudeNativeSlotAlias(model) {
     return false;
   }
   return model.trim().toLowerCase() === CLAUDE_NATIVE_SLOT_ALIAS;
+}
+
+/**
+ * Claude Code `/model` picker aliases that resolve at request time through the
+ * matching `ANTHROPIC_DEFAULT_*_MODEL` env slot (opus/sonnet/haiku/fable). They
+ * name no concrete model themselves, so FireConnect never writes one — a bare
+ * alias in `settings.model` is the user's picker choice, not a FireConnect pin.
+ */
+const CLAUDE_MODEL_ALIASES = new Set(["opus", "sonnet", "haiku", "fable"]);
+
+/** Whether a model reference is a bare Claude Code `/model` picker alias. */
+export function isClaudeModelAlias(model) {
+  if (typeof model !== "string") {
+    return false;
+  }
+  return CLAUDE_MODEL_ALIASES.has(stripContextSuffix(model.trim()).toLowerCase());
 }
 
 /**
@@ -168,6 +220,11 @@ export function fullFireworksResourceId(model) {
   if (isFirerouterModel(bare)) {
     return FIREROUTER_ROUTER_ID;
   }
+  // `auto` / `auto-*` have no accounts/fireworks resource path — the gateway
+  // serves them under the bare slug only, so they pass through unexpanded.
+  if (isAutoModelId(bare)) {
+    return canonicalAutoModelId(bare);
+  }
   // Classify routers by the same suffix/alias heuristic spec lookups use
   // (`isRouterShortId`), not a hand-maintained list. A stale list would expand a
   // real router slug (e.g. kimi-k3-fast) to a non-existent models/ path, which
@@ -193,6 +250,9 @@ export function normalizeModelId(model) {
   if (isFirerouterModel(bare)) {
     return FIREROUTER_MODEL_ID;
   }
+  if (isAutoModelId(bare)) {
+    return canonicalAutoModelId(bare);
+  }
   if (isClaudeNativeSlotAlias(bare) || isClaudeNativeModel(bare)) {
     return CLAUDE_NATIVE_MODEL_ID;
   }
@@ -206,7 +266,7 @@ export function normalizeModelId(model) {
 }
 
 export function validateModelId(model, flag) {
-  if (!model.startsWith("accounts/") && model.includes("/") && !isFirerouterGatewayPattern(model)) {
+  if (!model.startsWith("accounts/") && model.includes("/") && !isFirerouterModelPattern(model)) {
     throw new Error(
       `${flag} must be a Fireworks model ID like deepseek-v4-flash or a router ID like glm-latest`,
     );
@@ -219,7 +279,8 @@ export function isFireworksModelId(model) {
   }
   const ref = model.trim();
   return ref.startsWith("accounts/fireworks/")
-    || KNOWN_FIREWORKS_SHORT_IDS.has(fireworksModelSlug(ref));
+    || KNOWN_FIREWORKS_SHORT_IDS.has(fireworksModelSlug(ref))
+    || isAutoModelId(ref);
 }
 
 export function defaultMainModel(keyType = "fireworks") {

--- a/packages/setup-cli/lib/fireworks/model-list.mjs
+++ b/packages/setup-cli/lib/fireworks/model-list.mjs
@@ -1,13 +1,16 @@
 import { resolveModelDisplayMetadata } from "./model-display.mjs";
-import { resolveRouterSpecAliasTarget } from "./model-specs.mjs";
 import { visionCapabilityLabel } from "./vision.mjs";
 import { attachPricing } from "./pricing.mjs";
 import {
+  autoCatalogEntry,
   filterCatalogBySearch,
   catalogWithAutomaticFirerouter,
+  isAutoCatalogEntry,
   loadServerlessCatalog,
+  newestModelsByFamily,
   preferLatestAliases,
 } from "./models.mjs";
+import { KNOWN_AUTO_MODEL_IDS, canonicalAutoModelId } from "./model-id.mjs";
 import { bold, dim, warn, withSpinner } from "../ui.mjs";
 import { stripViaFireworksSuffix } from "./models.mjs";
 
@@ -17,6 +20,35 @@ function formatUsd(value) {
   }
   const text = value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
   return `$${text}`;
+}
+
+export function formatCatalogUpdatedAt(updatedAt, timeZone = undefined) {
+  if (!Number.isFinite(updatedAt) || updatedAt <= 0) {
+    return "bundled with FireConnect";
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+    ...(timeZone ? { timeZone } : {}),
+  }).format(new Date(updatedAt));
+}
+
+function catalogUpdatedAtIso(updatedAt) {
+  return Number.isFinite(updatedAt) && updatedAt > 0
+    ? new Date(updatedAt).toISOString()
+    : null;
+}
+
+function printCatalogFooter(displayCount, updatedAt) {
+  const count = displayCount == null
+    ? ""
+    : `${displayCount} model${displayCount === 1 ? "" : "s"} · `;
+  console.log(dim(`${count}Last updated: ${formatCatalogUpdatedAt(updatedAt)}`));
+  console.log(dim("Refresh catalog: fireconnect model list --refresh"));
 }
 
 function displayName(entry) {
@@ -33,58 +65,44 @@ function isFastLatestRouter(entry) {
   return entry.shortId?.endsWith("-fast-latest");
 }
 
+function isUsRouter(entry) {
+  return entry.shortId?.endsWith("-us");
+}
+
 function sortEntries(entries) {
   return [...entries].sort((left, right) => left.shortId.localeCompare(right.shortId));
 }
 
-function resolveLatestRouterBaseModelId(entry, catalog) {
-  if (entry.baseModelId) {
-    return entry.baseModelId;
-  }
-  const entryIds = new Set(catalog.map(({ id }) => id));
-  const targetSlug = resolveRouterSpecAliasTarget(entry.shortId, entryIds);
-  return targetSlug ? `accounts/fireworks/models/${targetSlug}` : null;
-}
-
-function individualModelsFromLatestRouters(catalog, latestRouters) {
-  const catalogById = new Map(catalog.map((entry) => [entry.id, entry]));
-  const modelIds = new Set();
-
-  for (const router of latestRouters) {
-    const baseModelId = resolveLatestRouterBaseModelId(router, catalog);
-    if (baseModelId && catalogById.has(baseModelId)) {
-      modelIds.add(baseModelId);
-    }
-  }
-
-  return sortEntries([...modelIds].map((id) => catalogById.get(id)));
-}
-
 export function organizeCatalogForDisplay(catalog) {
-  const smartRouters = catalog.filter((entry) => entry.shortId === "firerouter");
+  // `auto` sorts ahead of `firerouter`, so the smart-routing section leads with
+  // the default recommendation.
+  const smartRouters = catalog.filter((entry) => (
+    entry.shortId === "firerouter" || isAutoCatalogEntry(entry)
+  ));
   // Collapse versioned families via their -latest router aliases across the
   // whole catalog, then split. Running preferLatestAliases over the full set is
   // what keeps standalone models that have no -latest alias (gpt-oss-120b,
   // inkling, nemotron-3-ultra-nvfp4) visible instead of dropping them.
   const preferred = preferLatestAliases(catalog.filter((entry) => (
     entry.shortId !== "firerouter"
+    && !isAutoCatalogEntry(entry)
   )));
   const routers = preferred.filter((entry) => entry.id.includes("/routers/"));
+  const usRouters = routers.filter(isUsRouter);
   const fastRouters = routers.filter(isFastLatestRouter);
   const latestRouters = routers.filter((entry) => (
     !isFastLatestRouter(entry)
     && entry.shortId.endsWith("-latest")
   ));
-  const models = individualModelsFromLatestRouters(catalog, latestRouters);
-  const otherRouters = routers.filter((entry) => (
-    !fastRouters.includes(entry)
-    && !latestRouters.includes(entry)
-  ));
+  // Read straight off the catalog rather than following each -latest router to
+  // its pinned base model: a stale ROUTER_SPEC_ALIASES target must not be able
+  // to hide the newest version the API is serving.
+  const models = newestModelsByFamily(catalog);
 
   return [
     {
-      title: "SMART ROUTER",
-      description: "",
+      title: "SMART ROUTERS",
+      description: "pick a model per request",
       entries: sortEntries(smartRouters),
     },
     {
@@ -98,14 +116,14 @@ export function organizeCatalogForDisplay(catalog) {
       entries: sortEntries(fastRouters),
     },
     {
+      title: "US-ONLY ROUTERS",
+      description: "inference stays in the US",
+      entries: sortEntries(usRouters),
+    },
+    {
       title: "INDIVIDUAL MODELS",
       description: "pinned versions",
       entries: sortEntries(models),
-    },
-    {
-      title: "OTHER ROUTERS",
-      description: "",
-      entries: sortEntries(otherRouters),
     },
   ].filter((section) => section.entries.length > 0);
 }
@@ -180,15 +198,48 @@ export function globalListIncludesFirerouter(keyType) {
   return keyType !== "firepass";
 }
 
+/** Fire Pass advertises only its own curated routers, so `auto` is standard-key only. */
+export function globalListIncludesAuto(keyType) {
+  return keyType !== "firepass";
+}
+
+/**
+ * Add the synthesized auto-mix rows for display. The gateway serves them
+ * without listing them, so `model list` is the only place they can come from.
+ *
+ * Rows come from KNOWN_AUTO_MODEL_IDS, not from the `auto-*` matcher that
+ * governs acceptance: a name can only be advertised once FireConnect knows it
+ * exists, while `--model` stays free to pass a newer mix straight through.
+ * @param {import("./models.mjs").CatalogEntry[]} catalog
+ */
+export function catalogWithAutoEntry(catalog, keyType) {
+  if (!globalListIncludesAuto(keyType)) {
+    return catalog;
+  }
+  const present = new Set(
+    catalog
+      .filter(isAutoCatalogEntry)
+      .map((entry) => canonicalAutoModelId(entry.shortId) || canonicalAutoModelId(entry.id)),
+  );
+  const missing = KNOWN_AUTO_MODEL_IDS
+    .filter((id) => !present.has(id))
+    .map((id) => autoCatalogEntry(id));
+  return missing.length ? [...missing, ...catalog] : catalog;
+}
+
 export async function runModelListCommand({ options, apiKey }) {
-  const { catalog, keyType } = await withSpinner(
-    "Fetching Fireworks model catalog…",
-    () => loadServerlessCatalog({ apiKey }),
+  const refresh = Boolean(options.refresh);
+  const { catalog, keyType, source, updatedAt } = await withSpinner(
+    refresh ? "Refreshing Fireworks model catalog…" : "Fetching Fireworks model catalog…",
+    () => loadServerlessCatalog({ apiKey, refresh }),
   );
 
-  const fullCatalog = catalogWithAutomaticFirerouter(catalog, keyType, {
-    includeFirerouter: globalListIncludesFirerouter(keyType),
-  });
+  const fullCatalog = catalogWithAutoEntry(
+    catalogWithAutomaticFirerouter(catalog, keyType, {
+      includeFirerouter: globalListIncludesFirerouter(keyType),
+    }),
+    keyType,
+  );
 
   const enriched = enrichCatalogWithPricing(fullCatalog, {
     firepass: keyType === "firepass",
@@ -198,6 +249,8 @@ export async function runModelListCommand({ options, apiKey }) {
     const filtered = filterCatalogBySearch(enriched, options.search);
     console.log(JSON.stringify({
       keyType,
+      source,
+      updatedAt: catalogUpdatedAtIso(updatedAt),
       count: filtered.length,
       models: filtered,
     }, null, 2));
@@ -206,6 +259,13 @@ export async function runModelListCommand({ options, apiKey }) {
 
   if (keyType === "firepass") {
     console.log(warn("Fire Pass key: showing Fire Pass-supported serverless routers."));
+    console.log("");
+  }
+
+  // A refresh that couldn't reach the gateway falls back to the last snapshot,
+  // so say so rather than presenting cached rows as freshly fetched.
+  if (refresh && source === "stale") {
+    console.log(warn("Couldn't reach Fireworks — showing the last cached catalog."));
     console.log("");
   }
 
@@ -219,10 +279,12 @@ export async function runModelListCommand({ options, apiKey }) {
 
   if (displayCount === 0) {
     console.log("No serverless models matched your query.");
+    console.log("");
+    printCatalogFooter(null, updatedAt);
     return;
   }
 
   console.log(formatCatalogSections(sections));
   console.log("");
-  console.log(dim(`${displayCount} model${displayCount === 1 ? "" : "s"}.`));
+  printCatalogFooter(displayCount, updatedAt);
 }

--- a/packages/setup-cli/lib/fireworks/model-servability.mjs
+++ b/packages/setup-cli/lib/fireworks/model-servability.mjs
@@ -1,4 +1,4 @@
-import { isFirerouterGatewayPattern } from "./model-specs.mjs";
+import { isAutoModelId, isFirerouterModelPattern } from "./model-specs.mjs";
 import {
   isGatewayAnthropicSlot,
   shortFireworksModelRef,
@@ -13,17 +13,18 @@ const CUSTOM_DEPLOYMENT_REF_RE = /^accounts\/[^/]+\/deployments\/[^/]+/i;
 
 /**
  * Whether a `--model` id is one we validate against the serverless catalog.
- * Firerouter gateway ids, custom deployment ids, and real Anthropic model ids
- * are served on the gateway but aren't (or aren't always) listed in the public
- * catalog, so they're allowed unconditionally; an empty model means the harness
- * default is used.
+ * Firerouter gateway ids, the `auto` / `auto-*` open-mix routers, custom
+ * deployment ids, and real Anthropic model ids are served on the gateway but
+ * aren't (or aren't always) listed in the public catalog, so they're allowed
+ * unconditionally; an empty model means the harness default is used.
  * @param {string} modelId
  * @returns {boolean}
  */
 export function isModelIdValidationApplicable(modelId) {
   if (!modelId) return false;
   const ref = shortFireworksModelRef(modelId);
-  if (isFirerouterGatewayPattern(ref)) return false;
+  if (isFirerouterModelPattern(ref)) return false;
+  if (isAutoModelId(ref)) return false;
   if (isGatewayAnthropicSlot(ref)) return false;
   return !CUSTOM_DEPLOYMENT_REF_RE.test(ref);
 }

--- a/packages/setup-cli/lib/fireworks/model-specs.mjs
+++ b/packages/setup-cli/lib/fireworks/model-specs.mjs
@@ -14,23 +14,46 @@ export const FIREWORKS_PRICING_DOCS_URL = "https://docs.fireworks.ai/serverless/
 export const FIREWORKS_MODEL_SPECS = {
   "deepseek-v4-pro": {
     label: "DeepSeek V4 Pro",
-    pricing: { input: 1.74, cachedInput: 0.145, output: 3.48 },
+    pricing: { input: 1.32, cachedInput: 0.044, output: 3.96 },
     capabilities: { contextWindow: 1_000_000, maxOutputTokens: 384_000, vision: false, toolCalling: true },
   },
   "deepseek-v4-pro-0813": {
     label: "DeepSeek V4 Pro (0813)",
-    pricing: { input: 1.74, cachedInput: 0.145, output: 3.48 },
+    pricing: { input: 1.32, cachedInput: 0.044, output: 3.96 },
     capabilities: { contextWindow: 1_000_000, maxOutputTokens: 384_000, vision: false, toolCalling: true },
   },
   "deepseek-v4-flash": {
     label: "DeepSeek V4 Flash",
-    pricing: { input: 0.14, cachedInput: 0.028, output: 0.28 },
+    pricing: { input: 0.22, cachedInput: 0.007, output: 0.66 },
     capabilities: { contextWindow: 1_000_000, maxOutputTokens: 384_000, vision: false, toolCalling: true },
   },
   "deepseek-v4-flash-0731": {
     label: "DeepSeek V4 Flash (0731)",
-    pricing: { input: 0.14, cachedInput: 0.028, output: 0.28 },
+    pricing: { input: 0.22, cachedInput: 0.007, output: 0.66 },
     capabilities: { contextWindow: 1_000_000, maxOutputTokens: 384_000, vision: false, toolCalling: true },
+  },
+  "glm-5p3": {
+    label: "GLM 5.3",
+    pricing: { input: 1.40, cachedInput: 0.26, output: 4.40 },
+    capabilities: { contextWindow: 1_048_576, maxOutputTokens: 131_072, vision: false, toolCalling: true },
+  },
+  // GLM 5.3 Flash is a distinct cheaper model, not the fast tier of GLM 5.3 —
+  // `glm-flash-latest` names it, while `glm-fast-latest` is the GLM fast tier.
+  // It is also the first vision-capable GLM.
+  "glm-5p3-flash": {
+    label: "GLM 5.3 Flash",
+    pricing: { input: 0.15, cachedInput: 0.03, output: 0.50 },
+    capabilities: { contextWindow: 1_048_576, maxOutputTokens: 131_072, vision: true, toolCalling: true },
+    api: { contextLength: 1_048_576, supportsImageInput: true },
+  },
+  // US-only Serverless rates are per-model, not a uniform uplift: models
+  // launched from 2026-09-01 carry a 50% premium over the matching global row,
+  // while earlier US routers keep the rates they launched with.
+  "glm-5p3-flash-us": {
+    label: "GLM 5.3 Flash (US)",
+    pricing: { input: 0.225, cachedInput: 0.045, output: 0.75 },
+    capabilities: { contextWindow: 1_048_576, maxOutputTokens: 131_072, vision: true, toolCalling: true },
+    api: { contextLength: 1_048_576, supportsImageInput: true },
   },
   "glm-5p2": {
     label: "GLM 5.2",
@@ -52,14 +75,26 @@ export const FIREWORKS_MODEL_SPECS = {
     pricing: { input: 2.10, cachedInput: 0.21, output: 6.60, tier: "fast" },
     capabilities: { contextWindow: 1_048_575, maxOutputTokens: 131_072, vision: false, toolCalling: true },
   },
+  // Priced at parity with the global GLM 5.2 Fast row, with no US premium.
+  "glm-5p2-fast-us": {
+    label: "GLM 5.2 Fast (US)",
+    pricing: { input: 2.10, cachedInput: 0.21, output: 6.60, tier: "fast" },
+    capabilities: { contextWindow: 1_048_575, maxOutputTokens: 131_072, vision: false, toolCalling: true },
+  },
   "kimi-k3": {
     label: "Kimi K3",
     pricing: { input: 3.00, cachedInput: 0.30, output: 15.00 },
     capabilities: { contextWindow: 1_040_000, maxOutputTokens: 131_072, vision: true, toolCalling: true },
   },
+  // Launched before the 50% premium, at a 10% premium over the global row.
+  "kimi-k3-us": {
+    label: "Kimi K3 (US)",
+    pricing: { input: 3.30, cachedInput: 0.33, output: 16.50 },
+    capabilities: { contextWindow: 1_040_000, maxOutputTokens: 131_072, vision: true, toolCalling: true },
+  },
   "kimi-k3-fast": {
     label: "Kimi K3 Fast",
-    pricing: { input: 6.00, cachedInput: 0.60, output: 30.00, tier: "fast" },
+    pricing: { input: 4.50, cachedInput: 0.45, output: 22.50, tier: "fast" },
     capabilities: { contextWindow: 1_040_000, maxOutputTokens: 131_072, vision: true, toolCalling: true },
   },
   "kimi-k2p7-code": {
@@ -143,10 +178,75 @@ export const FIREWORKS_MODEL_SPECS = {
       toolCalling: true,
     },
   },
+  // Fireworks-managed mix of open models, served on the gateway but absent from
+  // the public serverless catalog.
+  auto: {
+    label: "Auto",
+    capabilities: {
+      contextWindow: 1_048_575,
+      maxOutputTokens: 131_072,
+      vision: true,
+      toolCalling: true,
+    },
+  },
 };
 
+/**
+ * Bare gateway slug for the default auto mix. Variants (`auto-instant`) share
+ * the same no-resource-path rule: the gateway serves them under the slug, not
+ * `accounts/fireworks/...`.
+ */
+export const AUTO_MODEL_ID = "auto";
+
+/** Latency-first auto mix (`--model auto-instant`). */
+export const AUTO_INSTANT_MODEL_ID = "auto-instant";
+
+/**
+ * Auto mixes to synthesize in `model list`. Acceptance is wider ({@link
+ * canonicalAutoModelId} matches any `auto-*`); this list only controls which
+ * names get a discoverable row when the serverless API omits them.
+ */
+export const KNOWN_AUTO_MODEL_IDS = [AUTO_MODEL_ID, AUTO_INSTANT_MODEL_ID];
+
+/** Cursor's built-in picker — not a Fireworks auto mix. */
+const NON_GATEWAY_AUTO_IDS = new Set(["auto-smart"]);
+
+/**
+ * Canonical short slug for an auto mix (`auto`, `auto-instant`). Empty when
+ * the ref is not an auto mix.
+ *
+ * Matched on the whole ref, never per path segment: a slash means the ref names
+ * something else that merely contains an auto-shaped part (a custom
+ * `accounts/auto-corp/...` resource, a `firerouter/auto-instant` selection), and
+ * collapsing it to a bare mix slug would send the gateway the wrong model.
+ * @param {string} model
+ * @returns {string}
+ */
+export function canonicalAutoModelId(model) {
+  if (typeof model !== "string") {
+    return "";
+  }
+  const slug = model.replace(/\[1m\]$/i, "").trim().toLowerCase();
+  if (!slug || slug.includes("/") || NON_GATEWAY_AUTO_IDS.has(slug)) {
+    return "";
+  }
+  return slug === AUTO_MODEL_ID || slug.startsWith(`${AUTO_MODEL_ID}-`) ? slug : "";
+}
+
+/**
+ * Whether a model reference is the `auto` mix or an `auto-*` variant
+ * (`auto-instant`). Unrelated to `firerouter*`: these route open models only
+ * and never need an Anthropic credential. Cursor-native `auto-smart` is not
+ * matched.
+ * @param {string} model
+ * @returns {boolean}
+ */
+export function isAutoModelId(model) {
+  return canonicalAutoModelId(model) !== "";
+}
+
 /** True when any path segment matches the `firerouter*` prefix. */
-export function isFirerouterGatewayPattern(model) {
+export function isFirerouterModelPattern(model) {
   if (typeof model !== "string") {
     return false;
   }
@@ -160,14 +260,20 @@ export function isFirerouterGatewayPattern(model) {
 export const ROUTER_SPEC_ALIASES = {
   "deepseek-flash-latest": "deepseek-v4-flash-0731",
   "deepseek-pro-latest": "deepseek-v4-pro-0813",
-  "glm-latest": "glm-5p2",
+  "glm-latest": "glm-5p3",
   "glm-fast-latest": "glm-5p2-fast",
+  "glm-flash-latest": "glm-5p3-flash",
+  "glm-5p2-fast-us": "glm-5p2",
+  "glm-5p3-flash-us": "glm-5p3-flash",
   "kimi-latest": "kimi-k3",
   "kimi-fast-latest": "kimi-k3-fast",
+  "kimi-k3-us": "kimi-k3",
   "minimax-latest": "minimax-m3",
   "qwen-plus-latest": "qwen3p7-plus",
 };
 
+const GLM_LATEST_BASE_CANDIDATES = ["glm-5p3", "glm-5p2"];
+const GLM_FLASH_LATEST_BASE_CANDIDATES = ["glm-5p3-flash"];
 const DEEPSEEK_FLASH_LATEST_BASE_CANDIDATES = ["deepseek-v4-flash-0731", "deepseek-v4-flash"];
 const DEEPSEEK_PRO_LATEST_BASE_CANDIDATES = ["deepseek-v4-pro-0813", "deepseek-v4-pro"];
 const KIMI_LATEST_BASE_CANDIDATES = ["kimi-k3", "kimi-k2p8-code", "kimi-k2p7-code"];
@@ -215,6 +321,16 @@ export function resolveRouterSpecAliasTarget(alias, entryIds = null) {
       return fastSpecSlugForBase(base, alias);
     }
     return ROUTER_SPEC_ALIASES[alias] ?? null;
+  }
+  if (alias === "glm-latest") {
+    return resolveFirstCatalogCandidate(catalogCheck, GLM_LATEST_BASE_CANDIDATES)
+      ?? ROUTER_SPEC_ALIASES[alias]
+      ?? null;
+  }
+  if (alias === "glm-flash-latest") {
+    return resolveFirstCatalogCandidate(catalogCheck, GLM_FLASH_LATEST_BASE_CANDIDATES)
+      ?? ROUTER_SPEC_ALIASES[alias]
+      ?? null;
   }
   if (alias === "minimax-latest") {
     return resolveFirstCatalogCandidate(catalogCheck, MINIMAX_LATEST_BASE_CANDIDATES)
@@ -344,6 +460,9 @@ function fastSpecSlugForBase(baseSlug, routerShortId) {
 
 export function resolveSpecSlug(modelRef) {
   const shortId = specShortIdFromModelRef(modelRef);
+  if (FIREWORKS_MODEL_SPECS[shortId]) {
+    return shortId;
+  }
   const baseModelId = resolveLiveRouterBaseModelId(modelRef);
   if (baseModelId) {
     const baseSlug = specShortIdFromModelRef(baseModelId);
@@ -366,7 +485,7 @@ export function isFireworksRoutedModelRef(modelRef) {
     return true;
   }
   const shortId = specShortIdFromModelRef(ref);
-  if (isFirerouterGatewayPattern(ref)) {
+  if (isFirerouterModelPattern(ref) || isAutoModelId(ref)) {
     return true;
   }
   if (ROUTER_SPEC_ALIASES[shortId]) {
@@ -383,7 +502,7 @@ export function isFireworksRoutedModelRef(modelRef) {
 export function resolveFireworksModelLabel(modelRef) {
   const shortId = specShortIdFromModelRef(modelRef);
   const routerSpec = FIREWORKS_MODEL_SPECS[shortId];
-  if (shortId.endsWith("-turbo") && routerSpec?.label) {
+  if ((shortId.endsWith("-turbo") || shortId.endsWith("-us")) && routerSpec?.label) {
     return routerSpec.label;
   }
   const baseModelId = resolveLiveRouterBaseModelId(modelRef);
@@ -422,8 +541,12 @@ export function resolveFireworksModelLabel(modelRef) {
 
 export function lookupModelSpec(modelRef) {
   // firerouter* IDs share the static firerouter catalog metadata (1M context, vision).
-  if (isFirerouterGatewayPattern(modelRef)) {
+  if (isFirerouterModelPattern(modelRef)) {
     return FIREWORKS_MODEL_SPECS.firerouter;
+  }
+  // auto / auto-* share the static auto mix metadata (1M context, vision).
+  if (isAutoModelId(modelRef)) {
+    return FIREWORKS_MODEL_SPECS.auto;
   }
   const slug = resolveSpecSlug(modelRef);
   const shortId = specShortIdFromModelRef(modelRef);
@@ -456,7 +579,7 @@ export function isRouterShortId(shortId) {
     return false;
   }
   // `firerouter*` prefix (not just the bare slug) mirrors
-  // isFirerouterGatewayPattern, so firerouter variants classify as routers too.
+  // isFirerouterModelPattern, so firerouter variants classify as routers too.
   return shortId.startsWith("firerouter")
     || Boolean(ROUTER_SPEC_ALIASES[shortId])
     || shortId.endsWith("-latest")
@@ -487,6 +610,7 @@ export function requiresFastTierPricing(modelRef) {
   const shortId = specShortIdFromModelRef(modelRef);
   return shortId.endsWith("-fast-latest")
     || shortId.endsWith("-fast")
+    || shortId.endsWith("-fast-us")
     || shortId.endsWith("-turbo");
 }
 
@@ -523,7 +647,7 @@ export function catalogCacheCandidates(modelRef) {
   }
   const shortId = specShortIdFromModelRef(modelRef);
   const aliasSlug = resolveRouterSpecAliasTarget(shortId);
-  if (aliasSlug) {
+  if (aliasSlug && !FIREWORKS_MODEL_SPECS[shortId]) {
     candidates.push(`accounts/fireworks/models/${aliasSlug}`);
     candidates.push(`accounts/fireworks/routers/${aliasSlug}`);
   }

--- a/packages/setup-cli/lib/fireworks/models.mjs
+++ b/packages/setup-cli/lib/fireworks/models.mjs
@@ -1,6 +1,11 @@
 import {
+  AUTO_MODEL_ID,
   FIREROUTER_ROUTER_ID,
   KIMI_FAST_LATEST_ROUTER_ID,
+  canonicalAutoModelId,
+  isAutoModelId,
+  isFirerouterModel,
+  isFirerouterModelPattern,
 } from "./model-id.mjs";
 import {
   detectApiKeyType,
@@ -8,6 +13,7 @@ import {
 } from "../keys/key-type.mjs";
 import {
   FIREWORKS_PRICING_DOCS_URL,
+  lookupModelSpec,
   pricingMatchesModelRefTier,
   resolveFireworksModelLabel,
   resolveRouterSpecAliasTarget,
@@ -21,6 +27,7 @@ import {
   readCatalogCache,
   setServerlessCatalogSnapshot,
 } from "./serverless-catalog-cache.mjs";
+import { fireworksGatewayFetchSignal } from "./gateway-fetch.mjs";
 
 export const FIREWORKS_GATEWAY_URL = "https://api.fireworks.ai";
 export const PLATFORM_ACCOUNT_ID = "fireworks";
@@ -77,6 +84,21 @@ export function firerouterCatalogEntry() {
   };
 }
 
+/**
+ * Synthesized row for an auto mix. The serverless API never returns them, so
+ * `model list` has to supply them to show the models at all.
+ * @param {string} [modelId] an auto mix slug (`auto`, `auto-instant`)
+ */
+export function autoCatalogEntry(modelId = AUTO_MODEL_ID) {
+  const autoId = canonicalAutoModelId(modelId) || AUTO_MODEL_ID;
+  return {
+    id: autoId,
+    shortId: autoId,
+    displayName: autoDisplayName(autoId),
+    kind: KIND_SERVERLESS,
+  };
+}
+
 export function shortIdFromResourceName(name) {
   if (typeof name !== "string" || !name) {
     return "";
@@ -126,6 +148,48 @@ export function prettyModelName(modelId) {
   return pretty.join(" ");
 }
 
+/**
+ * Human-readable label for an auto mix. Bare `auto` is "Auto"; variants use
+ * pretty slugs (`auto-instant` -> "Auto Instant").
+ * @param {string} modelId
+ * @returns {string}
+ */
+export function autoDisplayName(modelId) {
+  const slug = canonicalAutoModelId(modelId);
+  if (!slug || slug === AUTO_MODEL_ID) {
+    return lookupModelSpec(AUTO_MODEL_ID)?.label ?? "Auto";
+  }
+  return prettyModelName(slug);
+}
+
+/**
+ * Human-readable label for a FireRouter selection. Bare `firerouter` renders as
+ * "FireRouter"; a multi-model slug joins pretty model names with " · "
+ * (firerouter/claude-opus-5/kimi-k3-fast -> "FireRouter · Claude Opus 5 · Kimi K3 Fast").
+ * @param {string} modelId
+ * @returns {string}
+ */
+export function firerouterDisplayName(modelId) {
+  if (!isFirerouterModelPattern(modelId)) {
+    return "FireRouter";
+  }
+  if (isFirerouterModel(modelId)) {
+    return "FireRouter";
+  }
+  const stripped = String(modelId ?? "")
+    .replace(/\[1m\]$/i, "")
+    .replace(/^accounts\/fireworks\/(?:models|routers)\//i, "")
+    .trim();
+  const NOISE = new Set(["accounts", "fireworks", "models", "routers"]);
+  const segments = stripped.split("/").filter(
+    (part) => part && !part.startsWith("firerouter") && !NOISE.has(part.toLowerCase()),
+  );
+  if (segments.length === 0) {
+    return "FireRouter";
+  }
+  return ["FireRouter", ...segments.map(prettyModelName)].join(" · ");
+}
+
 /** Strip catalog/router suffix from a display label. */
 export function stripViaFireworksSuffix(label) {
   return String(label).replace(/ via Fireworks$/i, "");
@@ -140,6 +204,7 @@ async function fetchGatewayPage(path, apiKey) {
       Authorization: `Bearer ${apiKey}`,
       Accept: "application/json",
     },
+    signal: fireworksGatewayFetchSignal(),
   });
 
   if (!response.ok) {
@@ -328,10 +393,21 @@ function resolveAliasRouterSources(snapshot, targetSlug, modelIds, alias) {
   const modelId = `accounts/fireworks/models/${targetSlug}`;
   if (modelIds.has(modelId)) {
     const pricing = snapshot.pricingById.get(modelId);
-    const pricingSourceId = hasUsableCachedPricing(pricing) && pricingMatchesModelRefTier(alias, pricing)
+    // Region-bound routers have their own documented premium. Never copy the
+    // base model's global rate into their cache entry.
+    const pricingSourceId = !alias.endsWith("-us")
+      && hasUsableCachedPricing(pricing)
+      && pricingMatchesModelRefTier(alias, pricing)
       ? modelId
       : null;
     return { baseModelId: modelId, pricingSourceId };
+  }
+
+  // A geography-bound endpoint must never be synthesized against an older
+  // family router: that could send compliance traffic to the wrong model and
+  // attach the wrong regional price. Require its documented base model.
+  if (alias.endsWith("-us")) {
+    return null;
   }
 
   for (const routerId of routerIdsForTargetSlug(targetSlug)) {
@@ -534,10 +610,11 @@ function dedupeCatalog(entries) {
 export async function fetchServerlessCatalog(apiKey) {
   const models = await fetchServerlessCatalogRaw(apiKey);
   const snapshot = buildServerlessCatalogSnapshot(models);
-  cacheServerlessCatalogSnapshot(snapshot);
+  const updatedAt = cacheServerlessCatalogSnapshot(snapshot);
   return {
     catalog: snapshot.entries,
     routersUnavailable: false,
+    updatedAt,
   };
 }
 
@@ -679,8 +756,16 @@ function catalogFamilyVersion(shortId = "", aliasFamilies = []) {
     return { family: stripVersionSegments(aliasFamily).family, version: [], latest: true };
   }
   const { family, version } = stripVersionSegments(shortId);
+  // Geography is a serving constraint, not a model-family variant. Keep a US
+  // router separate from the global family so `*-latest` does not collapse it.
+  if (shortId.endsWith("-us")) {
+    return { family, version, latest: false };
+  }
+  if (aliasFamilies.includes(family)) {
+    return { family, version, latest: false };
+  }
   const prefixed = aliasFamilies
-    .filter((candidate) => family !== candidate && family.startsWith(`${candidate}-`))
+    .filter((candidate) => family.startsWith(`${candidate}-`))
     .sort((a, b) => b.length - a.length)[0];
   return { family: prefixed ?? family, version, latest: false };
 }
@@ -703,36 +788,75 @@ function compareVersions(a, b) {
  * @param {import("./models.mjs").CatalogEntry[]} catalog
  * @returns {import("./models.mjs").CatalogEntry[]}
  */
-export function preferLatestAliases(catalog) {
-  // First pass: the families this catalog's -latest aliases advertise, so
-  // versioned entries (including families this CLI has never seen) resolve
-  // against them in the second pass.
-  const aliasFamilies = [...new Set(
+/**
+ * Families this catalog's own `-latest` alias rows advertise, so versioned
+ * entries (including families this CLI has never seen) resolve against them.
+ */
+function catalogAliasFamilies(catalog) {
+  return [...new Set(
     catalog
       .map((entry) => latestAliasFamily(entry.shortId ?? ""))
       .filter((family) => family !== null)
       .map((family) => stripVersionSegments(family).family),
   )];
-  const parsed = catalog.map((entry) => ({
+}
+
+function parseCatalogFamilies(catalog) {
+  const aliasFamilies = catalogAliasFamilies(catalog);
+  return catalog.map((entry) => ({
     entry,
     ...catalogFamilyVersion(entry.shortId, aliasFamilies),
   }));
-  const aliasedFamilies = new Set(
-    parsed.filter(({ latest }) => latest).map(({ family }) => family),
-  );
+}
+
+/** Highest version vector seen per family among concrete (non-alias) entries. */
+function newestVersionByFamily(parsed) {
   const newestByFamily = new Map();
   for (const { family, version, latest } of parsed) {
-    if (latest || version.length === 0 || aliasedFamilies.has(family)) continue;
+    if (latest || version.length === 0) continue;
     const current = newestByFamily.get(family);
     if (!current || compareVersions(version, current) > 0) {
       newestByFamily.set(family, version);
     }
   }
+  return newestByFamily;
+}
+
+export function preferLatestAliases(catalog) {
+  const parsed = parseCatalogFamilies(catalog);
+  const aliasedFamilies = new Set(
+    parsed.filter(({ latest }) => latest).map(({ family }) => family),
+  );
+  const newestByFamily = newestVersionByFamily(parsed);
 
   return parsed
     .filter(({ family, version, latest }) => {
       if (latest) return true;
       if (aliasedFamilies.has(family)) return false;
+      const newest = newestByFamily.get(family);
+      return !newest || compareVersions(version, newest) === 0;
+    })
+    .map(({ entry }) => entry);
+}
+
+/**
+ * Newest concrete model of every family the catalog carries.
+ *
+ * Families are still named after the catalog's own `-latest` alias rows, but
+ * the winning version is read off the catalog itself rather than from an
+ * alias's pinned target. A `ROUTER_SPEC_ALIASES` entry left on an older
+ * version therefore cannot hide a model the API is already serving, and
+ * families with no alias at all (gpt-oss-120b) are still represented.
+ * @param {import("./models.mjs").CatalogEntry[]} catalog
+ * @returns {import("./models.mjs").CatalogEntry[]}
+ */
+export function newestModelsByFamily(catalog) {
+  const parsed = parseCatalogFamilies(catalog)
+    .filter(({ entry, latest }) => !latest && entry.id?.includes("/models/"));
+  const newestByFamily = newestVersionByFamily(parsed);
+
+  return parsed
+    .filter(({ family, version }) => {
       const newest = newestByFamily.get(family);
       return !newest || compareVersions(version, newest) === 0;
     })
@@ -754,17 +878,34 @@ export function registerableModelIds(catalog, keyType, { includeFirerouter = fal
   ).map((entry) => entry.id);
 }
 
+/**
+ * Whether a catalog row is one of the auto routers, by either the short id or
+ * the final segment of the resource name. They're selectable with `--model` but
+ * aren't listable catalog rows, so they're dropped before any picker pass and
+ * re-added by `model list` itself.
+ * @param {CatalogEntry} entry
+ */
+export function isAutoCatalogEntry(entry) {
+  return isAutoModelId(entry?.shortId) || isAutoModelId(shortIdFromResourceName(entry?.id));
+}
+
 export function catalogWithAutomaticFirerouter(
   catalog,
   keyType,
   { includeFirerouter = false } = {},
 ) {
-  const withoutFirerouter = catalog.filter((entry) => entry.id !== FIREROUTER_ROUTER_ID);
+  // Every decision below compares against the auto-free list, so a catalog that
+  // ships an `auto` row can't make the "firerouter already present" check
+  // misfire and return the unfiltered catalog.
+  const listable = catalog.filter((entry) => !isAutoCatalogEntry(entry));
+  const withoutFirerouter = listable.filter((entry) => entry.id !== FIREROUTER_ROUTER_ID);
   if (!includeFirerouter || keyType === "firepass") {
     return withoutFirerouter;
   }
-  if (withoutFirerouter.length !== catalog.length) {
-    return catalog;
+  // The catalog carried its own firerouter row: keep it in place rather than
+  // prepending a synthesized duplicate.
+  if (withoutFirerouter.length !== listable.length) {
+    return listable;
   }
   return [firerouterCatalogEntry(), ...withoutFirerouter];
 }
@@ -775,7 +916,7 @@ export async function loadRegisterableModels({ apiKey, includeFirerouter = false
   return { ids, keyType };
 }
 
-export async function loadServerlessCatalog({ apiKey, keyType = "" }) {
+export async function loadServerlessCatalog({ apiKey, keyType = "", refresh = false }) {
   const resolvedKey = apiKey;
   if (!resolvedKey) {
     throw new Error(MISSING_FIREWORKS_API_KEY_MESSAGE);
@@ -784,7 +925,9 @@ export async function loadServerlessCatalog({ apiKey, keyType = "" }) {
   const resolvedKeyType = keyType || detectApiKeyType(resolvedKey);
 
   // Fire Pass keys cannot list the account catalog, so return the known
-  // Fire Pass router directly without hitting the API.
+  // Fire Pass router directly without hitting the API. `refresh` has nothing to
+  // refetch here, and dropping the cache would leave harnesses with no snapshot
+  // to register from offline.
   if (resolvedKeyType === "firepass") {
     return {
       apiKey: resolvedKey,
@@ -792,6 +935,7 @@ export async function loadServerlessCatalog({ apiKey, keyType = "" }) {
       catalog: filterCatalogForKeyType(FIREPASS_FALLBACK_ROUTERS, "firepass"),
       routersUnavailable: false,
       source: "firepass",
+      updatedAt: null,
     };
   }
 
@@ -800,8 +944,13 @@ export async function loadServerlessCatalog({ apiKey, keyType = "" }) {
   // snapshot is served without a network round-trip, a stale one is refreshed,
   // and offline we reuse whatever is cached so the picker is never wiped. Only
   // a true cold start (no cache + unreachable network) is an error.
+  //
+  // `refresh` (model list --refresh) ignores the TTL so a still-fresh snapshot
+  // can't short-circuit the fetch. The old snapshot is kept until a successful
+  // fetch replaces it: deleting it up front would turn an offline refresh into
+  // a cold start and wipe a catalog the user still depends on.
   const cache = readCatalogCache();
-  if (cache && isCatalogCacheFresh()) {
+  if (!refresh && cache && isCatalogCacheFresh()) {
     // Serve from disk AND hydrate the in-memory snapshot, so downstream
     // catalog consumers (getServerlessCatalogSnapshot) see it even if this
     // process previously resolved the snapshot to null.
@@ -812,11 +961,12 @@ export async function loadServerlessCatalog({ apiKey, keyType = "" }) {
       catalog: filterCatalogForKeyType(cache.snapshot.entries, resolvedKeyType),
       routersUnavailable: false,
       source: "cache",
+      updatedAt: cache.cachedAt || null,
     };
   }
 
   try {
-    const { catalog, routersUnavailable } = await fetchServerlessCatalog(resolvedKey);
+    const { catalog, routersUnavailable, updatedAt } = await fetchServerlessCatalog(resolvedKey);
     const filteredCatalog = filterCatalogForKeyType(catalog, resolvedKeyType);
     return {
       apiKey: resolvedKey,
@@ -824,6 +974,7 @@ export async function loadServerlessCatalog({ apiKey, keyType = "" }) {
       catalog: filteredCatalog,
       routersUnavailable,
       source: "network",
+      updatedAt,
     };
   } catch (error) {
     if (cache?.snapshot) {
@@ -834,6 +985,7 @@ export async function loadServerlessCatalog({ apiKey, keyType = "" }) {
         catalog: filterCatalogForKeyType(cache.snapshot.entries, resolvedKeyType),
         routersUnavailable: false,
         source: "stale",
+        updatedAt: cache.cachedAt || null,
       };
     }
     throw new Error(

--- a/packages/setup-cli/lib/fireworks/serverless-catalog-cache.mjs
+++ b/packages/setup-cli/lib/fireworks/serverless-catalog-cache.mjs
@@ -124,20 +124,22 @@ function loadPersistedSnapshot() {
 }
 
 function persistSnapshot(snapshot) {
+  const cachedAt = snapshot ? Date.now() : null;
   try {
     const file = cacheFilePath();
     if (!snapshot) {
       rmSync(file, { force: true });
-      return;
+      return cachedAt;
     }
     mkdirSync(path.dirname(file), { recursive: true });
     writeFileSync(file, JSON.stringify({
-      cachedAt: Date.now(),
+      cachedAt,
       snapshot: serializeSnapshot(snapshot),
     }));
   } catch {
     // Best-effort — a failed persist must never break catalog loading.
   }
+  return cachedAt;
 }
 
 /**
@@ -158,11 +160,12 @@ export function setServerlessCatalogSnapshot(snapshot) {
  * process can recover the last-known catalog (e.g. offline registration or
  * `off` cleanup). Only call with a freshly-fetched authoritative snapshot.
  * @param {ServerlessCatalogSnapshot | null} snapshot
+ * @returns {number | null} Snapshot time, or null when clearing.
  */
 export function cacheServerlessCatalogSnapshot(snapshot) {
   activeSnapshot = snapshot;
   snapshotResolved = true;
-  persistSnapshot(snapshot);
+  return persistSnapshot(snapshot);
 }
 
 export function getServerlessCatalogSnapshot() {
@@ -173,12 +176,16 @@ export function getServerlessCatalogSnapshot() {
   return activeSnapshot;
 }
 
+// Lookups lazy-load the persisted snapshot for short-lived consumers such as
+// the statusline helper. An explicit setServerlessCatalogSnapshot(null) still
+// wins because it marks the snapshot resolved.
+
 /**
  * @param {string} modelRef
  * @returns {ServerlessPricing | null}
  */
 export function lookupCachedServerlessPricing(modelRef) {
-  return activeSnapshot?.pricingById.get(modelRef) ?? null;
+  return getServerlessCatalogSnapshot()?.pricingById.get(modelRef) ?? null;
 }
 
 /**
@@ -186,7 +193,7 @@ export function lookupCachedServerlessPricing(modelRef) {
  * @returns {string[] | null}
  */
 export function lookupCachedInputModalities(modelRef) {
-  return activeSnapshot?.inputModalitiesById.get(modelRef) ?? null;
+  return getServerlessCatalogSnapshot()?.inputModalitiesById.get(modelRef) ?? null;
 }
 
 /**
@@ -194,7 +201,7 @@ export function lookupCachedInputModalities(modelRef) {
  * @returns {number | null}
  */
 export function lookupCachedContextLength(modelRef) {
-  return activeSnapshot?.contextLengthById.get(modelRef) ?? null;
+  return getServerlessCatalogSnapshot()?.contextLengthById.get(modelRef) ?? null;
 }
 
 /**
@@ -202,7 +209,7 @@ export function lookupCachedContextLength(modelRef) {
  * @returns {boolean | null}
  */
 export function lookupCachedSupportsTools(modelRef) {
-  const value = activeSnapshot?.supportsToolsById.get(modelRef);
+  const value = getServerlessCatalogSnapshot()?.supportsToolsById.get(modelRef);
   return value === undefined ? null : value;
 }
 
@@ -211,11 +218,12 @@ export function lookupCachedSupportsTools(modelRef) {
  * @returns {string | null}
  */
 export function lookupCachedRouterBaseModel(routerId) {
-  if (!activeSnapshot || !routerId) {
+  const snapshot = getServerlessCatalogSnapshot();
+  if (!snapshot || !routerId) {
     return null;
   }
   const normalized = routerId.replace(/\[1m\]$/i, "");
-  return activeSnapshot.routerBaseModelById.get(normalized) ?? null;
+  return snapshot.routerBaseModelById.get(normalized) ?? null;
 }
 
 /**
@@ -223,9 +231,10 @@ export function lookupCachedRouterBaseModel(routerId) {
  * @returns {import("./models.mjs").CatalogEntry | null}
  */
 export function lookupCatalogEntryById(modelId) {
-  if (!activeSnapshot || !modelId) {
+  const snapshot = getServerlessCatalogSnapshot();
+  if (!snapshot || !modelId) {
     return null;
   }
   const normalized = modelId.replace(/\[1m\]$/i, "");
-  return activeSnapshot.entries.find((entry) => entry.id === normalized) ?? null;
+  return snapshot.entries.find((entry) => entry.id === normalized) ?? null;
 }

--- a/packages/setup-cli/lib/fireworks/vision.mjs
+++ b/packages/setup-cli/lib/fireworks/vision.mjs
@@ -1,10 +1,10 @@
-import { fireworksModelSlug, isGatewayAnthropicSlot, isFirerouterModel } from "./model-id.mjs";
+import { fireworksModelSlug, isFirerouterModelPattern, isGatewayAnthropicSlot } from "./model-id.mjs";
 import { lookupFireworksModelLimits } from "./model-specs.mjs";
 
 /** Whether a Fireworks model/router accepts image input. FireRouter and
  * native Anthropic models (claude-*) are excluded from the catalog lookup. */
 export function modelSupportsVision(modelRef) {
-  if (!modelRef || isFirerouterModel(modelRef) || isGatewayAnthropicSlot(modelRef)) {
+  if (!modelRef || isFirerouterModelPattern(modelRef) || isGatewayAnthropicSlot(modelRef)) {
     return true;
   }
   return lookupFireworksModelLimits(modelRef).vision;
@@ -14,7 +14,7 @@ export function modelSupportsVision(modelRef) {
 export function uniqueNonVisionModelShortIds(modelRefs) {
   return [...new Set(
     [...modelRefs]
-      .filter((modelRef) => modelRef && !isFirerouterModel(modelRef))
+      .filter((modelRef) => modelRef && !isFirerouterModelPattern(modelRef))
       .filter((modelRef) => !modelSupportsVision(modelRef))
       .map((modelRef) => fireworksModelSlug(modelRef))
       .filter(Boolean),
@@ -31,7 +31,7 @@ export function formatNonVisionModelsWarning(shortIds) {
 
 /** Compact label for status and catalog output. */
 export function visionCapabilityLabel(modelRef) {
-  if (!modelRef || isFirerouterModel(modelRef)) {
+  if (!modelRef || isFirerouterModelPattern(modelRef)) {
     return "";
   }
   return modelSupportsVision(modelRef) ? "vision" : "text-only";

--- a/packages/setup-cli/lib/harness/engine.mjs
+++ b/packages/setup-cli/lib/harness/engine.mjs
@@ -6,7 +6,7 @@ import {
   printHarnessOnFootnotes,
   printHarnessOnSuccess,
 } from "../cli/messages.mjs";
-import { isFirerouterModel } from "../fireworks/model-id.mjs";
+import { isFirerouterModelPattern } from "../fireworks/model-id.mjs";
 import { assertRequestedModelServable } from "../fireworks/model-servability.mjs";
 import { detectApiKeyType } from "../keys/key-type.mjs";
 import { resolveAzureBaseUrl, resolveAzureOnApiKey } from "../fireworks/azure-core.mjs";
@@ -133,7 +133,7 @@ export async function engineOn(profile, ctx) {
     const settingsEnv = profile.readByokEnv ? await profile.readByokEnv(ctx, paths) : {};
     // Direct Fireworks gateway `on` only (Azure returns above). Fire Pass cannot
     // use FireRouter; assertFirerouterKeyType throws on explicit firerouter + fpk_.
-    if (isFirerouterRequested && firerouterCredentialsApplyOnGateway(keyType)) {
+    if (plan.requiresAnthropicKey && firerouterCredentialsApplyOnGateway(keyType)) {
       ({ anthropicKey: preResolvedAnthropicKey } = await resolveExplicitFirerouterCredential({
         firerouter: profile.firerouter,
         availability: automaticFirerouter,
@@ -184,7 +184,7 @@ export async function engineOn(profile, ctx) {
 
   const modelsAdded = result.modelsAdded ?? [result.model];
   const firerouterIncluded = Boolean(
-    profile.firerouter && isFirerouterModel(result.model),
+    profile.firerouter && isFirerouterModelPattern(result.model),
   );
   const footnotes = buildFirerouterOnFootnotes({
     harnessId: profile.id,

--- a/packages/setup-cli/lib/harness/id.mjs
+++ b/packages/setup-cli/lib/harness/id.mjs
@@ -12,6 +12,27 @@ export const HARNESS = Object.freeze({
 
 export const HARNESSES = Object.freeze(Object.values(HARNESS));
 
+/**
+ * Harness name aliases → canonical harness id. The ChatGPT app shares
+ * ~/.codex/config.toml + the fireworks-model-catalog.json with the Codex CLI, so
+ * `chatgpt` is not a separate harness — it routes to `codex`. Kept here, next to
+ * the canonical harness names, so the parser and help text share one source of
+ * truth.
+ */
+export const HARNESS_ALIASES = Object.freeze({
+  chatgpt: HARNESS.CODEX,
+});
+
+/**
+ * Resolve a harness alias to its canonical harness id (or return the input
+ * unchanged if it is not an alias).
+ * @param {string} token
+ * @returns {string}
+ */
+export function resolveHarnessAlias(token) {
+  return HARNESS_ALIASES[token] ?? token;
+}
+
 /** Codex, OpenCode, Pi, and DeepSeek Harness — file-based configs (literal or legacy env ref). */
 export const FILE_CONFIG_HARNESS_IDS = Object.freeze([
   HARNESS.CODEX,

--- a/packages/setup-cli/lib/harness/types.mjs
+++ b/packages/setup-cli/lib/harness/types.mjs
@@ -24,6 +24,7 @@ import { HARNESSES } from "./id.mjs";
  * @property {string} fable
  * @property {string} subagent
  * @property {string} search
+ * @property {boolean} [refresh] // model list: drop the 1h catalog cache and refetch
  * @property {string} [session] // claude usage: session id prefix or explicit .jsonl path
  * @property {string} [lastN]   // claude usage: latest N parent sessions
  * @property {boolean} [verbose]

--- a/packages/setup-cli/lib/harnesses/claude/activation.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/activation.mjs
@@ -9,6 +9,9 @@ import {
 } from "./core.mjs";
 import {
   claudeModelOverridesFrom,
+  CLAUDE_FIREWORKS_PINNED_DEFAULTS,
+  FIRST_CONNECT_AUTOMATIC_OPUS_MODEL,
+  FIRST_CONNECT_AUTOMATIC_SONNET_MODEL,
   hasClaudeModelOverrides,
   mergeClaudeModelMappings,
   migrateLegacyClaudeModelMapping,
@@ -16,6 +19,11 @@ import {
   resolveClaudeModelMapping,
   savedClaudeModelMapping,
 } from "./model-profile.mjs";
+import {
+  isClaudeNativeModel,
+  isClaudeNativeSlotAlias,
+  isFirerouterModelPattern,
+} from "../../fireworks/model-id.mjs";
 export async function readClaudeActivationSnapshot(ctx) {
   const paths = claudePathsFor(ctx);
   const [settings, backup, state, globalConfig] = await Promise.all([
@@ -52,11 +60,12 @@ export function resolveClaudeActivationPlan({
   const overrides = claudeModelOverridesFrom(ctx);
   const explicitOverrides = hasClaudeModelOverrides(ctx);
   // FireRouter is Opus-tier (it routes hard tasks to Claude Opus 5), so on first
-  // setup with firerouter auth it takes the Opus slot. Every other slot keeps its
-  // default; Fable already carries the vision model, so the vision slot stays
-  // covered when Opus is the router.
+  // setup with firerouter auth it takes the Opus slot and GLM moves to Sonnet.
   const automatic = firstSetup && automaticFirerouter && !explicitOverrides
-    ? { opus: "firerouter" }
+    ? {
+      opus: FIRST_CONNECT_AUTOMATIC_OPUS_MODEL,
+      sonnet: FIRST_CONNECT_AUTOMATIC_SONNET_MODEL,
+    }
     : {};
   // Migrate legacy pinned slugs baked into an existing install (saved profile
   // and/or live settings) to their -latest router aliases before merging. Only
@@ -64,14 +73,55 @@ export function resolveClaudeActivationPlan({
   // are merged afterward so a deliberate `--haiku deepseek-v4-flash` is honored.
   const migratedSaved = migrateLegacyClaudeModelMapping(saved).mapping;
   const migratedActive = migrateLegacyClaudeModelMapping(active).mapping;
+  const merged = resolveClaudeModelMapping(
+    mergeClaudeModelMappings(migratedSaved, migratedActive, automatic, overrides),
+    keyType,
+  );
   return {
     firstSetup,
     explicitOverrides,
-    mapping: resolveClaudeModelMapping(
-      mergeClaudeModelMappings(migratedSaved, migratedActive, automatic, overrides),
-      keyType,
-    ),
+    mapping: applyFirerouterSonnetDefault(merged, overrides, {
+      saved: migratedSaved,
+      active: migratedActive,
+    }),
   };
+}
+
+/** When Opus is FireRouter, pin Sonnet to GLM unless the user chose Sonnet explicitly. */
+function applyFirerouterSonnetDefault(mapping, overrides = {}, { saved = {}, active = {} } = {}) {
+  if (!isFirerouterModelPattern(mapping.opus)) {
+    return mapping;
+  }
+  if (overrides.sonnet?.trim()) {
+    return mapping;
+  }
+
+  const baselineSonnet = CLAUDE_FIREWORKS_PINNED_DEFAULTS.sonnet;
+  const activeSonnet = active.sonnet?.trim();
+  if (activeSonnet) {
+    if (isClaudeNativeModel(activeSonnet) || isClaudeNativeSlotAlias(activeSonnet)) {
+      return mapping;
+    }
+    if (activeSonnet !== baselineSonnet) {
+      return mapping;
+    }
+    // Live settings already pair FireRouter Opus with baseline Sonnet — keep it.
+    if (isFirerouterModelPattern(active.opus)) {
+      return mapping;
+    }
+  }
+
+  const savedSonnet = saved.sonnet?.trim();
+  if (savedSonnet && savedSonnet !== baselineSonnet) {
+    return mapping;
+  }
+
+  const mergedSonnet = mapping.sonnet?.trim();
+  if (mergedSonnet && mergedSonnet !== baselineSonnet) {
+    return mapping;
+  }
+
+  return { ...mapping, sonnet: FIRST_CONNECT_AUTOMATIC_SONNET_MODEL };
 }
 
 export function canOnboardingSelectFirerouter({

--- a/packages/setup-cli/lib/harnesses/claude/code-context.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/code-context.mjs
@@ -4,7 +4,7 @@ import {
   isAnthropicModelId,
   isClaudeNativeModel,
   isGatewayAnthropicSlot,
-  isFirerouterGatewayPattern,
+  isFirerouterModelPattern,
 } from "../../fireworks/model-id.mjs";
 import { lookupFireworksModelLimits } from "../../fireworks/model-specs.mjs";
 import { loadServerlessCatalog } from "../../fireworks/models.mjs";
@@ -65,7 +65,7 @@ export function modelQualifiesForClaudeCode1mContext(modelId) {
     }
     return true;
   }
-  if (isFirerouterGatewayPattern(modelId)) {
+  if (isFirerouterModelPattern(modelId)) {
     return true;
   }
   const slug = fireworksModelSlug(modelId);
@@ -85,6 +85,9 @@ export function claudeCodeModelId(modelId) {
   if (isClaudeNativeModel(modelId)) {
     return modelId;
   }
+  // Like glm-latest and other 1M Fireworks models: tag with [1m] for Claude Code's
+  // context window. Claude Code strips the suffix before the gateway API call, so
+  // `auto[1m]` still reaches the gateway as bare `auto`.
   return `${stripClaudeCodeContextSuffix(modelId)}${CLAUDE_CODE_1M_SUFFIX}`;
 }
 

--- a/packages/setup-cli/lib/harnesses/claude/core.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/core.mjs
@@ -13,7 +13,6 @@ import {
 import {
   buildClaudeCustomHeaders,
   fireworksKeyFromCustomHeaders,
-  LEGACY_FIREROUTER_FIREWORKS_HEADER,
   setFireworksKeyInCustomHeaders,
   stripFireworksKeyFromCustomHeaders,
   stripFirerouterOwnedEnv,
@@ -21,15 +20,16 @@ import {
 } from "../../firerouter/core.mjs";
 import { lookupModelSpec, FIREWORKS_PRICING_DOCS_URL, resolveFireworksModelLabel, appendLatestRouterSuffix } from "../../fireworks/model-specs.mjs";
 import { formatPricingDescription, lookupFireworksPricing } from "../../fireworks/pricing.mjs";
-import { prettyModelName, stripViaFireworksSuffix } from "../../fireworks/models.mjs";
+import { autoDisplayName, prettyModelName, stripViaFireworksSuffix } from "../../fireworks/models.mjs";
 import {
   CLAUDE_NATIVE_MODEL_ID,
   DEEPSEEK_FLASH_LATEST_ROUTER_ID,
   DEEPSEEK_PRO_LATEST_ROUTER_ID,
   FIREWORKS_BASE_URL,
-  FIREROUTER_ROUTER_ID,
   GLM_FAST_LATEST_ROUTER_ID,
   KIMI_FAST_LATEST_ROUTER_ID,
+  isAutoModelId,
+  isClaudeModelAlias,
   isClaudeNativeModel,
   shortFireworksModelRef,
 } from "../../fireworks/model-id.mjs";
@@ -45,14 +45,13 @@ import {
   stripFireconnectTelemetryHeaderLines,
 } from "../../telemetry/request-headers.mjs";
 import {
-  CLAUDE_MODEL_SLOTS,
   mappingUsesFirerouter,
   resolveClaudeModelMapping,
 } from "./model-profile.mjs";
+import { stripClaudeStatusLine, withClaudeStatusLine } from "./statusline.mjs";
 
 export const DEFAULT_DATA_DIR = ".fireconnect/claude";
 export const USER_SETTINGS_RELATIVE_PATH = ".claude/settings.json";
-const LEGACY_FIREROUTER_HOSTNAME = "router.fireworks.ai";
 
 /** Legacy main-default env keys stripped when writing FireConnect-managed settings. */
 const LEGACY_ANTHROPIC_MAIN_ENV_KEYS = ["ANTHROPIC_MODEL", "ANTHROPIC_SMALL_FAST_MODEL"];
@@ -131,6 +130,10 @@ export const CLAUDE_CODE_BEHAVIOR_ENV = {
   DISABLE_TELEMETRY: "1",
   DO_NOT_TRACK: "1",
   CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+  // Claude Code disables MCP tool search when ANTHROPIC_BASE_URL is not
+  // api.anthropic.com. Force it on so deferred tool_reference loading still
+  // works through the Fireworks gateway.
+  ENABLE_TOOL_SEARCH: "true",
 };
 
 export const DEFAULT_FIREWORKS_PRESET = {
@@ -190,6 +193,11 @@ export function mappingFromSettings(settings = {}) {
   const mainFromModel = typeof settings.model === "string" && settings.model.trim()
     ? stripMappedModelId(settings.model.trim())
     : null;
+  // A bare Claude Code `/model` picker alias (opus/sonnet/haiku/fable) names no
+  // concrete model: it resolves at request time through the alias's own env slot,
+  // which the slot rows below already report. Treat it as unpinned (native) main
+  // instead of misreading the user's picker choice as a FireConnect model pin.
+  const mainAliasPicked = isClaudeModelAlias(mainFromModel);
   const mainFromEnv = env.ANTHROPIC_MODEL
     ? stripMappedModelId(env.ANTHROPIC_MODEL)
     : null;
@@ -204,7 +212,7 @@ export function mappingFromSettings(settings = {}) {
   ) || env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_API_KEY || "";
   const firepass = routed && detectApiKeyType(gatewayKey) === "firepass";
   const native = routed && !firepass ? CLAUDE_NATIVE_MODEL_ID : null;
-  const resolvedMain = mainFromModel || mainFromEnv;
+  const resolvedMain = (mainFromModel && !mainAliasPicked ? mainFromModel : null) || mainFromEnv;
   return {
     main: resolvedMain || native,
     opus: stripMappedModelId(env.ANTHROPIC_DEFAULT_OPUS_MODEL ?? null) || native,
@@ -254,22 +262,10 @@ export function fireworksHostnameFromBaseUrl(baseUrl) {
   }
 }
 
-function customHeadersContain(value, headerName) {
-  if (typeof value !== "string") {
-    return false;
-  }
-  const wanted = headerName.toLowerCase();
-  return value.split("\n").some((line) => {
-    const colon = line.indexOf(":");
-    return colon !== -1 && line.slice(0, colon).trim().toLowerCase() === wanted;
-  });
-}
-
 /**
- * Recover the active FireConnect intent from settings written by either the
- * current CLI or a legacy router.fireworks.ai release. A Fireworks hostname is
- * not sufficient by itself: backup/state, a managed helper/header, telemetry,
- * or FireConnect's model/preset wiring must also identify ownership.
+ * Recover active FireConnect intent from current settings. A Fireworks
+ * hostname is not sufficient by itself: backup/state, a managed helper/header,
+ * telemetry, or FireConnect's model mapping must also identify ownership.
  */
 export function claudeFireconnectIntent(settings, { backup = {}, state = {} } = {}) {
   const env = settings.env ?? {};
@@ -281,37 +277,26 @@ export function claudeFireconnectIntent(settings, { backup = {}, state = {} } = 
   const mapping = mappingFromSettings(settings);
   const headers = env.ANTHROPIC_CUSTOM_HEADERS;
   const hasFireworksMapping = Object.values(mapping).some(Boolean);
-  const hasManagedPreset = env.CLAUDE_CODE_ATTRIBUTION_HEADER === "0"
-    && env.CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING === "1";
-  const hasLegacyHeader = customHeadersContain(
-    headers,
-    LEGACY_FIREROUTER_FIREWORKS_HEADER,
-  );
   const hasTelemetry = typeof headers === "string"
     && stripFireconnectTelemetryHeaderLines(headers) !== headers;
   const hasCurrentManagedHeader = isFireworksShapedKey(
     fireworksKeyFromCustomHeaders(headers),
-  ) && (hasFireworksMapping || hasManagedPreset);
+  ) && hasFireworksMapping;
   const hasManagedEvidence = backup.snapshot !== undefined
     || backup.values !== undefined
     || Boolean(state.authMode || state.managedApiKeyHelper)
     || stripManagedApiKeyHelper(settings, state).changed
     || env.ANTHROPIC_API_KEY === "fireconnect"
-    || hasLegacyHeader
     || hasTelemetry
-    || hasCurrentManagedHeader
-    || (hasFireworksMapping && hasManagedPreset);
+    || hasCurrentManagedHeader;
   if (!hasManagedEvidence) {
     return null;
   }
 
-  const legacyFullRouter = hostname === LEGACY_FIREROUTER_HOSTNAME;
   return {
     hostname,
-    mode: legacyFullRouter ? "router" : "direct",
-    mapping: legacyFullRouter
-      ? Object.fromEntries(CLAUDE_MODEL_SLOTS.map((slot) => [slot, FIREROUTER_ROUTER_ID]))
-      : mapping,
+    mode: "direct",
+    mapping,
     needsUpgrade: backup.snapshot === undefined,
   };
 }
@@ -467,6 +452,7 @@ export function stripFireconnectManagedClaudeSettings(settings, state = {}) {
 
   let nextSettings = { ...settings, env: nextEnv };
   nextSettings = clearFireworksTopLevelWithoutBackup(nextSettings);
+  nextSettings = stripClaudeStatusLine(nextSettings).settings;
   return stripManagedApiKeyHelper(nextSettings, state).settings;
 }
 
@@ -541,6 +527,9 @@ export function stripModelMappingEnv(env) {
  * @returns {string}
  */
 export function fireworksModelPickerName(modelId) {
+  if (isAutoModelId(modelId)) {
+    return autoDisplayName(modelId);
+  }
   const liveLabel = resolveFireworksModelLabel(modelId);
   if (liveLabel) {
     return stripViaFireworksSuffix(liveLabel);
@@ -699,7 +688,6 @@ export function buildFireworksProviderEnv(env, {
   });
   delete nextEnv.ANTHROPIC_API_KEY;
   delete nextEnv.ANTHROPIC_AUTH_TOKEN;
-  delete nextEnv.ENABLE_TOOL_SEARCH;
   // Let Claude Code emit its normal attribution block. The Fireworks gateway
   // strips that synthetic block before inference, while disabling it client-side
   // breaks Claude Code's classifier/auto-mode behavior.
@@ -807,6 +795,10 @@ export function buildFireworksSettings(settings, {
     } else {
       next.model = shortFireworksModelRef(claudeCodeModelId(mapping.main));
     }
+    // Claude Code prices the routed model against Anthropic's list, so its own
+    // status line reports a cost the user is never billed. Ours reads the
+    // transcript at Fireworks rates. A user's existing statusLine is left as-is.
+    return { settings: withClaudeStatusLine(next), token, keyType: resolvedKeyType };
   }
   return { settings: next, token, keyType: resolvedKeyType };
 }
@@ -939,6 +931,9 @@ export async function disableFireworksProvider({ settingsPath, dataDir, wasEnabl
       nextSettings = clearFireworksTopLevelWithoutBackup(nextSettings);
     }
     nextSettings = stripManagedApiKeyHelper(nextSettings, state).settings;
+    // This legacy backup predates the managed status line, so it cannot restore
+    // its absence — strip it explicitly (a user's own statusLine is untouched).
+    nextSettings = stripClaudeStatusLine(nextSettings).settings;
 
     await writeJson(settingsPath, nextSettings);
     await writeJson(statePath, {
@@ -962,7 +957,10 @@ export async function disableFireworksProvider({ settingsPath, dataDir, wasEnabl
   const { settings: clearedSettings, changed: helperChanged } = stripManagedApiKeyHelper(nextSettings, state);
   nextSettings = clearedSettings;
 
-  if (envChanged || clearedTopLevel || helperChanged) {
+  const { settings: withoutStatusLine, changed: statusLineChanged } = stripClaudeStatusLine(nextSettings);
+  nextSettings = withoutStatusLine;
+
+  if (envChanged || clearedTopLevel || helperChanged || statusLineChanged) {
     await writeJson(settingsPath, nextSettings);
   }
 

--- a/packages/setup-cli/lib/harnesses/claude/index.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/index.mjs
@@ -100,7 +100,6 @@ import { printWebsearchOnStep } from "../../system/websearch-install-guide.mjs";
 import {
   printClaudeModelMapping,
   runClaudeModelOnboarding,
-  standardClaudeModelMapping,
 } from "./onboarding.mjs";
 import {
   canOnboardingSelectFirerouter,
@@ -112,7 +111,7 @@ import {
   defaultClaudeModelMapping,
   hasClaudeModelOverrides,
   inferClaudeActiveKeyType,
-  isClaudeMappingOverride,
+  mappingRequiresAnthropicKey,
   mappingUsesFirerouter,
   withSavedClaudeModelMapping,
 } from "./model-profile.mjs";
@@ -124,7 +123,7 @@ const CLAUDE_FIREROUTER = Object.freeze({
 });
 
 export const CLAUDE_FIREROUTER_FALLBACK_WARNING =
-  "FireRouter off · Sign in to Claude or pass --anthropic-api-key to enable automatic routing.";
+  "FireRouter off · Sign in to Claude or pass --anthropic-api-key to route between Claude and open models.";
 
 export const CLAUDE_FIREROUTER_AUTH_REQUIRED =
   "FireRouter requires Claude sign-in, workspace BYOK, or an Anthropic API key. "
@@ -465,8 +464,7 @@ export default defineHarnessProfile({
     ) {
       throw new Error("--routing-preference requires a Claude slot set to firerouter.");
     }
-    const fastDefaults = defaultClaudeModelMapping(keyType);
-    const nonFastDefaults = standardClaudeModelMapping(keyType);
+    const defaultMapping = defaultClaudeModelMapping(keyType);
     let pickerCatalogPromise;
     const loadPickerCatalog = () => {
       pickerCatalogPromise ??= loadClaudeModelPickerCatalog({
@@ -475,8 +473,7 @@ export default defineHarnessProfile({
         includeFirerouter: canUseFirerouter,
         extraModelIds: [
           ...Object.values(plan.mapping),
-          ...Object.values(fastDefaults),
-          ...Object.values(nonFastDefaults),
+          ...Object.values(defaultMapping),
         ],
       });
       return pickerCatalogPromise;
@@ -486,8 +483,8 @@ export default defineHarnessProfile({
     }
     if (shouldRunOnboarding) {
       const selected = await runClaudeModelOnboarding({
-        recommended: mapping,
-        fastDefaults,
+        shownMapping: mapping,
+        badgeMapping: plan.firstSetup ? mapping : defaultMapping,
         mappingLabel: plan.firstSetup ? "Recommended" : "Current",
         keyType,
         loadCatalog: loadPickerCatalog,
@@ -513,7 +510,8 @@ export default defineHarnessProfile({
       );
     }
     let anthropicKeyForFirerouter = nativeAuth.anthropicApiKey;
-    if (usesFirerouter && !canUseFirerouter) {
+    const firerouterNeedsAnthropicKey = mappingRequiresAnthropicKey(mapping);
+    if (usesFirerouter && firerouterNeedsAnthropicKey && !canUseFirerouter) {
       if (onboardingMode !== "skip") {
         const prompted = await resolveExplicitFirerouterCredential({
           firerouter: CLAUDE_FIREROUTER,
@@ -710,12 +708,6 @@ export default defineHarnessProfile({
       model: routed ? undefined : mainModel,
       mappingRows: routed
         ? Object.entries(payload.current)
-          .filter(([slot, modelId]) => isClaudeMappingOverride(
-            modelId,
-            slot,
-            payload.keyType,
-            payload.defaults,
-          ))
           .map(([slot, modelId]) => {
             const resolved = modelId || payload.defaults[slot] || "";
             const detailParts = [
@@ -724,7 +716,9 @@ export default defineHarnessProfile({
             ].filter(Boolean);
             return {
               slot,
-              value: shortModelId(resolved),
+              value: isClaudeNativeModel(resolved)
+                ? "Using Anthropic"
+                : shortModelId(resolved),
               detail: detailParts.join(" · "),
             };
           })

--- a/packages/setup-cli/lib/harnesses/claude/model-picker.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/model-picker.mjs
@@ -1,6 +1,12 @@
 import { resolveModelDisplayMetadata } from "../../fireworks/model-display.mjs";
-import { FIREWORKS_MODEL_SPECS, ROUTER_SPEC_ALIASES } from "../../fireworks/model-specs.mjs";
 import {
+  AUTO_INSTANT_MODEL_ID,
+  FIREWORKS_MODEL_SPECS,
+  isAutoModelId,
+  ROUTER_SPEC_ALIASES,
+} from "../../fireworks/model-specs.mjs";
+import {
+  autoCatalogEntry,
   catalogWithAutomaticFirerouter,
   FIREPASS_FALLBACK_ROUTERS,
   loadServerlessCatalog,
@@ -15,15 +21,36 @@ import {
   isClaudeNativeModel,
 } from "../../fireworks/model-id.mjs";
 import { attachPricing } from "../../fireworks/pricing.mjs";
+import { CLAUDE_FIREWORKS_PINNED_DEFAULTS } from "./model-profile.mjs";
 
-const SLOT_RECOMMENDATIONS = Object.freeze({
-  main: ["kimi-fast-latest", "firerouter", "glm-fast-latest", "glm-latest"],
-  opus: ["glm-fast-latest", "glm-latest", "deepseek-v4-pro", "firerouter"],
-  sonnet: ["glm-fast-latest", "kimi-fast-latest", "glm-latest", "deepseek-flash-latest"],
-  haiku: ["deepseek-flash-latest", "kimi-fast-latest", "gpt-oss-120b", "minimax-latest"],
-  fable: ["kimi-fast-latest", "kimi-latest", "qwen-plus-latest", "minimax-latest"],
-  subagent: ["deepseek-flash-latest", "kimi-fast-latest", "gpt-oss-120b", "glm-fast-latest"],
+// Wizard picker alternates follow each slot default (see CLAUDE_FIREWORKS_PINNED_DEFAULTS).
+// minimax-latest is last in every slot — discoverable, never a default.
+const MAIN_PICKER_HEAD = "kimi-latest";
+
+const SLOT_PICKER_ALTERNATIVES = Object.freeze({
+  main: ["firerouter", "auto", "glm-latest", "glm-flash-latest", "minimax-latest"],
+  opus: ["kimi-latest", "deepseek-pro-latest", "firerouter", "auto", "minimax-latest"],
+  sonnet: ["glm-latest", "kimi-latest", "auto", "auto-instant", "glm-flash-latest", "deepseek-flash-latest", "minimax-latest"],
+  haiku: ["auto", "gpt-oss-120b", "glm-flash-latest", "qwen-plus-latest", "minimax-latest"],
+  fable: ["auto", "kimi-latest", "qwen-plus-latest", "glm-latest", "minimax-latest"],
+  subagent: ["auto", "gpt-oss-120b", "glm-flash-latest", "kimi-latest", "minimax-latest"],
 });
+
+export function slotPickerRecommendations(slot) {
+  const head = slot === "main"
+    ? MAIN_PICKER_HEAD
+    : CLAUDE_FIREWORKS_PINNED_DEFAULTS[slot];
+  const ordered = [];
+  const seen = new Set();
+  for (const slug of [head, ...(SLOT_PICKER_ALTERNATIVES[slot] ?? [])]) {
+    if (!slug || seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+    ordered.push(slug);
+  }
+  return ordered;
+}
 
 const STATIC_MODEL_SLUGS = [
   ...Object.keys(ROUTER_SPEC_ALIASES),
@@ -44,8 +71,8 @@ function syntheticEntry(modelId) {
 /**
  * The "Claude default" slot choice. Selecting it means "don't pin
  * this slot — use Claude's own default Anthropic model for the role" (served via
- * the Fireworks gateway). Keep it out of the Fireworks-only fast/non-fast tiers;
- * it's a first-class choice with no pricing/limits in the FW catalog.
+ * the Fireworks gateway). It's a first-class choice with no pricing/limits in
+ * the FW catalog.
  */
 function claudeNativePickerEntry() {
   const id = fullFireworksResourceId(CLAUDE_NATIVE_MODEL_ID);
@@ -77,14 +104,33 @@ function enrichEntry(entry) {
     id: entry.id,
     slug: entry.shortId,
     label: stripViaFireworksSuffix(entry.displayName || prettyModelName(entry.shortId)),
-    fast: pricing?.tier === "fast" || /(?:-fast|-turbo|-flash)(?:-|$)/i.test(entry.shortId),
+    fast: pricing?.tier === "fast",
     contextWindow: metadata.maxInputTokens ?? 128_000,
     vision: metadata.vision === true,
     tools: metadata.toolCalling !== false,
     pricing,
     router: entry.id.includes("/routers/"),
     firerouter: entry.shortId === "firerouter",
+    auto: isAutoModelId(entry.shortId),
   };
+}
+
+/** Standard-key catalogs: inject synthesized `auto` rows the serverless API omits. */
+function injectAutoMixCatalogRows(catalog, keyType) {
+  if (keyType === "firepass") {
+    return catalog;
+  }
+  const present = new Set(
+    catalog.map((entry) => entry.shortId).filter(Boolean),
+  );
+  const injected = [];
+  if (!present.has("auto")) {
+    injected.push(autoCatalogEntry());
+  }
+  if (!present.has(AUTO_INSTANT_MODEL_ID)) {
+    injected.push(autoCatalogEntry(AUTO_INSTANT_MODEL_ID));
+  }
+  return injected.length ? [...injected, ...catalog] : catalog;
 }
 
 export async function loadClaudeModelPickerCatalog({
@@ -105,11 +151,12 @@ export async function loadClaudeModelPickerCatalog({
     keyType,
     { includeFirerouter },
   );
+  const withAuto = injectAutoMixCatalogRows(withRouter, keyType);
   const extras = extraModelIds
     .filter((modelId) => includeFirerouter || modelId !== "firerouter")
     .map(syntheticEntry);
   const bySlug = new Map(
-    [...withRouter, ...extras]
+    [...withAuto, ...extras]
       .map(enrichEntry)
       .filter((model) => model.tools)
       .map((model) => [model.slug, model]),
@@ -126,14 +173,11 @@ export function rankClaudeModelsForSlot(models, {
   currentModel,
   recommendedModel,
 }) {
-  const recommendations = SLOT_RECOMMENDATIONS[slot] ?? [];
+  const recommendations = slotPickerRecommendations(slot);
   const rank = (model) => {
     if (model.slug === currentModel) return -300;
     if (model.slug === recommendedModel) return -200;
     if (model.slug === CLAUDE_NATIVE_MODEL_ID) {
-      // Always keep "Claude default" in the visible top slice — in non-fast mode
-      // too, where the slot's recommendation is a Fireworks alias and the native
-      // entry would otherwise rank off the end of the list.
       return isClaudeNativeModel(currentModel) || isClaudeNativeModel(recommendedModel)
         ? -250
         : -150;
@@ -148,8 +192,18 @@ export function rankClaudeModelsForSlot(models, {
   ));
 }
 
-export function suitableClaudeModelsForSlot(models, options, limit = 5) {
-  return rankClaudeModelsForSlot(models, options).slice(0, limit);
+function wizardVisibleSlugs({ slot, currentModel, recommendedModel }) {
+  return new Set([
+    currentModel,
+    recommendedModel,
+    CLAUDE_NATIVE_MODEL_ID,
+    ...slotPickerRecommendations(slot),
+  ].filter(Boolean));
+}
+
+export function suitableClaudeModelsForSlot(models, options) {
+  const visible = wizardVisibleSlugs(options);
+  return rankClaudeModelsForSlot(models, options).filter((model) => visible.has(model.slug));
 }
 
 export function formatContextWindow(tokens) {
@@ -169,9 +223,9 @@ export function modelPickerBadges(model, {
     model.slug === currentModel ? "Current" : "",
     model.slug === recommendedModel ? "Recommended" : "",
     isClaudeNativeModel(model.slug) ? CLAUDE_NATIVE_SLOT_LABEL : "",
-    model.firerouter ? "Automatic routing" : (model.fast ? "Fast" : "Standard"),
+    model.firerouter ? "Claude + open models" : (model.auto ? "Open-model mix" : (model.fast ? "Fast" : "Standard")),
     formatContextWindow(model.contextWindow),
-    model.firerouter ? "" : (model.vision ? "Vision" : "Text-only"),
+    model.firerouter || model.auto ? "" : (model.vision ? "Vision" : "Text-only"),
     model.pricing?.display ?? "",
   ].filter(Boolean);
 }

--- a/packages/setup-cli/lib/harnesses/claude/model-profile.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/model-profile.mjs
@@ -6,7 +6,8 @@ import {
   fireworksModelSlug,
   isClaudeNativeModel,
   isClaudeNativeSlotAlias,
-  isFirerouterModel,
+  isFirerouterModelPattern,
+  firerouterRequiresAnthropicKey,
   normalizeModelId,
   validateModelId,
 } from "../../fireworks/model-id.mjs";
@@ -20,13 +21,25 @@ export const CLAUDE_MODEL_SLOTS = Object.freeze([
   "subagent",
 ]);
 
-export const DEFAULT_OPUS_MODEL = "deepseek-pro-latest";
-export const DEFAULT_FABLE_MODEL = "kimi-fast-latest";
-// Sonnet stays native: it is the alias most people pick deliberately in
-// `/model`, so FireConnect leaves it pointing at Anthropic's own model.
-export const DEFAULT_SONNET_MODEL = CLAUDE_NATIVE_MODEL_ID;
-export const DEFAULT_HAIKU_MODEL = "deepseek-flash-latest";
-export const DEFAULT_SUBAGENT_MODEL = DEFAULT_HAIKU_MODEL;
+/** Pinned Fireworks router aliases for each Claude slot (main stays native). */
+export const CLAUDE_FIREWORKS_PINNED_DEFAULTS = Object.freeze({
+  opus: "glm-latest",
+  sonnet: "deepseek-pro-latest",
+  haiku: "deepseek-flash-latest",
+  fable: "glm-flash-latest",
+  subagent: "deepseek-flash-latest",
+});
+
+/** Opus override applied on first connect when FireRouter auth is available. */
+export const FIRST_CONNECT_AUTOMATIC_OPUS_MODEL = "firerouter";
+/** Sonnet companion when Opus is FireRouter — GLM moves off the Opus slot. */
+export const FIRST_CONNECT_AUTOMATIC_SONNET_MODEL = "glm-latest";
+
+export const DEFAULT_OPUS_MODEL = CLAUDE_FIREWORKS_PINNED_DEFAULTS.opus;
+export const DEFAULT_FABLE_MODEL = CLAUDE_FIREWORKS_PINNED_DEFAULTS.fable;
+export const DEFAULT_SONNET_MODEL = CLAUDE_FIREWORKS_PINNED_DEFAULTS.sonnet;
+export const DEFAULT_HAIKU_MODEL = CLAUDE_FIREWORKS_PINNED_DEFAULTS.haiku;
+export const DEFAULT_SUBAGENT_MODEL = CLAUDE_FIREWORKS_PINNED_DEFAULTS.subagent;
 
 const PROFILE_VERSION = 1;
 const KEY_TYPES = ["fireworks", "firepass"];
@@ -42,11 +55,7 @@ export function defaultClaudeModelMapping(keyType = "fireworks") {
   // Pinning it would write settings.model and shadow the `/model` picker.
   return {
     main: CLAUDE_NATIVE_MODEL_ID,
-    opus: DEFAULT_OPUS_MODEL,
-    sonnet: DEFAULT_SONNET_MODEL,
-    haiku: DEFAULT_HAIKU_MODEL,
-    fable: DEFAULT_FABLE_MODEL,
-    subagent: DEFAULT_SUBAGENT_MODEL,
+    ...CLAUDE_FIREWORKS_PINNED_DEFAULTS,
   };
 }
 
@@ -175,7 +184,12 @@ export function resolveClaudeModelMapping(overrides = {}, keyType = "fireworks")
 }
 
 export function mappingUsesFirerouter(mapping) {
-  return Object.values(mapping).some((modelId) => isFirerouterModel(modelId));
+  return Object.values(mapping).some((modelId) => isFirerouterModelPattern(modelId));
+}
+
+/** Whether any Claude slot is an Anthropic-requiring FireRouter selection. */
+export function mappingRequiresAnthropicKey(mapping) {
+  return Object.values(mapping).some((modelId) => firerouterRequiresAnthropicKey(modelId));
 }
 
 function completeMapping(raw) {

--- a/packages/setup-cli/lib/harnesses/claude/onboarding.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/onboarding.mjs
@@ -42,21 +42,6 @@ function isPinnedMainSlot(modelId) {
   return Boolean(modelId && modelId !== CLAUDE_NATIVE_MODEL_ID);
 }
 
-/**
- * Apply a fast/non-fast mapping without discarding a deliberate `--model` pin.
- *
- * For fw_ keys both mode mappings leave main native, so applying one verbatim
- * would silently clear a pin the user asked for. Fire Pass mappings do pin main
- * (it has no Anthropic fallback) and it is a normal editable row there, so the
- * toggle must update it like every other slot.
- */
-function mappingForMode(target, current) {
-  if (isPinnedMainSlot(target.main) || !isPinnedMainSlot(current.main)) {
-    return { ...target };
-  }
-  return { ...target, main: current.main };
-}
-
 function onboardingSlotOrder(keyType, mapping = null) {
   if (keyType === "firepass") {
     return FIREPASS_SLOT_ORDER;
@@ -73,17 +58,6 @@ const SLOT_INTENT = Object.freeze({
   haiku: "low latency · low cost",
   fable: "lighter general work · vision",
   subagent: "fast · economical tool use",
-});
-
-// Non-fast counterparts of the defaults. Native slots stay native here too, so
-// toggling non-fast never pins a main model or replaces the native Sonnet.
-const STANDARD_MODELS = Object.freeze({
-  main: CLAUDE_NATIVE_MODEL_ID,
-  opus: "glm-latest",
-  sonnet: CLAUDE_NATIVE_MODEL_ID,
-  haiku: "deepseek-v4-pro",
-  fable: "kimi-latest",
-  subagent: "deepseek-v4-pro",
 });
 
 function profileChoiceName(label, detail, output) {
@@ -121,17 +95,6 @@ export function printClaudeModelMapping(mapping, output = process.stdout) {
   output.write("\n");
 }
 
-/**
- * The non-fast profile keeps aliases stable so future model upgrades can move
- * behind the aliases without changing persisted user preferences.
- */
-export function standardClaudeModelMapping(keyType = "fireworks") {
-  if (keyType === "firepass") {
-    return Object.fromEntries(CLAUDE_MODEL_SLOTS.map((slot) => [slot, "glm-latest"]));
-  }
-  return { ...STANDARD_MODELS };
-}
-
 function pickerChoice(model, options, output) {
   const badges = modelPickerBadges(model, options);
   const pricing = model.pricing?.display ?? "";
@@ -152,16 +115,12 @@ async function selectModelForSlot({
   mapping,
   recommended,
   catalog,
-  selectionMode,
   select,
   search,
   input,
   output,
 }) {
-  const compatibleCatalog = selectionMode === "non-fast"
-    ? catalog.filter((model) => !model.fast && !model.firerouter)
-    : catalog;
-  if (compatibleCatalog.length === 0) {
+  if (catalog.length === 0) {
     return null;
   }
   const options = {
@@ -169,8 +128,8 @@ async function selectModelForSlot({
     currentModel: mapping[slot],
     recommendedModel: recommended[slot],
   };
-  const ranked = rankClaudeModelsForSlot(compatibleCatalog, options);
-  const suitable = suitableClaudeModelsForSlot(compatibleCatalog, options);
+  const ranked = rankClaudeModelsForSlot(catalog, options);
+  const suitable = suitableClaudeModelsForSlot(catalog, options);
   const choices = suitable.map((model) => ({
     ...pickerChoice(model, options, output),
     value: { action: "model", model },
@@ -205,8 +164,6 @@ async function selectModelForSlot({
 export async function runClaudeMappingEditor({
   initialMapping,
   recommended,
-  fastMapping = recommended,
-  nonFastMapping,
   baselineLabel = "Recommended",
   slots = ONBOARDING_SLOT_ORDER,
   catalog = null,
@@ -218,17 +175,6 @@ export async function runClaudeMappingEditor({
 }) {
   let mapping = { ...initialMapping };
   let availableCatalog = catalog;
-  const nonFastChangesNothing = slots
-    .every((slot) => fastMapping[slot] === nonFastMapping[slot]);
-  // "Already non-fast" means the mapping the non-fast button would produce, not a
-  // raw comparison against nonFastMapping — otherwise a preserved main pin (which
-  // the toggle keeps) reads as a difference and the header claims fast mode while
-  // every editable slot is already non-fast.
-  const nonFastBaseline = mappingForMode(nonFastMapping, initialMapping);
-  const baselineSelectionMode = CLAUDE_MODEL_SLOTS.every(
-    (slot) => initialMapping[slot] === nonFastBaseline[slot],
-  ) ? "non-fast" : "all";
-  let selectionMode = baselineSelectionMode;
   let focus = slots.length;
   while (true) {
     const changed = CLAUDE_MODEL_SLOTS.some(
@@ -249,15 +195,6 @@ export async function runClaudeMappingEditor({
         value: { action: "save" },
         short: "Save mapping",
       },
-      {
-        name: profileChoiceName(
-          selectionMode === "non-fast" ? "Use fast models" : "Use non-fast models",
-          selectionMode === "non-fast" || nonFastChangesNothing ? "" : "all slots",
-          output,
-        ),
-        value: { action: selectionMode === "non-fast" ? "fast" : "non-fast" },
-        short: selectionMode === "non-fast" ? "Fast models" : "Non-fast models",
-      },
       ...(changed ? [{
         name: profileChoiceName(
           baselineLabel === "Current" ? "Discard edits" : "Reset to recommended",
@@ -269,9 +206,7 @@ export async function runClaudeMappingEditor({
       }] : []),
     ];
     const action = await select({
-      message: selectionMode === "non-fast"
-        ? "Claude model mapping · Non-fast mode · select a row to change it"
-        : "Claude model mapping · select a row to change it",
+      message: "Claude model mapping · select a row to change it",
       choices,
       initialIndex: focus,
       summary: false,
@@ -280,21 +215,8 @@ export async function runClaudeMappingEditor({
     });
     if (!action) return null;
     if (action.action === "save") return mapping;
-    if (action.action === "non-fast") {
-      mapping = mappingForMode(nonFastMapping, mapping);
-      selectionMode = "non-fast";
-      focus = slots.length;
-      continue;
-    }
-    if (action.action === "fast") {
-      mapping = mappingForMode(fastMapping, mapping);
-      selectionMode = "all";
-      focus = slots.length;
-      continue;
-    }
     if (action.action === "reset") {
       mapping = { ...initialMapping };
-      selectionMode = baselineSelectionMode;
       focus = slots.length;
       continue;
     }
@@ -302,9 +224,8 @@ export async function runClaudeMappingEditor({
     const model = await selectModelForSlot({
       slot: action.slot,
       mapping,
-      recommended: selectionMode === "non-fast" ? nonFastMapping : recommended,
+      recommended,
       catalog: availableCatalog,
-      selectionMode,
       select,
       search,
       input,
@@ -323,8 +244,8 @@ export async function runClaudeMappingEditor({
  * mostly-Anthropic mapping is one or two edits away from the same defaults.
  *
  * @param {{
- *   recommended: Record<string, string>,
- *   fastDefaults: Record<string, string>,
+ *   shownMapping: Record<string, string>,
+ *   badgeMapping?: Record<string, string>,
  *   mappingLabel?: "Recommended"|"Current",
  *   keyType?: string,
  *   input?: NodeJS.ReadStream,
@@ -335,8 +256,8 @@ export async function runClaudeMappingEditor({
  * }} args
  */
 export async function runClaudeModelOnboarding({
-  recommended,
-  fastDefaults,
+  shownMapping,
+  badgeMapping = shownMapping,
   mappingLabel = "Recommended",
   keyType = "fireworks",
   input = process.stdin,
@@ -345,22 +266,16 @@ export async function runClaudeModelOnboarding({
   search = promptSearch,
   loadCatalog = async () => [],
 }) {
-  const currentMapping = mappingLabel === "Current";
-  const initialMapping = recommended;
-  const fastMapping = fastDefaults;
-  const nonFastMapping = standardClaudeModelMapping(keyType);
   output.write(`\n${paint(
     ANSI.muted,
     "Set Claude Code model defaults (you can change these later with model flags).",
     output,
   )}\n`);
   return runClaudeMappingEditor({
-    initialMapping,
-    recommended: currentMapping ? fastMapping : initialMapping,
-    fastMapping,
-    nonFastMapping,
+    initialMapping: shownMapping,
+    recommended: badgeMapping,
     baselineLabel: mappingLabel,
-    slots: onboardingSlotOrder(keyType, initialMapping),
+    slots: onboardingSlotOrder(keyType, shownMapping),
     loadCatalog,
     select,
     search,

--- a/packages/setup-cli/lib/harnesses/claude/statusline.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/statusline.mjs
@@ -1,0 +1,520 @@
+/**
+ * Claude Code status line: the Fireworks model actually being routed, plus a
+ * cost computed from Fireworks rates.
+ *
+ * Claude Code's own `cost.total_cost_usd` prices every call against Anthropic's
+ * list, so on a Fireworks gateway it reports a number the user is never billed.
+ * The session transcript records the real model id and token usage per API call,
+ * so the cost here is recomputed from it with the same engine `claude usage`
+ * uses — which prices each call by its own model, and therefore stays correct
+ * across a session that switched slots mid-flight.
+ */
+
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { shellQuote } from "../../cli/path.mjs";
+import {
+  appendLatestRouterSuffix,
+  lookupModelSpec,
+  resolveFireworksModelLabel,
+  specShortIdFromModelRef,
+} from "../../fireworks/model-specs.mjs";
+import { lookupFireworksPricing } from "../../fireworks/pricing.mjs";
+import { providerListPricing } from "../../demo/list-pricing.mjs";
+import { isAnthropicModelId, isAutoModelId, isClaudeNativeModel } from "../../fireworks/model-id.mjs";
+import { autoDisplayName } from "../../fireworks/models.mjs";
+import { UNPRICED_TEXT, addUsage } from "./usage/cost.mjs";
+import {
+  formatUsageCost,
+  formatUsageCachePct,
+} from "./usage/format.mjs";
+
+/** The helper Claude Code spawns on every status line refresh. */
+const STATUSLINE_SCRIPT = fileURLToPath(
+  new URL("../../../bin/claude-statusline.mjs", import.meta.url),
+);
+
+/** Substring that identifies a FireConnect-managed statusLine command. */
+const STATUSLINE_MARKER = "bin/claude-statusline.mjs";
+
+/**
+ * Shell command for the `statusLine.command` field.
+ *
+ * `process.execPath` rather than a bare `node`: Claude Code spawns the status
+ * line through a shell whose PATH may not include the Node that runs the CLI
+ * (same reason apiKeyHelper embeds it — see fireconnectExportCommand).
+ */
+export function claudeStatusLineCommand() {
+  return `${shellQuote(process.execPath)} ${shellQuote(STATUSLINE_SCRIPT)}`;
+}
+
+/**
+ * The `statusLine` block FireConnect writes into settings.json.
+ *
+ * No `refreshInterval`: the cost only changes when a call completes, and Claude
+ * Code already re-runs the command on every assistant message. A timer would
+ * re-read the transcript for an unchanged number.
+ */
+export function claudeStatusLineSettings() {
+  return { type: "command", command: claudeStatusLineCommand() };
+}
+
+/**
+ * True when `statusLine` is one FireConnect wrote (so `on` may replace it and
+ * `off` may remove it). A user's own status line matches nothing here and is
+ * left alone.
+ * @param {unknown} statusLine
+ */
+export function isFireconnectStatusLine(statusLine) {
+  if (!statusLine || typeof statusLine !== "object") {
+    return false;
+  }
+  const command = /** @type {{ command?: unknown }} */ (statusLine).command;
+  return typeof command === "string" && command.includes(STATUSLINE_MARKER);
+}
+
+/**
+ * Add the managed status line, preserving a user's own.
+ * @param {Record<string, unknown>} settings
+ * @returns {Record<string, unknown>}
+ */
+export function withClaudeStatusLine(settings) {
+  if (Object.hasOwn(settings, "statusLine") && !isFireconnectStatusLine(settings.statusLine)) {
+    return settings;
+  }
+  return { ...settings, statusLine: claudeStatusLineSettings() };
+}
+
+/**
+ * Remove the managed status line. Returns `{ settings, changed }` like the
+ * sibling strip helpers in core.mjs so callers don't diff before and after.
+ * @param {Record<string, unknown>} settings
+ * @returns {{ settings: Record<string, unknown>, changed: boolean }}
+ */
+export function stripClaudeStatusLine(settings) {
+  if (!isFireconnectStatusLine(settings?.statusLine)) {
+    return { settings, changed: false };
+  }
+  const next = { ...settings };
+  delete next.statusLine;
+  return { settings: next, changed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+// Raw escapes, not lib/ui/style.mjs: that module disables color when stdout is
+// not a TTY, and a status line's stdout is always a captured pipe. Claude Code
+// renders ANSI from status line output, so color is correct here — NO_COLOR
+// still wins for anyone who sets it. Codes match the live cost meter
+// (lib/ui/palette.mjs METER) so the line reads like `claude usage`.
+//
+// Every sequence MUST carry its `m` terminator. Without it the next character
+// terminates the CSI instead: `\x1b[38;5;141` + "GLM" parses as `\x1b[38;5;141G`
+// (CHA, cursor-move) and eats the "G", while `\x1b[38;5;141` + "█" is an invalid
+// sequence whose parameters leak to the screen as literal `38;5;141` text.
+// Text tokens. Values, labels and legends wear these — never a series color.
+//
+// Both are relative to the terminal's own foreground rather than fixed values:
+// `primary` is the default foreground (\x1b[39m) and `secondary` is that same
+// foreground faint (\x1b[2m). A status line has no say over the surface it
+// lands on — a hardcoded light grey is legible on a dark theme and washes out
+// on a light one — so de-emphasis has to be expressed as a modifier, not a
+// colour. (The series hues below are different: they are marks, not text, and
+// they are validated for contrast.)
+const COLOR = process.env.NO_COLOR ? null : {
+  bold: "\x1b[1m",
+  primary: "\x1b[39m",
+  secondary: "\x1b[2m\x1b[39m",
+  reset: "\x1b[0m",
+};
+
+// Categorical series hues, assigned in fixed order by share rank and never
+// cycled. These are the validated dark-mode steps: every check passes against
+// the dark surface (lightness band, chroma floor, CVD separation, normal-vision
+// floor, 3:1 contrast), with worst adjacent CVD ΔE 8.4 across all eight.
+//
+// Truecolor rather than 256-color so the rendered value is the validated one.
+// They carry identity ONLY — as bar segments and legend swatches. Text beside
+// them stays in the tokens above, which is what keeps the line calm.
+const SERIES_COLORS = Object.freeze([
+  "\x1b[38;2;57;135;229m", // #3987e5 blue
+  "\x1b[38;2;217;89;38m", // #d95926 orange
+  "\x1b[38;2;25;158;112m", // #199e70 aqua
+  "\x1b[38;2;201;133;0m", // #c98500 yellow
+  "\x1b[38;2;213;81;129m", // #d55181 magenta
+  "\x1b[38;2;0;131;0m", // #008300 green
+  "\x1b[38;2;144;133;233m", // #9085e9 violet
+  "\x1b[38;2;230;103;103m", // #e66767 red
+]);
+
+/** @param {keyof typeof COLOR} name @param {string} text */
+function paint(name, text) {
+  return COLOR ? `${COLOR[name]}${text}${COLOR.reset}` : String(text);
+}
+
+/** A mark in a series hue — bar segment or legend swatch, never prose. */
+function paintSeries(index, mark) {
+  if (!COLOR) {
+    return String(mark);
+  }
+  return `${SERIES_COLORS[index % SERIES_COLORS.length]}${mark}${COLOR.reset}`;
+}
+
+function sep() {
+  return paint("secondary", "·");
+}
+
+/** Join non-empty parts with the dim separator. */
+function joinParts(parts) {
+  return parts.filter(Boolean).join(` ${sep()} `);
+}
+
+/**
+ * The bar's fill glyph, doubling as the legend swatch so a legend entry reads as
+ * a piece of the bar. Heavy horizontal rule (U+2501): unambiguous single-column
+ * width in every terminal, unlike the square/circle glyphs legends usually use,
+ * which are East-Asian-ambiguous and can render double-wide and misalign.
+ */
+const BAR_MARK = "━";
+
+/**
+ * One multi-color stacked bar showing each backend model's share of the
+ * session's SPEND, encoded purely as segment width.
+ *
+ * Cost, not call count: the line exists to answer "where is the money going",
+ * and those two answers diverge hard on a router — a model can take 47% of the
+ * calls and 89% of the bill. Drawing calls put the less important dimension in
+ * the most prominent position, and left the bar disagreeing with the legend
+ * beneath it, which states cost.
+ *
+ * Deliberately textless. The legend already carries a percentage per model
+ * (cache hit), and printing a share inside the segments put two unrelated kinds
+ * of `%` side by side — the reader had to work out which was which. Width
+ * answers "how much of the spend" at a glance, and the legend lists the models
+ * in the same order with the exact dollars.
+ *
+ * @param {Array<{ label: string, costShare: number }>} models largest first
+ * @param {number} width total bar width in cells
+ * @returns {string}
+ */
+function renderModelBar(models, width) {
+  if (models.length === 0) {
+    return "";
+  }
+  // One blank cell between segments — the terminal's version of the surface gap
+  // a stacked chart puts between fills. It separates neighbours without relying
+  // on hue alone, which matters for colorblind readers and for the two segments
+  // whose adjacent CVD separation is closest to the floor.
+  const gaps = models.length - 1;
+  const inkWidth = Math.max(models.length, width - gaps);
+  // Min one cell: a model that cost a rounding error still ran, and a segment
+  // that vanishes reads as "this model was not used".
+  const widths = models.map((m) => Math.max(1, Math.round(m.costShare * inkWidth)));
+  // Rounding drift: hand the remainder to the largest segment so the bar always
+  // occupies exactly the width it was given.
+  const drift = inkWidth - widths.reduce((sum, w) => sum + w, 0);
+  if (drift !== 0) {
+    widths[0] = Math.max(1, widths[0] + drift);
+  }
+  return models
+    // A thin rule, not a filled block: the bar is chrome, and a slab of
+    // saturated color out-shouts the numbers it exists to introduce.
+    .map((model, index) => paintSeries(index, BAR_MARK.repeat(widths[index])))
+    .join(" ");
+}
+
+function stripViaFireworks(label) {
+  return String(label).replace(/ via Fireworks$/i, "");
+}
+
+/**
+ * Tighten a model label for the bar and legend.
+ *
+ * Catalog labels carry qualifiers that earn their place in a picker but not in a
+ * status line: `DeepSeek V4 Flash (0731)` and `GLM 5.2 Fast (Latest)` cost ~9
+ * columns apiece to say something the line does not turn on. With three models
+ * plus the metrics, that overflow is what gets truncated away. The base name is
+ * enough to tell the segments apart.
+ *
+ * @param {string} label
+ * @returns {string}
+ */
+function compactModelLabel(label) {
+  return String(label).replace(/\s*\([^)]*\)\s*$/, "").trim() || String(label);
+}
+
+/**
+ * Human label for the routed model.
+ *
+ * Mirrors `fireworksModelPickerName` (core.mjs) rather than importing it: the
+ * status line runs on every assistant message, so it stays off core.mjs's
+ * dependency graph. Live catalog label first, then static spec, then pricing
+ * table, then the bare slug.
+ *
+ * @param {string} modelId
+ * @returns {string}
+ */
+export function claudeStatusLineModelLabel(modelId) {
+  const id = String(modelId ?? "").trim();
+  if (!id) {
+    return "unknown model";
+  }
+  if (isAutoModelId(id)) {
+    return autoDisplayName(id);
+  }
+  const live = resolveFireworksModelLabel(id);
+  if (live) {
+    return stripViaFireworks(live);
+  }
+  const spec = lookupModelSpec(id);
+  if (spec?.label) {
+    return stripViaFireworks(appendLatestRouterSuffix(id, spec.label));
+  }
+  const pricing = lookupFireworksPricing(id);
+  if (pricing?.label) {
+    return stripViaFireworks(appendLatestRouterSuffix(id, pricing.label));
+  }
+  // A native Anthropic model (a slot left on Claude's own default): label it
+  // from the list-price table rather than printing the bare slug.
+  if (isAnthropicModelId(id)) {
+    const anthropic = providerListPricing({ provider: "anthropic", modelId: id });
+    if (anthropic?.label && !anthropic.estimated) {
+      return anthropic.label;
+    }
+  }
+  // An id we have no metadata for — the bare slug, minus the Claude Code-only
+  // [1m] tag.
+  return specShortIdFromModelRef(id) || id;
+}
+
+async function isFile(filePath) {
+  try {
+    return (await stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fireworks-accurate usage for the session, including its subagents.
+ *
+ * Returns null when there is nothing to report yet (no transcript on a fresh
+ * session) so the caller can omit those fields instead of claiming $0.00.
+ *
+ * `lastModel` is the real backend model the gateway selected for the most
+ * recent parent call — the transcript records it per assistant turn, so a
+ * FireRouter session surfaces the model that actually served the last turn
+ * (e.g. `accounts/fireworks/models/glm-5p2` or `claude-opus-5`), not the
+ * `firerouter` alias the slot is pinned to.
+ *
+ * `models` is the per-backend breakdown of every billed call in the session,
+ * subagents included — each entry `{ label, share, calls, cost }`, largest share
+ * first — so the status line can draw one multi-color bar and attribute spend
+ * per model instead of naming only the latest one. That split is the point: a
+ * router sending 40% of calls to a frontier model can put 95% of the bill there,
+ * which a single total hides. FireRouter routes per call and a `/model` switch
+ * changes the slot mid-session, so a session can span several backends.
+ *
+ * In a fully priced session the per-model costs reconcile with `cost`. If any
+ * call is unpriced the headline is `cost n/a`; known per-model costs remain in
+ * the legend, and the bar switches from spend share to call share.
+ *
+ * @param {string} transcriptPath
+ * @param {{ home?: string }} [opts]
+ * @returns {Promise<{ cost: number, estimated: boolean, lastModel: string, models: Array<{ label: string, share: number, calls: number, cost: number }>, cachePct: string } | null>}
+ */
+export async function claudeStatusLineUsage(transcriptPath, { home = process.env.HOME ?? "" } = {}) {
+  const target = String(transcriptPath ?? "").trim();
+  // Guard before calling readClaudeUsage: given a path that does not exist it
+  // falls back to scanning every .jsonl under ~/.claude, which is far too much
+  // work for a status line (and would price the wrong session).
+  if (!target || !path.isAbsolute(target) || !await isFile(target)) {
+    return null;
+  }
+  // Imported here, not at module scope: core.mjs pulls this module in on every
+  // `claude on` for the settings helpers alone, and the cost engine's dependency
+  // graph (pricing tables, catalog cache) is only needed when a status line is
+  // actually being rendered.
+  const { readClaudeUsage } = await import("./usage/report.mjs");
+  const report = await readClaudeUsage({ home, session: target });
+  // `lastModel` tracks the MAIN thread only: it answers "what is serving me
+  // right now", which a subagent's model does not.
+  const lastModel = report.rows.at(-1)?.model ?? "";
+  // The breakdown, however, must cover every billed call — subagents included.
+  // `grandTotals.cost` (the headline) sums parent + subagents, so tallying only
+  // parent rows would leave the legend short of the total and silently orphan
+  // the subagents' spend.
+  const allRows = [
+    ...report.rows,
+    ...(report.subagents ?? []).flatMap((subagent) => subagent.rows),
+  ];
+  // Claude Code creates the transcript before the first API call — it opens with
+  // user and metadata lines. Existing-but-callless is still "nothing to price",
+  // so return null rather than a zero-cost report the caller would render as
+  // `$0.00` and pass off as a free session.
+  if (allRows.length === 0) {
+    return null;
+  }
+  // Tally per backend, distinct by normalized short id so
+  // `accounts/fireworks/models/glm-5p2` and a bare `glm-5p2` are one model.
+  // The token buckets mirror the live meter's per-model Tally (meter-model.mjs):
+  // uncached input, cache reads, and both Anthropic cache-write TTLs summed —
+  // so the cache figure here is computed from the same inputs by the same
+  // helpers the meter's `cache%` column uses.
+  /** @type {Map<string, { calls: number, cost: number | null, input: number, cacheRead: number, cacheWrite5m: number, cacheWrite1h: number }>} */
+  const byModel = new Map();
+  for (const row of allRows) {
+    const sid = specShortIdFromModelRef(row.model);
+    if (!sid) continue;
+    const entry = byModel.get(sid)
+      ?? {
+        calls: 0,
+        cost: 0,
+        input: 0,
+        cacheRead: 0,
+        cacheWrite5m: 0,
+        cacheWrite1h: 0,
+      };
+    byModel.set(sid, {
+      ...entry,
+      ...addUsage(entry, row),
+      calls: entry.calls + 1,
+    });
+  }
+  const totalCalls = allRows.length || 1;
+  const modelTallies = [...byModel.values()];
+  const hasUnpriced = modelTallies.some((entry) => entry.cost == null);
+  const totalCost = modelTallies.reduce((sum, entry) => sum + (entry.cost ?? 0), 0);
+  const models = [...byModel.entries()]
+    // Spend share is undefined if even one model is unpriced. In that case every
+    // segment uses the same call-share denominator instead of combining priced
+    // spend share with unpriced call share (fractions that can sum above 100%).
+    .sort((a, b) => (
+      hasUnpriced
+        ? b[1].calls - a[1].calls
+        : (b[1].cost ?? 0) - (a[1].cost ?? 0) || b[1].calls - a[1].calls
+    ))
+    .map(([sid, entry]) => ({
+      label: claudeStatusLineModelLabel(sid),
+      // A fully-priced nonzero session draws spend share. A free or partly
+      // unpriced session draws call share for every segment.
+      costShare: !hasUnpriced && totalCost > 0
+        ? entry.cost / totalCost
+        : entry.calls / totalCalls,
+      share: entry.calls / totalCalls,
+      calls: entry.calls,
+      cost: entry.cost,
+      // Same function the session figure uses, and the same ratio+rounding the
+      // meter applies per row — a 99.85%-cached model must not read "100%".
+      cachePct: formatUsageCachePct(entry),
+    }));
+  return {
+    cost: report.grandTotals.cost,
+    estimated: report.estimated,
+    lastModel,
+    models,
+    // `formatUsageCachePct` returns "—" before the first prompt has any cached
+    // tokens; the caller drops the field in that case.
+    cachePct: formatUsageCachePct(report.grandTotals),
+  };
+}
+
+// Bar width in cells. Fixed rather than COLUMNS-adaptive so the line layout is
+// predictable and the cost always fits beside it on line 1. Kept modest so the
+// legend + metrics on line 2 stay within a typical status-line width.
+const MODEL_BAR_WIDTH = 16;
+
+/**
+ * Build the status line text from Claude Code's stdin payload.
+ *
+ * Two lines:
+ *   <textless spend-share bar> · <session total>
+ *   <swatch> <model> <its cost> <its cache>% cache   (repeated per backend)
+ *
+ * Every number carries its unit: `$` for money, an explicit `% cache` for hit
+ * rate. Spend share is the one figure left unlabeled, so it is shown only as bar
+ * width — a bare percentage next to a bare percentage meaning something else is
+ * what made an earlier version unreadable, and the exact dollars sit in the
+ * legend directly beneath. Before the first call lands there is no transcript to
+ * break down, so line 1 falls back to the slot alias and the bar is omitted.
+ * Never more than two lines.
+ *
+ * @param {{
+ *   model?: { id?: string, display_name?: string },
+ *   transcript_path?: string,
+ * }} input
+ * @param {{ home?: string }} [opts]
+ * @returns {Promise<string>}
+ */
+export async function renderClaudeStatusLine(input = {}, { home = process.env.HOME ?? "" } = {}) {
+  const slotModelId = input.model?.id ?? "";
+  // The `claude-default` sentinel is FireConnect's own marker for an unpinned
+  // native slot; Claude Code never sends it as a model id, so prefer whatever
+  // display name it did send. Everything else — Fireworks routers, real
+  // Anthropic ids, unknown ids — resolves through the label helper.
+  const slotLabel = isClaudeNativeModel(slotModelId)
+    ? (input.model?.display_name || "Claude default")
+    : claudeStatusLineModelLabel(slotModelId);
+
+  let usage = null;
+  try {
+    usage = await claudeStatusLineUsage(input.transcript_path ?? "", { home });
+  } catch {
+    // An unreadable or half-written transcript must not blank the status line.
+    usage = null;
+  }
+
+  const multi = (usage?.models.length ?? 0) > 1;
+
+  // Line 1: the model bar (or the slot alias before any call lands) + cost.
+  const bar = usage?.models.length
+    ? renderModelBar(usage.models, MODEL_BAR_WIDTH)
+    : "";
+  // No context-window figure here on purpose. Every other number on this line is
+  // one only FireConnect can give you — the real backend model, cost at
+  // Fireworks rates, per-model cache. Context usage is a value Claude Code
+  // hands us and already surfaces itself (`/context`, auto-compact warnings), so
+  // echoing it spent columns to repeat someone else's number and blurred what
+  // the line is for.
+  const line1 = joinParts([
+    bar || paint("secondary", slotLabel),
+    // The session total is the headline number: primary ink, bold. Colour is
+    // spent on identity (which model), never on emphasis.
+    //
+    // A null total means some call in the session has no rate we can look up, so
+    // there is no honest number to print: it reads `cost n/a` rather than a
+    // figure that would silently exclude those calls. The `~` estimate marker
+    // has nothing to qualify in that case.
+    usage && (usage.cost == null
+      ? paint("secondary", `cost ${UNPRICED_TEXT}`)
+      : `${usage.estimated ? "~" : ""}${COLOR ? COLOR.bold : ""}${paint("primary", formatUsageCost(usage.cost))}`),
+  ]);
+
+  // Line 2: one entry per backend — `<swatch> <model> <its cost> <its cache>`.
+  // Every figure is labeled, including a repeated `cache` on each entry: the
+  // repetition costs columns but leaves nothing to infer. Per-model spend is the
+  // fact a single total hides (47% of calls can be 89% of the bill).
+  //
+  // Only the swatch is coloured. Painting the whole entry in its series hue —
+  // name, cost AND cache — turned the line into three bands of saturated text
+  // competing with each other; identity belongs on a mark, and the numbers read
+  // far better in one consistent ink.
+  const legend = usage?.models.map((m, index) => {
+    // A single-model session needs no per-model cost: it equals the total
+    // already shown on line 1.
+    const label = compactModelLabel(m.label);
+    const cache = m.cachePct && m.cachePct !== "—" ? ` ${m.cachePct} cache` : "";
+    const text = multi
+      ? `${label} ${formatUsageCost(m.cost)}${cache}`
+      : `${label}${cache}`;
+    return `${paintSeries(index, BAR_MARK)} ${paint("primary", text)}`;
+  }) ?? [];
+  const line2 = joinParts(legend);
+
+  return [line1, line2].filter(Boolean).join("\n");
+}

--- a/packages/setup-cli/lib/harnesses/claude/upgrade-migrations.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/upgrade-migrations.mjs
@@ -1,0 +1,42 @@
+import { isEnabledFireworksHarness, readGlobalConfig } from "../../config/global-config.mjs";
+import { HARNESS } from "../../harness/id.mjs";
+import { readJsonIfExists, writeJson } from "../../io/json.mjs";
+import { CLAUDE_CODE_BEHAVIOR_ENV, providerStatusFromEnv, userSettingsPath } from "./core.mjs";
+
+/**
+ * Add `ENABLE_TOOL_SEARCH` to an already-connected Claude Code install.
+ * Installs connected before this key existed route to the Fireworks gateway
+ * without it, and Claude Code turns MCP tool search off for a non-first-party
+ * `ANTHROPIC_BASE_URL` unless it is set.
+ *
+ * Owns every gate: the harness must be enabled and Fireworks-routed, settings
+ * must already point at Fireworks, and an existing value (including a user's
+ * `false` / `auto:N`) is left alone.
+ * @param {string} home
+ * @returns {Promise<boolean>} true when the file was updated
+ */
+export async function migrateClaudeToolSearchOnUpgrade(home) {
+  if (!home) {
+    return false;
+  }
+  const { harnesses } = await readGlobalConfig(home);
+  if (!isEnabledFireworksHarness(harnesses, HARNESS.CLAUDE)) {
+    return false;
+  }
+  const settingsPath = userSettingsPath(home);
+  const settings = await readJsonIfExists(settingsPath);
+  const env = settings.env ?? {};
+  if (providerStatusFromEnv(env) !== "fireworks" || Object.hasOwn(env, "ENABLE_TOOL_SEARCH")) {
+    return false;
+  }
+  await writeJson(
+    settingsPath,
+    {
+      ...settings,
+      env: { ...env, ENABLE_TOOL_SEARCH: CLAUDE_CODE_BEHAVIOR_ENV.ENABLE_TOOL_SEARCH },
+    },
+    // Managed settings hold the baked Fireworks key.
+    { mode: 0o600 },
+  );
+  return true;
+}

--- a/packages/setup-cli/lib/harnesses/claude/usage/README.md
+++ b/packages/setup-cli/lib/harnesses/claude/usage/README.md
@@ -15,9 +15,12 @@ The harness (`../index.mjs`) uses two, depending on the flags:
 
 **Shared**
 
-- `report.mjs` — parses session JSONL and prices it. `computeClaudeUsageCost`
-  lives here and is the only place cost is computed, so the live meter and the
-  one-shot snapshot cannot disagree.
+- `pricing.mjs` — canonical provider-rate lookup and call pricing. Snapshot,
+  live meter, statusline, and demo all call `computeClaudeUsageCost` here.
+- `cost.mjs` — nullable cost representation (`null` means unavailable) and
+  null-propagating total arithmetic.
+- `report.mjs` — parses session JSONL, aggregates priced rows, and orchestrates
+  snapshot output.
 - `format.mjs` — cost and cache-percentage strings shared by the meter and both
   pickers.
 - `agents.mjs` — discovers subagent logs and labels them from the `.meta.json`

--- a/packages/setup-cli/lib/harnesses/claude/usage/agent-picker.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/agent-picker.mjs
@@ -17,7 +17,8 @@ import {
   listSessionAgents,
 } from "./agents.mjs";
 import { agentPaneWorthShowing } from "./meter.mjs";
-import { formatLiveCostTotal } from "./format.mjs";
+import { formatUsageCost } from "./format.mjs";
+import { COST_COL } from "./meter-layout.mjs";
 
 /** Returned when ←/Esc should resume the previous live meter without switching. */
 export const CLAUDE_USAGE_AGENT_RESUME = Object.freeze({ resume: true });
@@ -47,8 +48,10 @@ export function formatClaudeUsageAgentChoice(agent, opts = {}) {
   const active = opts.active !== false;
 
   const totals = agent.report?.totals ?? {};
-  // An agent's spend is a total, so 2 decimals.
-  const costText = formatLiveCostTotal(totals.cost ?? 0).padStart(8);
+  // Preserve null: it means at least one call has no rate, not a free agent.
+  const costText = formatUsageCost(
+    totals.cost === undefined ? 0 : totals.cost,
+  ).padStart(COST_COL);
   const cacheText = formatUsageCachePct(totals).padStart(4);
   const callsText = String(agent.report?.requests ?? 0).padStart(3);
 

--- a/packages/setup-cli/lib/harnesses/claude/usage/cost.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/cost.mjs
@@ -1,0 +1,65 @@
+/** Shared representation and aggregation for nullable usage costs. */
+
+/** Cost cell for a call whose model has no rate we can look up. */
+export const UNPRICED_TEXT = "n/a";
+
+/**
+ * Add two costs where either may be unknown.
+ *
+ * A total containing an unpriceable call is itself unknown. Null therefore
+ * wins; treating it as zero would silently understate the total.
+ *
+ * @param {number | null} a
+ * @param {number | null} b
+ * @returns {number | null}
+ */
+export function addCost(a, b) {
+  return a == null || b == null ? null : a + b;
+}
+
+/** @param {Array<number | null>} costs @returns {number | null} */
+export function sumCosts(costs) {
+  return costs.reduce(addCost, 0);
+}
+
+/** New zero-valued usage totals. */
+export function emptyUsage() {
+  return {
+    input: 0,
+    cacheWrite5m: 0,
+    cacheWrite1h: 0,
+    cacheRead: 0,
+    output: 0,
+    webSearches: 0,
+    cost: 0,
+  };
+}
+
+function numberOrZero(value) {
+  return Number.isFinite(value) ? value : 0;
+}
+
+function costOrZero(value) {
+  return value === undefined ? 0 : value;
+}
+
+/**
+ * Add the numeric usage fields shared by calls, model tallies, and reports.
+ * Metadata on either operand is intentionally ignored.
+ */
+export function addUsage(a, b) {
+  return {
+    input: numberOrZero(a?.input) + numberOrZero(b?.input),
+    cacheWrite5m: numberOrZero(a?.cacheWrite5m) + numberOrZero(b?.cacheWrite5m),
+    cacheWrite1h: numberOrZero(a?.cacheWrite1h) + numberOrZero(b?.cacheWrite1h),
+    cacheRead: numberOrZero(a?.cacheRead) + numberOrZero(b?.cacheRead),
+    output: numberOrZero(a?.output) + numberOrZero(b?.output),
+    webSearches: numberOrZero(a?.webSearches) + numberOrZero(b?.webSearches),
+    cost: addCost(costOrZero(a?.cost), costOrZero(b?.cost)),
+  };
+}
+
+/** @param {object[]} items */
+export function sumUsage(items) {
+  return items.reduce(addUsage, emptyUsage());
+}

--- a/packages/setup-cli/lib/harnesses/claude/usage/display.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/display.mjs
@@ -2,6 +2,12 @@ import process, { stdin, stdout } from "node:process";
 import path from "node:path";
 import { colorEnabled, bold, accent } from "../../../ui/term.mjs";
 import { ANSI } from "../../../ui/palette.mjs";
+import {
+  UNPRICED_TEXT,
+  addUsage,
+  sumUsage,
+} from "./cost.mjs";
+import { usageCostDigits } from "./format.mjs";
 
 const ANTHROPIC_PRICING_DOCS_URL = "https://platform.claude.com/docs/en/about-claude/pricing";
 
@@ -23,6 +29,7 @@ const CLEAR_LINE = ANSI.clearLine;
 const ANSI_PATTERN = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const PENDING_ESCAPE_MS = 25;
 const FALLBACK_PRICING_NOTE = "Some rows used fallback pricing for unrecognized model ids.";
+const UNPRICED_NOTE = `Some calls have no rate available; their cost reads ${UNPRICED_TEXT} and is left out of totals.`;
 
 export function formatCostEstimateNote() {
   return [
@@ -89,9 +96,10 @@ function wrapPlainLine(text, width) {
   return wrapped;
 }
 
-function formatInteractiveEstimateNote(width, stream = stdout, { estimated = false } = {}) {
+function formatInteractiveEstimateNote(width, stream = stdout, { estimated = false, unpriced = 0 } = {}) {
   const lines = formatCostEstimateNote();
   if (estimated) lines.push(FALLBACK_PRICING_NOTE);
+  if (unpriced) lines.push(UNPRICED_NOTE);
   return lines
     .flatMap((line) => wrapPlainLine(line, width))
     .map((line) => dim(line, stream));
@@ -112,14 +120,18 @@ function fmtCompact(value) {
   return fmtInt(value);
 }
 
+// An unpriced call has `cost: null` (see report.mjs) — a rate we could not look
+// up, not a free call — so every cost cell here renders it as `n/a` and every
+// total that contains one is null too.
 function fmtCost(value) {
-  return value < 0.01
-    ? value.toFixed(4).replace(/0+$/, "").replace(/\.$/, "")
-    : value.toFixed(2);
+  if (value == null) {
+    return UNPRICED_TEXT;
+  }
+  return usageCostDigits(value);
 }
 
 function fmtCostUsd(value) {
-  return `$${fmtCost(value)}`;
+  return value == null ? UNPRICED_TEXT : `$${fmtCost(value)}`;
 }
 
 function displayModelName(model) {
@@ -219,12 +231,11 @@ function summarizeRows(report) {
       cacheRead: 0,
       cost: 0,
     };
-    current.calls += 1;
-    current.input += row.input;
-    current.output += row.output;
-    current.cacheRead += row.cacheRead;
-    current.cost += row.cost;
-    byModelAndAgent.set(key, current);
+    byModelAndAgent.set(key, {
+      ...current,
+      ...addUsage(current, row),
+      calls: current.calls + 1,
+    });
   };
 
   for (const row of report.rows) ingest(row);
@@ -247,15 +258,14 @@ function aggregateModels(reports) {
         cacheRead: 0,
         cost: 0,
       };
-      current.calls += row.calls;
-      current.input += row.input;
-      current.output += row.output;
-      current.cacheRead += row.cacheRead;
-      current.cost += row.cost;
-      byModel.set(row.model, current);
+      byModel.set(row.model, {
+        ...current,
+        ...addUsage(current, row),
+        calls: current.calls + row.calls,
+      });
     }
   }
-  return [...byModel.values()].sort((a, b) => b.cost - a.cost || a.displayModel.localeCompare(b.displayModel));
+  return [...byModel.values()].sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0) || a.displayModel.localeCompare(b.displayModel));
 }
 
 function formatHero({ totals, calls, sessions }, width, stream = stdout) {
@@ -336,7 +346,9 @@ function formatSessionSummaryRow(report, maxCost, totalCost, width, stream = std
 }
 
 function formatInteractiveSessionRow({ report, maxCost, totalCost, width, selected, expanded }, stream = stdout) {
-  const costWidth = 8;
+  // 9, like every other cost column: four decimals make `$116.9562` the widest
+  // realistic cell, and a narrower slot would push the bar out of alignment.
+  const costWidth = 9;
   const percentWidth = 5;
   const marker = dim(expanded ? "▾" : "▸", stream);
   const reserved = 2 + 1 + costWidth + 1 + 4 + 1 + percentWidth;
@@ -422,14 +434,7 @@ function clamp(value, min, max) {
 }
 
 function totalsForRequestItems(items) {
-  return items.reduce((totals, item) => ({
-    input: totals.input + (item.row.input ?? 0),
-    cacheWrite5m: totals.cacheWrite5m + (item.row.cacheWrite5m ?? 0),
-    cacheWrite1h: totals.cacheWrite1h + (item.row.cacheWrite1h ?? 0),
-    cacheRead: totals.cacheRead + (item.row.cacheRead ?? 0),
-    output: totals.output + (item.row.output ?? 0),
-    cost: totals.cost + (item.row.cost ?? 0),
-  }), { input: 0, cacheWrite5m: 0, cacheWrite1h: 0, cacheRead: 0, output: 0, cost: 0 });
+  return sumUsage(items.map((item) => item.row));
 }
 
 function sourceModelRows(report) {
@@ -448,14 +453,11 @@ function sourceModelRows(report) {
       output: 0,
       cost: 0,
     };
-    current.calls += 1;
-    current.input += row.input;
-    current.cacheWrite5m += row.cacheWrite5m ?? 0;
-    current.cacheWrite1h += row.cacheWrite1h ?? 0;
-    current.cacheRead += row.cacheRead ?? 0;
-    current.output += row.output;
-    current.cost += row.cost;
-    bySourceAndModel.set(key, current);
+    bySourceAndModel.set(key, {
+      ...current,
+      ...addUsage(current, row),
+      calls: current.calls + 1,
+    });
   };
 
   for (const row of report.rows) ingest("parent", row);
@@ -566,6 +568,7 @@ function usageGroupFromInput(input) {
     totals,
     calls,
     estimated: input?.estimated ?? false,
+    unpriced: input?.unpriced ?? 0,
   };
 }
 
@@ -602,7 +605,7 @@ function layerTableLimit(input, state, stream = stdout) {
 
   const width = lineWidth(stream);
   const heroRows = formatHero({ totals: group.totals, calls: group.calls, sessions: sessions.length }, width, stream).length;
-  const estimateRows = formatInteractiveEstimateNote(width, stream, { estimated: group.estimated }).length;
+  const estimateRows = formatInteractiveEstimateNote(width, stream, { estimated: group.estimated, unpriced: group.unpriced }).length;
   const modelRows = formatInteractiveModelBreakdown(report, width, stream).length;
   const nameRows = formatSessionNameLines(report, width, stream).length > 0 ? 2 : 0;
   const fixedRows = 1 + 1 + estimateRows + 1 + heroRows + 1 + 1 + 1
@@ -627,7 +630,7 @@ export function formatClaudeUsageInteractiveFrame(input, state = {}, { stream = 
   const lines = [
     dim(title, stream),
     "",
-    ...formatInteractiveEstimateNote(width, stream, { estimated: group.estimated }),
+    ...formatInteractiveEstimateNote(width, stream, { estimated: group.estimated, unpriced: group.unpriced }),
     "",
     ...formatHero({ totals: group.totals, calls: group.calls, sessions: sessions.length }, width, stream),
     "",
@@ -980,7 +983,7 @@ export async function runClaudeUsageInteractiveDisplay(input, { stdin: in_ = std
   return true;
 }
 
-function formatEstimateFooter({ estimated }, stream = stdout) {
+function formatEstimateFooter({ estimated, unpriced = 0 }, stream = stdout) {
   const lines = [
     "",
     ...formatCostEstimateNote().map((line) => dim(line, stream)),
@@ -988,6 +991,9 @@ function formatEstimateFooter({ estimated }, stream = stdout) {
   ];
   if (estimated) {
     lines.push(dim(FALLBACK_PRICING_NOTE, stream));
+  }
+  if (unpriced) {
+    lines.push(dim(UNPRICED_NOTE, stream));
   }
   return lines;
 }
@@ -1013,7 +1019,7 @@ function formatSessionDetail(report, title, width, stream = stdout) {
   return lines;
 }
 
-function formatSummary({ sessions, totals, calls, estimated }, stream = stdout) {
+function formatSummary({ sessions, totals, calls, estimated, unpriced = 0 }, stream = stdout) {
   const width = lineWidth(stream);
   const lines = [];
   const hasNames = sessions.some((report) => Boolean(sessionName(report)));
@@ -1045,7 +1051,7 @@ function formatSummary({ sessions, totals, calls, estimated }, stream = stdout) 
     }
   }
 
-  lines.push(...formatEstimateFooter({ estimated }, stream));
+  lines.push(...formatEstimateFooter({ estimated, unpriced }, stream));
   return lines.join("\n");
 }
 
@@ -1086,6 +1092,7 @@ export function formatClaudeUsageSummaryDisplay(report, { stream = stdout } = {}
     totals: report.grandTotals,
     calls: report.grandRequests,
     estimated: report.estimated,
+    unpriced: report.unpriced,
   }, stream);
 }
 
@@ -1097,5 +1104,6 @@ export function formatClaudeUsageReportsSummaryDisplay(reportGroup, { stream = s
     totals: reportGroup.grandTotals,
     calls: reportGroup.grandRequests,
     estimated: reportGroup.estimated,
+    unpriced: reportGroup.unpriced,
   }, stream);
 }

--- a/packages/setup-cli/lib/harnesses/claude/usage/format.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/format.mjs
@@ -3,38 +3,53 @@
  * Matches the meter’s cost columns and cache-hit share (PR #230).
  */
 
+import { UNPRICED_TEXT } from "./cost.mjs";
+
 /**
- * A single call's cost, at 4 decimals.
+ * Digits for a cost, without a currency sign: always four decimals.
  *
- * A cheap GLM call really is worth $0.0018, so rounding to cents would erase the
- * row entirely. Only per-call figures want this precision — see
- * `formatLiveCostTotal` for anything summed.
+ * Two decimals is the wrong scale for this product. At Fireworks rates a whole
+ * session is routinely worth less than a cent, so the digits that carry the
+ * information sit past the cents column: $0.006891 quoted as `$0.01` is 45%
+ * high, and $0.075436 as `$0.08` is 6% high. Four decimals hold the error under
+ * a hundredth of a cent at every magnitude, and the fixed width keeps a column
+ * of costs aligned without any trimming rules.
+ *
+ * Three outcomes are deliberately distinct, because they mean different things:
+ * exactly `0` is free and reads `0` with no decimals to imply a measurement;
+ * a positive amount too small for four decimals reads as an exponent
+ * (`4.0e-5`), never `0`, because that call did cost something; everything else
+ * reads at four decimals.
  *
  * @param {number} cost
  * @returns {string}
  */
-export function formatLiveCost(cost) {
-  if (!Number.isFinite(cost) || cost <= 0) return "$0.0000";
-  if (cost < 0.0001) return `$${cost.toExponential(1)}`;
-  return `$${cost.toFixed(4)}`;
+export function usageCostDigits(cost) {
+  if (cost <= 0) return "0";
+  return cost < 0.0001 ? cost.toExponential(1) : cost.toFixed(4);
 }
 
 /**
- * A summed cost, at 2 decimals — the precision you'd actually quote.
+ * A cost with its currency sign — one call, one model, or a whole session.
  *
- * Nobody reads the fourth decimal of a $116.9562 session; the extra digits just
- * make a column of totals harder to scan. But a real charge must not round to
- * nothing, so anything under half a cent reads `<$0.01` instead of `$0.00` —
- * a subagent that cost $0.0072 did cost something.
+ * One function for all three on purpose: a single-call session's total has to
+ * read exactly like the call it sums, and the live meter, the status line, the
+ * pickers and the `claude usage` report all quote the same figures. Splitting
+ * "per call" from "per total" is what let those surfaces disagree, with the
+ * report printing $0.0069 where the status line printed $0.01.
  *
- * @param {number} cost
+ * `null` means no rate could be looked up. That reads `n/a`, never `$0`: a call
+ * we cannot price is not a free call. A free call is `$0`, matching the demo's
+ * `formatUsd`.
+ *
+ * @param {number | null} cost
  * @returns {string}
  */
-export function formatLiveCostTotal(cost) {
+export function formatUsageCost(cost) {
+  if (cost == null) return UNPRICED_TEXT;
   const n = Number(cost);
-  if (!Number.isFinite(n) || n <= 0) return "$0.00";
-  if (n < 0.005) return "<$0.01";
-  return `$${n.toFixed(2)}`;
+  if (!Number.isFinite(n)) return "$0";
+  return `$${usageCostDigits(n)}`;
 }
 
 /**

--- a/packages/setup-cli/lib/harnesses/claude/usage/live.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/live.mjs
@@ -16,9 +16,46 @@ import {
   promptClaudeUsageAgent,
 } from "./agent-picker.mjs";
 import { listSessionAgents } from "./agents.mjs";
+import { sumCosts } from "./cost.mjs";
 import { findClaudeSessionLog } from "./report.mjs";
 import { runUsageMeter } from "./meter.mjs";
 import { ANSI } from "../../../ui/palette.mjs";
+
+/**
+ * Totals for agents other than the one the meter is currently tracking.
+ * Null costs stay null: an agent with an unpriceable call has an unknown total,
+ * not a free one, and that unknown must reach the session total.
+ *
+ * @param {any[]} agents
+ */
+export function summarizePeerAgents(agents) {
+  let count = 0;
+  let calls = 0;
+  /** @type {Array<number | null>} */
+  const costs = [];
+  /** @type {{ label: string, calls: number, cost: number | null } | null} */
+  let main = null;
+
+  for (const agent of agents) {
+    const agentCalls = agent.report?.requests ?? 0;
+    const agentCost = agent.report?.totals?.cost === undefined
+      ? 0
+      : agent.report.totals.cost;
+    if (agent.kind === "main") {
+      main = { label: agent.label || "Main", calls: agentCalls, cost: agentCost };
+      continue;
+    }
+    count += 1;
+    calls += agentCalls;
+    costs.push(agentCost);
+  }
+  return {
+    count,
+    calls,
+    cost: sumCosts(costs),
+    main,
+  };
+}
 
 /**
  * Whether `claude usage` should run the live meter rather than a snapshot.
@@ -125,25 +162,8 @@ export async function runClaudeUsageLive({
    * @param {string} selfPath the tracked agent's log
    */
   const peersExcluding = async (selfPath) => {
-    const all = await agentsOf(sessionPath);
-    let count = 0;
-    let calls = 0;
-    let cost = 0;
-    /** @type {{ label: string, calls: number, cost: number } | null} */
-    let main = null;
-    for (const agent of all) {
-      if (agent.filePath === selfPath) continue;
-      const agentCalls = agent.report?.requests ?? 0;
-      const agentCost = agent.report?.totals?.cost ?? 0;
-      if (agent.kind === "main") {
-        main = { label: agent.label || "Main", calls: agentCalls, cost: agentCost };
-        continue;
-      }
-      count += 1;
-      calls += agentCalls;
-      cost += agentCost;
-    }
-    return { count, calls, cost, main };
+    const others = (await agentsOf(sessionPath)).filter((agent) => agent.filePath !== selfPath);
+    return summarizePeerAgents(others);
   };
 
   /** Main (or the first agent) of the session at `sessionPath`. */

--- a/packages/setup-cli/lib/harnesses/claude/usage/meter-layout.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/meter-layout.mjs
@@ -8,34 +8,16 @@
  * that had to agree, and didn't.
  */
 
-import { roundCachePct, usageCacheHitRatio } from "./format.mjs";
+import { formatUsageCost, roundCachePct, usageCacheHitRatio } from "./format.mjs";
 
 // ── value formatting ─────────────────────────────────────────────────────────
 
 /**
- * One call's cost, right-aligned so the `$` sits against the digits.
- *
- * 4 decimals: a single cheap GLM call really is worth $0.0018, and rounding it
- * to cents would erase the row.
+ * A cost — one call or a total — right-aligned so the `$` sits against the
+ * digits. `formatUsageCost` is the CLI-wide rule (4 decimals, `n/a` when there
+ * is no rate); all this adds is the column width.
  */
-export const money = (v, w = 8) => `$${v.toFixed(4)}`.padStart(w);
-
-/**
- * A TOTAL, at 2 decimals — the precision you'd actually quote.
- *
- * Nobody reads the fourth decimal of a $116.9562 session, and the extra digits
- * make a column of totals harder to scan.
- *
- * `<$0.01` rather than `$0.00` for a small nonzero total: rounding a real charge
- * down to zero is the one thing 2 decimals could get actively wrong, and a
- * subagent that cost $0.0072 did cost something. Padded to `money`'s width so
- * both keep the cost column aligned.
- */
-export const moneyTotal = (v, w = 8) => {
-  const n = Number(v) || 0;
-  if (n > 0 && n < 0.005) return "<$0.01".padStart(w);
-  return `$${n.toFixed(2)}`.padStart(w);
-};
+export const money = (v, w = COST_COL) => formatUsageCost(v).padStart(w);
 
 /** Token count as a short magnitude: 1234 -> "1.2k", 2.3e6 -> "2.3M". */
 export function tok(n) {
@@ -105,7 +87,7 @@ export const TOKEN_COLUMNS_WIDTH = TOKEN_COLUMNS.reduce((n, c) => n + c.width, 0
 export const MODEL_COL = 8;
 
 /** Cost column — wide enough for "$1234.5678". */
-export const COST_COL = 8;
+export const COST_COL = 10;
 
 /** Turn-number column, e.g. " 7" or "28". */
 export const TURN_NO_WIDTH = 2;

--- a/packages/setup-cli/lib/harnesses/claude/usage/meter-model.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/meter-model.mjs
@@ -10,7 +10,7 @@
 import { providerListPricing } from "../../../demo/incumbent-detect.mjs";
 import { fireworksModelSlug } from "../../../fireworks/model-id.mjs";
 import { sanitize } from "../../../ui/sanitize.mjs";
-import { computeClaudeUsageCost } from "./report.mjs";
+import { computeClaudeUsageCost } from "./pricing.mjs";
 
 // ── pricing one call ─────────────────────────────────────────────────────────
 
@@ -21,18 +21,21 @@ import { computeClaudeUsageCost } from "./report.mjs";
  * 5m/1h cache-write breakdown — `computeClaudeUsageCost` already does that,
  * including the flat-total fallback for older logs that lack `cache_creation`.
  *
- * `estimated` is the CLI's own "this id matched no known model, here's a default
- * rate" flag. The meter treats that as unpriced and excludes it: a
+ * `estimated` is the CLI's own "this id matched no known model, here's a
+ * reference rate" flag. The meter treats that as unpriced and excludes it: a
  * plausible-looking wrong number during a demo is worse than a visible gap.
+ * `cost: null` is the engine saying the same thing outright — it found no rate
+ * at all — and is excluded on the same grounds.
  *
  * @param {string} model
  * @param {object} usage
  */
 export function priceCall(model, usage) {
   const r = computeClaudeUsageCost(model, usage);
+  const unpriced = r.estimated || r.cost == null;
   return {
-    cost: r.estimated ? 0 : r.cost,
-    priced: !r.estimated,
+    cost: unpriced ? 0 : r.cost,
+    priced: !unpriced,
     label: labelFor(model, r),
     input: r.input,
     cacheRead: r.cacheRead,

--- a/packages/setup-cli/lib/harnesses/claude/usage/meter-render.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/meter-render.mjs
@@ -12,6 +12,7 @@
  */
 
 import { sanitize } from "../../../ui/sanitize.mjs";
+import { sumCosts } from "./cost.mjs";
 import {
   BAR_MAX,
   COST_COL,
@@ -19,7 +20,6 @@ import {
   LABEL_BLOCK,
   MODEL_COL,
   money,
-  moneyTotal,
   SHARE_COL,
   TOKEN_COLUMNS_WIDTH,
   tokenCells,
@@ -159,8 +159,7 @@ export function renderAgentPane(pane, width) {
     const on = focused && start + i === cursor;
     const tracked = pane.trackingId && agent.id === pane.trackingId;
     const totals = agent.report?.totals ?? {};
-    // An agent row is a total, not a single call.
-    const cost = moneyTotal(totals.cost ?? 0);
+    const cost = money(totals.cost === undefined ? 0 : totals.cost);
     const calls = String(agent.report?.requests ?? 0).padStart(3);
     const cache = formatUsageCachePct(totals).padStart(4);
     // The tracked agent gets the gold dot; the cursor gets the pointer. They
@@ -187,7 +186,7 @@ export function renderAgentPane(pane, width) {
  * @param {{
  *   totals: Map<string, any>,
  *   unpriced: Set<string>,
- *   peers: { count: number, calls: number, cost: number, main?: any } | null,
+ *   peers: { count: number, calls: number, cost: number | null, main?: any } | null,
  *   agentLabel: string,
  *   colorOf: (key: string) => string,
  *   width: number,
@@ -196,6 +195,7 @@ export function renderAgentPane(pane, width) {
 export function renderFooter({ totals, unpriced, peers, agentLabel, colorOf, width }) {
   let grand = 0;
   for (const t of totals.values()) grand += t.cost;
+  const trackedCost = unpriced.size ? null : grand;
 
   // The share bar is the one elastic column, so it absorbs a narrow pane and
   // drops out entirely rather than forcing every line to wrap. The launcher gives
@@ -216,19 +216,19 @@ export function renderFooter({ totals, unpriced, peers, agentLabel, colorOf, wid
     const label = key.slice(0, MODEL_COL).padEnd(LABEL_BLOCK - FOOTER_LABEL_INDENT);
     lines.push(
       `  ${c}●${R} ${label}${D}${tokenCells(t)}${R} `
-      + `${bar}${GHOST}${share}${R} ${GOLD}${moneyTotal(t.cost)}${R}`,
+      + `${bar}${GHOST}${share}${R} ${GOLD}${money(t.cost)}${R}`,
     );
   }
   if (!lines.length) lines.push(`  ${GHOST}no priced turns yet${R}`);
 
   // Summary rows carry no numeric columns, so right-align their cost against
   // where a model row's cost cell ends. Padding the label instead would drift,
-  // because `moneyTotal` is variable width ("$0.87" vs "$20.37"). Measured off a
+  // because `money` is variable width ("$0.8700" vs "$20.3700"). Measured off a
   // rendered row rather than re-summing the terms, which is one place for the
   // arithmetic to go wrong instead of two.
   const modelRowEnd = totals.size ? vislen(lines[0]) : fixedRow + (barw ? barw + 1 : 0);
   const summary = (label, value, { bold: strong = false, ghost = false } = {}) => {
-    const cost = moneyTotal(value);
+    const cost = money(value);
     const room = Math.max(1, modelRowEnd - 2 - cost.length);
     const text = clip(label, room);
     const style = strong ? B : (ghost ? GHOST : "");
@@ -247,7 +247,7 @@ export function renderFooter({ totals, unpriced, peers, agentLabel, colorOf, wid
   const subCount = peers?.count ?? 0;
   if (peers && (subCount > 0 || peerMain)) {
     const callWord = (n) => (n === 1 ? "call" : "calls");
-    lines.push(summary(agentLabel || "Main", grand));
+    lines.push(summary(agentLabel || "Main", trackedCost));
     if (peerMain) {
       lines.push(summary(
         `${peerMain.label} · ${peerMain.calls} ${callWord(peerMain.calls)}`,
@@ -262,9 +262,12 @@ export function renderFooter({ totals, unpriced, peers, agentLabel, colorOf, wid
         { ghost: true },
       ));
     }
-    lines.push(summary("SESSION COST", grand + peers.cost + (peerMain?.cost ?? 0), { bold: true }));
+    const sessionCosts = [trackedCost, peers.cost];
+    if (peerMain) sessionCosts.push(peerMain.cost);
+    const sessionCost = sumCosts(sessionCosts);
+    lines.push(summary("SESSION COST", sessionCost, { bold: true }));
   } else {
-    lines.push(summary("TOTAL COST", grand, { bold: true }));
+    lines.push(summary("TOTAL COST", trackedCost, { bold: true }));
   }
 
   if (unpriced.size) {

--- a/packages/setup-cli/lib/harnesses/claude/usage/pricing.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/pricing.mjs
@@ -1,0 +1,172 @@
+/**
+ * Canonical pricing for Claude Code usage records.
+ *
+ * Both transcript reports/statusline and the demo runner call this module.
+ * A rate lookup either produces a real provider rate or no cost (`null`); there
+ * is deliberately no reference-price fallback.
+ */
+
+import { providerListPricing } from "../../../demo/list-pricing.mjs";
+import {
+  isAnthropicModelId,
+  isClaudeModelAlias,
+  shortFireworksModelRef,
+} from "../../../fireworks/model-id.mjs";
+import { lookupFireworksPricing } from "../../../fireworks/pricing.mjs";
+
+const WEB_SEARCH_PER_1K = 10;
+const US_INFERENCE_GEO_MULTIPLIER = 1.1;
+const BATCH_DISCOUNT = 0.5;
+
+function displayModel(model) {
+  return shortFireworksModelRef(model);
+}
+
+function fireworksPriceFor(model) {
+  const pricing = lookupFireworksPricing(model);
+  if (!pricing) {
+    return null;
+  }
+  return {
+    inputPerMillion: pricing.input,
+    cacheWrite5mPerMillion: 0,
+    cacheWrite1hPerMillion: 0,
+    cacheReadPerMillion: pricing.cachedInput,
+    outputPerMillion: pricing.output,
+    label: pricing.label,
+    source: pricing.source,
+    estimated: false,
+  };
+}
+
+function anthropicPriceFor(model, usage) {
+  const rate = providerListPricing({
+    provider: "anthropic",
+    modelId: model,
+    speed: usage.speed,
+  });
+  // providerListPricing returns a plausible reference row for unknown ids.
+  // That is useful for broad incumbent discovery, but not for measured usage:
+  // only a concrete list-price match may become a dollar figure.
+  if (!rate || rate.tier === "subscription" || rate.estimated) {
+    return null;
+  }
+  return {
+    inputPerMillion: rate.inputPerMillion,
+    cacheWrite5mPerMillion: rate.cacheWrite5mPerMillion,
+    cacheWrite1hPerMillion: rate.cacheWrite1hPerMillion,
+    cacheReadPerMillion: rate.cacheReadPerMillion,
+    outputPerMillion: rate.outputPerMillion,
+    label: rate.label,
+    source: rate.source,
+    estimated: rate.estimated,
+  };
+}
+
+/**
+ * Rates for one call, or null when we have none.
+ *
+ * `providerListPricing` returns a Claude reference rate for any unknown id, so
+ * it is only called after the id has been classified as Anthropic.
+ */
+function priceFor(model, usage) {
+  const fireworksPrice = fireworksPriceFor(model);
+  const price = fireworksPrice
+    ?? ((isAnthropicModelId(model) || isClaudeModelAlias(model))
+      ? anthropicPriceFor(model, usage)
+      : null);
+  if (!price) {
+    return null;
+  }
+
+  return { ...price, fireworks: Boolean(fireworksPrice) };
+}
+
+function numberValue(value) {
+  return Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Price one Claude Code usage record from real Fireworks serverless or
+ * Anthropic list rates.
+ *
+ * Unknown rates preserve usage but return `cost: null`, never an estimate.
+ *
+ * @param {string} model
+ * @param {object} usage
+ */
+export function computeClaudeUsageCost(model, usage = {}) {
+  const price = priceFor(model, usage);
+  const input = numberValue(usage.input_tokens);
+  const cacheRead = numberValue(usage.cache_read_input_tokens);
+  const output = numberValue(usage.output_tokens);
+  const cacheCreation = usage.cache_creation && typeof usage.cache_creation === "object"
+    ? usage.cache_creation
+    : null;
+  const cacheWrite5m = cacheCreation
+    ? numberValue(cacheCreation.ephemeral_5m_input_tokens)
+    : numberValue(usage.cache_creation_input_tokens);
+  const cacheWrite1h = cacheCreation
+    ? numberValue(cacheCreation.ephemeral_1h_input_tokens)
+    : 0;
+  const webSearches = numberValue(usage.server_tool_use?.web_search_requests);
+
+  if (!price) {
+    return {
+      model,
+      displayModel: displayModel(model),
+      fireworks: false,
+      priced: false,
+      input,
+      cacheWrite5m,
+      cacheWrite1h,
+      cacheRead,
+      output,
+      webSearches,
+      cost: null,
+      estimated: false,
+      rates: null,
+    };
+  }
+
+  let tokenCost = (
+    input * price.inputPerMillion
+    + cacheWrite5m * price.cacheWrite5mPerMillion
+    + cacheWrite1h * price.cacheWrite1hPerMillion
+    + cacheRead * price.cacheReadPerMillion
+    + output * price.outputPerMillion
+  ) / 1_000_000;
+
+  if (usage.inference_geo === "us") {
+    tokenCost *= US_INFERENCE_GEO_MULTIPLIER;
+  }
+  if (usage.service_tier === "batch") {
+    tokenCost *= BATCH_DISCOUNT;
+  }
+
+  return {
+    model,
+    displayModel: displayModel(model),
+    fireworks: price.fireworks,
+    priced: true,
+    input,
+    cacheWrite5m,
+    cacheWrite1h,
+    cacheRead,
+    output,
+    webSearches,
+    cost: tokenCost + (webSearches / 1000) * WEB_SEARCH_PER_1K,
+    estimated: price.estimated,
+    rates: {
+      inputPerMillion: price.inputPerMillion,
+      cacheWrite5mPerMillion: price.cacheWrite5mPerMillion,
+      cacheWrite1hPerMillion: price.cacheWrite1hPerMillion,
+      cacheReadPerMillion: price.cacheReadPerMillion,
+      outputPerMillion: price.outputPerMillion,
+      webSearchPer1k: WEB_SEARCH_PER_1K,
+      label: price.label,
+      source: price.source,
+      estimated: price.estimated,
+    },
+  };
+}

--- a/packages/setup-cli/lib/harnesses/claude/usage/report.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/report.mjs
@@ -1,33 +1,21 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import { lookupFireworksPricing } from "../../../fireworks/pricing.mjs";
-import { shortFireworksModelRef } from "../../../fireworks/model-id.mjs";
-import { providerListPricing } from "../../../demo/incumbent-detect.mjs";
+import { FIREWORKS_PRICING_DOCS_URL } from "../../../fireworks/pricing.mjs";
+import {
+  UNPRICED_TEXT,
+  addUsage,
+  sumUsage,
+} from "./cost.mjs";
+import { computeClaudeUsageCost } from "./pricing.mjs";
+import { usageCostDigits } from "./format.mjs";
 import {
   formatCostEstimateNote,
   formatClaudeUsageReportsSummaryDisplay,
   formatClaudeUsageSummaryDisplay,
 } from "./display.mjs";
 
-const DEFAULT_PRICE = {
-  input: 1,
-  cacheWrite5m: 1.25,
-  cacheWrite1h: 2,
-  cacheRead: 0.1,
-  output: 5,
-  label: "Default reference",
-  source: "",
-  estimated: true,
-};
+export { computeClaudeUsageCost };
 
-const FAST_PRICES = {
-  "claude-opus-4-8": { input: 10, output: 50 },
-  "claude-opus-4-7": { input: 30, output: 150 },
-};
-
-const WEB_SEARCH_PER_1K = 10;
-const US_INFERENCE_GEO_MULTIPLIER = 1.1;
-const BATCH_DISCOUNT = 0.5;
 const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function expandHome(value, home) {
@@ -320,130 +308,8 @@ export async function findClaudeSessionLogs({ home, session = "", lastN = 1, wit
   return withMtime.slice(0, parseLastN(lastN)).map(({ filePath }) => filePath);
 }
 
-function displayModel(model) {
-  return shortFireworksModelRef(model);
-}
-
-function fireworkPriceFor(model) {
-  const pricing = lookupFireworksPricing(model);
-  if (!pricing) {
-    return null;
-  }
-  return {
-    input: pricing.input,
-    cacheWrite5m: 0,
-    cacheWrite1h: 0,
-    cacheRead: pricing.cachedInput,
-    output: pricing.output,
-    label: pricing.label,
-    source: pricing.source,
-    estimated: false,
-  };
-}
-
-function anthropicPriceFor(model) {
-  const rate = providerListPricing({ provider: "anthropic", modelId: model });
-  if (!rate || rate.tier === "subscription") {
-    return null;
-  }
-  const input = rate.inputPerMillion;
-  return {
-    input,
-    cacheWrite5m: input * 1.25,
-    cacheWrite1h: input * 2,
-    cacheRead: input * 0.1,
-    output: rate.outputPerMillion,
-    label: rate.label,
-    source: rate.source,
-    estimated: rate.estimated,
-  };
-}
-
-function fastPriceFor(model) {
-  const id = model.toLowerCase();
-  const key = Object.keys(FAST_PRICES).find((candidate) => id.startsWith(candidate));
-  return key ? FAST_PRICES[key] : null;
-}
-
-function priceFor(model, usage) {
-  const fireworksPrice = fireworkPriceFor(model);
-  let price = fireworksPrice ?? anthropicPriceFor(model);
-  price ??= DEFAULT_PRICE;
-
-  const fast = usage.speed === "fast" ? fastPriceFor(model) : null;
-  if (fast) {
-    return {
-      ...price,
-      fireworks: Boolean(fireworksPrice),
-      input: fast.input,
-      cacheWrite5m: fast.input * 1.25,
-      cacheWrite1h: fast.input * 2,
-      cacheRead: fast.input * 0.1,
-      output: fast.output,
-    };
-  }
-  return { ...price, fireworks: Boolean(fireworksPrice) };
-}
-
 function numberValue(value) {
   return Number.isFinite(value) ? value : 0;
-}
-
-export function computeClaudeUsageCost(model, usage = {}) {
-  const price = priceFor(model, usage);
-  const input = numberValue(usage.input_tokens);
-  const cacheRead = numberValue(usage.cache_read_input_tokens);
-  const output = numberValue(usage.output_tokens);
-  const cacheCreation = usage.cache_creation && typeof usage.cache_creation === "object"
-    ? usage.cache_creation
-    : null;
-  const cacheWrite5m = cacheCreation
-    ? numberValue(cacheCreation.ephemeral_5m_input_tokens)
-    : numberValue(usage.cache_creation_input_tokens);
-  const cacheWrite1h = cacheCreation ? numberValue(cacheCreation.ephemeral_1h_input_tokens) : 0;
-
-  let tokenCost = (
-    input * price.input
-    + cacheWrite5m * price.cacheWrite5m
-    + cacheWrite1h * price.cacheWrite1h
-    + cacheRead * price.cacheRead
-    + output * price.output
-  ) / 1_000_000;
-
-  if (usage.inference_geo === "us") {
-    tokenCost *= US_INFERENCE_GEO_MULTIPLIER;
-  }
-  if (usage.service_tier === "batch") {
-    tokenCost *= BATCH_DISCOUNT;
-  }
-
-  const webSearches = numberValue(usage.server_tool_use?.web_search_requests);
-  const cost = tokenCost + (webSearches / 1000) * WEB_SEARCH_PER_1K;
-
-  return {
-    model,
-    displayModel: displayModel(model),
-    fireworks: price.fireworks,
-    input,
-    cacheWrite5m,
-    cacheWrite1h,
-    cacheRead,
-    output,
-    webSearches,
-    cost,
-    estimated: price.estimated,
-    rates: {
-      inputPerMillion: price.input,
-      cacheWrite5mPerMillion: price.cacheWrite5m,
-      cacheWrite1hPerMillion: price.cacheWrite1h,
-      cacheReadPerMillion: price.cacheRead,
-      outputPerMillion: price.output,
-      webSearchPer1k: WEB_SEARCH_PER_1K,
-      label: price.label,
-      source: price.source,
-      estimated: price.estimated,
-    },
-  };
 }
 
 function cleanSessionName(value) {
@@ -642,35 +508,11 @@ export function parseClaudeUsageLog(text) {
 }
 
 function sumRows(rows) {
-  return rows.reduce((totals, row) => ({
-    input: totals.input + row.input,
-    cacheWrite5m: totals.cacheWrite5m + row.cacheWrite5m,
-    cacheWrite1h: totals.cacheWrite1h + row.cacheWrite1h,
-    cacheRead: totals.cacheRead + row.cacheRead,
-    output: totals.output + row.output,
-    webSearches: totals.webSearches + row.webSearches,
-    cost: totals.cost + row.cost,
-  }), {
-    input: 0,
-    cacheWrite5m: 0,
-    cacheWrite1h: 0,
-    cacheRead: 0,
-    output: 0,
-    webSearches: 0,
-    cost: 0,
-  });
+  return sumUsage(rows);
 }
 
 function addTotals(a, b) {
-  return {
-    input: a.input + b.input,
-    cacheWrite5m: a.cacheWrite5m + b.cacheWrite5m,
-    cacheWrite1h: a.cacheWrite1h + b.cacheWrite1h,
-    cacheRead: a.cacheRead + b.cacheRead,
-    output: a.output + b.output,
-    webSearches: a.webSearches + b.webSearches,
-    cost: a.cost + b.cost,
-  };
+  return addUsage(a, b);
 }
 
 function rowHasUsage(row) {
@@ -680,7 +522,7 @@ function rowHasUsage(row) {
     || row.cacheRead > 0
     || row.output > 0
     || row.webSearches > 0
-    || row.cost > 0;
+    || (row.cost ?? 0) > 0;
 }
 
 function reportHasUsage(report) {
@@ -695,6 +537,7 @@ function reportFromRows(filePath, rows, { sessionName = "" } = {}) {
     rows: usedRows,
     totals: sumRows(usedRows),
     estimated: usedRows.some((row) => row.estimated),
+    unpriced: usedRows.filter((row) => row.priced === false).length,
   };
   if (sessionName) {
     report.sessionName = sessionName;
@@ -744,6 +587,7 @@ async function readClaudeUsageAtPath(sessionPath) {
     grandTotals,
     grandRequests: report.requests + subagents.reduce((total, subagent) => total + subagent.requests, 0),
     estimated: report.estimated || subagents.some((subagent) => subagent.estimated),
+    unpriced: report.unpriced + subagents.reduce((total, subagent) => total + subagent.unpriced, 0),
   };
 }
 
@@ -764,6 +608,7 @@ export async function readClaudeUsages({ home, session = "", lastN = 1 }) {
     grandTotals,
     grandRequests: sessions.reduce((total, report) => total + report.grandRequests, 0),
     estimated: sessions.some((report) => report.estimated),
+    unpriced: sessions.reduce((total, report) => total + report.unpriced, 0),
     lastN: sessions.length,
     requestedLastN,
     sessionCount: sessions.length,
@@ -775,10 +620,13 @@ function fmtInt(value) {
 }
 
 function fmtCost(value) {
-  return value.toFixed(2);
+  return value == null ? UNPRICED_TEXT : usageCostDigits(value);
 }
 
 function fmtRate(value) {
+  if (value == null) {
+    return UNPRICED_TEXT;
+  }
   const text = value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
   return `$${text}`;
 }
@@ -880,11 +728,11 @@ function modelRateRows(report) {
   for (const row of allRows(report)) {
     const key = [
       row.model,
-      row.rates.inputPerMillion,
-      row.rates.cacheWrite5mPerMillion,
-      row.rates.cacheWrite1hPerMillion,
-      row.rates.cacheReadPerMillion,
-      row.rates.outputPerMillion,
+      row.rates?.inputPerMillion,
+      row.rates?.cacheWrite5mPerMillion,
+      row.rates?.cacheWrite1hPerMillion,
+      row.rates?.cacheReadPerMillion,
+      row.rates?.outputPerMillion,
     ].join("|");
     if (seen.has(key)) {
       continue;
@@ -923,14 +771,14 @@ function formatEstimateExplanation(report) {
   ];
 
   const rows = rates.map((row) => {
-    const r = row.rates;
+    const r = row.rates ?? {};
     return [
       row.model,
-      fmtRate(r.inputPerMillion),
-      row.fireworks ? "-" : fmtRate(r.cacheWrite5mPerMillion),
-      row.fireworks ? "-" : fmtRate(r.cacheWrite1hPerMillion),
-      fmtRate(r.cacheReadPerMillion),
-      fmtRate(r.outputPerMillion),
+      fmtRate(r.inputPerMillion ?? null),
+      row.fireworks ? "-" : fmtRate(r.cacheWrite5mPerMillion ?? null),
+      row.fireworks ? "-" : fmtRate(r.cacheWrite1hPerMillion ?? null),
+      fmtRate(r.cacheReadPerMillion ?? null),
+      fmtRate(r.outputPerMillion ?? null),
     ];
   });
   lines.push(...formatWrappedTable({
@@ -989,11 +837,11 @@ function summarizeUsageRows(rows) {
       output: 0,
       cost: 0,
     };
-    current.calls += 1;
-    current.input += row.input;
-    current.output += row.output;
-    current.cost += row.cost;
-    byModel.set(key, current);
+    byModel.set(key, {
+      ...current,
+      ...addUsage(current, row),
+      calls: current.calls + 1,
+    });
   }
   return [...byModel.values()].sort((a, b) => (
     (a.subagentId === "Parent" && b.subagentId !== "Parent" ? -1 : 0)
@@ -1004,15 +852,10 @@ function summarizeUsageRows(rows) {
 }
 
 function formatPlainSummaryTable(rows, label) {
+  const totals = sumUsage(rows);
   let calls = 0;
-  let input = 0;
-  let output = 0;
-  let cost = 0;
   const tableRows = rows.map((row) => {
     calls += row.calls;
-    input += row.input;
-    output += row.output;
-    cost += row.cost;
     return [
       row.subagentId,
       row.model,
@@ -1023,7 +866,14 @@ function formatPlainSummaryTable(rows, label) {
     ];
   });
 
-  tableRows.push(["TOTAL", "", fmtInt(calls), fmtInt(input), fmtInt(output), fmtCost(cost)]);
+  tableRows.push([
+    "TOTAL",
+    "",
+    fmtInt(calls),
+    fmtInt(totals.input),
+    fmtInt(totals.output),
+    fmtCost(totals.cost),
+  ]);
   return formatWrappedTable({
     label,
     headers: ["Parent/Sub-agent ID", "Model", "Calls", "Input", "Output", "Cost (USD)"],
@@ -1045,10 +895,8 @@ function formatPlainSessionTotalsTable(sessions, label) {
 
   const totals = sessions.reduce(
     (total, report) => ({
+      ...addUsage(total, report.grandTotals),
       calls: total.calls + report.grandRequests,
-      input: total.input + report.grandTotals.input,
-      output: total.output + report.grandTotals.output,
-      cost: total.cost + report.grandTotals.cost,
     }),
     { calls: 0, input: 0, output: 0, cost: 0 },
   );
@@ -1073,7 +921,28 @@ function plainSummaryRowsForReport(report) {
 }
 
 function formatTotalsLine(label, totals) {
-  return `${label}: $${fmtCost(totals.cost)} (${fmtInt(totals.input)} input, ${fmtInt(totals.cacheRead)} cache read, ${fmtInt(totals.output)} output)`;
+  const cost = totals.cost == null ? UNPRICED_TEXT : `$${fmtCost(totals.cost)}`;
+  return `${label}: ${cost} (${fmtInt(totals.input)} input, ${fmtInt(totals.cacheRead)} cache read, ${fmtInt(totals.output)} output)`;
+}
+
+/**
+ * Why a cost column reads `n/a`, named per model so it is actionable.
+ *
+ * @param {{ rows?: any[], subagents?: any[], unpriced?: number }} report
+ * @returns {string[]}
+ */
+function unpricedNote(report) {
+  if (!report.unpriced) {
+    return [];
+  }
+  const models = [...new Set(allRows(report)
+    .filter((row) => row.priced === false)
+    .map((row) => row.displayModel))].sort();
+  return [
+    `Note: ${report.unpriced} request(s) have no rate available, so their cost is not shown`
+    + ` and totals that include them read ${UNPRICED_TEXT}: ${models.join(", ")}.`
+    + ` Refresh the model catalog (fireconnect model list --refresh) or see ${FIREWORKS_PRICING_DOCS_URL}.`,
+  ];
 }
 
 function sessionId(report) {
@@ -1123,6 +992,7 @@ function formatClaudeUsageVerboseReport(report) {
   if (report.estimated) {
     lines.push("Note: Some rows used fallback/reference pricing because the model id was not recognized.");
   }
+  lines.push(...unpricedNote(report));
   return lines.join("\n");
 }
 
@@ -1147,6 +1017,7 @@ function formatClaudeUsagePlainSummaryReport(report) {
   if (report.estimated) {
     lines.push("Note: Some rows used fallback/reference pricing because the model id was not recognized.");
   }
+  lines.push(...unpricedNote(report));
   return lines.join("\n");
 }
 
@@ -1181,6 +1052,9 @@ export function formatClaudeUsageReports(reportGroup, { verbose = false, plain =
     if (reportGroup.estimated) {
       lines.push("Note: Some rows used fallback/reference pricing because the model id was not recognized.");
     }
+    if (reportGroup.unpriced) {
+      lines.push(`Note: ${reportGroup.unpriced} request(s) have no rate available; their cost is not included.`);
+    }
     return lines.join("\n");
   }
   if (plain) {
@@ -1200,6 +1074,9 @@ export function formatClaudeUsageReports(reportGroup, { verbose = false, plain =
     lines.push(...formatPlainSessionTotalsTable(sessions, `Session totals for last ${sessions.length} sessions:`));
     if (reportGroup.estimated) {
       lines.push("Note: Some rows used fallback/reference pricing because the model id was not recognized.");
+    }
+    if (reportGroup.unpriced) {
+      lines.push(`Note: ${reportGroup.unpriced} request(s) have no rate available; their cost is not included.`);
     }
     return lines.join("\n");
   }

--- a/packages/setup-cli/lib/harnesses/claude/usage/session-picker.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/session-picker.mjs
@@ -15,7 +15,8 @@ import { colorsEnabled } from "../../../ui/color.mjs";
 import { METER } from "../../../ui/palette.mjs";
 import { promptSelect } from "../../../ui/prompt.mjs";
 import { sanitize } from "../../../ui/sanitize.mjs";
-import { formatLiveCostTotal } from "./format.mjs";
+import { formatUsageCost } from "./format.mjs";
+import { COST_COL } from "./meter-layout.mjs";
 import {
   findClaudeSessionLogs,
   readClaudeUsage,
@@ -60,14 +61,17 @@ export function formatClaudeUsageSessionChoice(entry, now = Date.now(), opts = {
 
   const id = path.basename(entry.filePath, ".jsonl");
   const shortId = `${id.slice(0, 8)}…`;
-  const costValue = entry.report.grandTotals?.cost ?? entry.report.totals?.cost ?? 0;
+  const grandCost = entry.report.grandTotals?.cost;
+  const totalCost = entry.report.totals?.cost;
+  const costValue = grandCost !== undefined
+    ? grandCost
+    : (totalCost !== undefined ? totalCost : 0);
   const calls = entry.report.grandRequests ?? entry.report.requests ?? 0;
   const name = typeof entry.report.sessionName === "string"
     ? sanitize(entry.report.sessionName).replace(/\s+/g, " ").trim()
     : "";
   const age = formatSessionAge(entry.mtimeMs, now);
-  // A whole session's spend is a total, so 2 decimals.
-  const costText = formatLiveCostTotal(costValue).padStart(8);
+  const costText = formatUsageCost(costValue).padStart(COST_COL);
   const callsText = `${String(calls).padStart(3)} calls`;
 
   if (!useColor) {

--- a/packages/setup-cli/lib/harnesses/codex/catalog.mjs
+++ b/packages/setup-cli/lib/harnesses/codex/catalog.mjs
@@ -2,11 +2,15 @@ import {
   FIREROUTER_TAGLINE,
 } from "../../firerouter/core.mjs";
 import { MODEL_API_OVERRIDES as MODEL_OVERRIDES, lookupModelSpec, resolveFireworksModelLabel } from "../../fireworks/model-specs.mjs";
-import { buildServerlessCatalogSnapshot, prettyModelName } from "../../fireworks/models.mjs";
+import { autoDisplayName, buildServerlessCatalogSnapshot, firerouterDisplayName, prettyModelName } from "../../fireworks/models.mjs";
 import {
+  AUTO_INSTANT_MODEL_ID,
+  AUTO_MODEL_ID,
   FIREROUTER_ROUTER_ID,
+  canonicalAutoModelId,
   fireworksModelSlug,
-  isFirerouterGatewayPattern,
+  isAutoModelId,
+  isFirerouterModelPattern,
   isFirerouterModel,
   shortFireworksModelRef,
 } from "../../fireworks/model-id.mjs";
@@ -42,53 +46,94 @@ function reasoningLevel(effort) {
   return { effort, description: REASONING_DESCRIPTIONS[effort] };
 }
 
+/** Standard ladder: every reasoning model offers at least these three tiers. */
+const STANDARD_LEVELS = [reasoningLevel("low"), reasoningLevel("medium"), reasoningLevel("high")];
+/** Ladder for models that also expose the deepest tier. */
+const MAX_LEVELS = [...STANDARD_LEVELS, reasoningLevel("max")];
+
+/*
+ * Per-model reasoning tiers offered in the Codex/ChatGPT app effort picker.
+ *
+ * The app only renders a selectable Effort row when a model advertises more than
+ * one tier, so every entry exposes the full low/medium/high ladder (the Fireworks
+ * API accepts these values for reasoning models) and adds `max` only where the
+ * docs confirm it (GLM 5.2, DeepSeek V4 Pro/Flash). Some models may treat the
+ * lower tiers as a no-op; the tier is still selectable rather than absent.
+ *
+ * `default` stays `high` for every model.
+ */
 export const MODEL_REASONING = {
   "accounts/fireworks/models/glm-5p2": {
-    default: "max",
-    levels: [reasoningLevel("high"), reasoningLevel("max")],
+    default: "high",
+    levels: MAX_LEVELS,
   },
   "accounts/fireworks/models/deepseek-v4-flash": {
     default: "high",
-    levels: [reasoningLevel("high"), reasoningLevel("max")],
+    levels: MAX_LEVELS,
   },
   "accounts/fireworks/models/deepseek-v4-pro": {
     default: "high",
-    levels: [reasoningLevel("high"), reasoningLevel("max")],
+    levels: MAX_LEVELS,
   },
   "accounts/fireworks/models/kimi-k2p6": {
     default: "high",
-    levels: [reasoningLevel("high")],
+    levels: STANDARD_LEVELS,
   },
   "accounts/fireworks/models/kimi-k2p7-code": {
     default: "high",
-    levels: [reasoningLevel("high")],
+    levels: STANDARD_LEVELS,
   },
   "accounts/fireworks/models/minimax-m2p7": {
-    default: "medium",
-    levels: [reasoningLevel("low"), reasoningLevel("medium"), reasoningLevel("high")],
+    default: "high",
+    levels: STANDARD_LEVELS,
   },
   "accounts/fireworks/models/minimax-m3": {
     default: "high",
-    levels: [reasoningLevel("high")],
+    levels: STANDARD_LEVELS,
   },
   "accounts/fireworks/models/gpt-oss-120b": {
-    default: "medium",
-    levels: [reasoningLevel("low"), reasoningLevel("medium"), reasoningLevel("high")],
+    default: "high",
+    levels: STANDARD_LEVELS,
   },
   "accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
     default: "high",
-    levels: [reasoningLevel("high")],
+    levels: STANDARD_LEVELS,
   },
   "accounts/fireworks/models/qwen3p7-plus": {
-    default: "medium",
-    levels: [reasoningLevel("low"), reasoningLevel("medium"), reasoningLevel("high")],
+    default: "high",
+    levels: STANDARD_LEVELS,
+  },
+  // Kimi K3 / K3 Fast (current Kimi generation; supersedes kimi-k2p6 / kimi-k2p7-code).
+  "accounts/fireworks/models/kimi-k3": {
+    default: "high",
+    levels: STANDARD_LEVELS,
   },
 };
 
 const DEFAULT_REASONING = {
   default: "high",
-  levels: [reasoningLevel("high")],
+  levels: STANDARD_LEVELS,
 };
+
+/**
+ * Resolve the reasoning config for a model. Tries the exact full ref, then —
+ * because the live serverless catalog returns versioned slugs (e.g.
+ * `deepseek-v4-flash-0731`) while {@link MODEL_REASONING} is keyed by the
+ * unversioned base ref (`deepseek-v4-flash`) — strips a trailing pure-numeric
+ * version suffix and retries. Falls back to {@link DEFAULT_REASONING}.
+ * @param {string} modelRef full model ref, e.g. `accounts/fireworks/models/deepseek-v4-flash-0731`
+ * @returns {{ default: string, levels: object[] }}
+ */
+function reasoningConfigFor(modelRef) {
+  if (MODEL_REASONING[modelRef]) {
+    return MODEL_REASONING[modelRef];
+  }
+  const baseRef = modelRef.replace(/-\d+$/, "");
+  if (baseRef !== modelRef && MODEL_REASONING[baseRef]) {
+    return MODEL_REASONING[baseRef];
+  }
+  return DEFAULT_REASONING;
+}
 
 export const DEPRECATED_MODELS = new Set([
   "accounts/fireworks/models/glm-5p1",
@@ -137,7 +182,7 @@ function effectiveModelFields(model) {
 export function buildCodexCatalogEntry(model) {
   const { contextLength, supportsImageInput, supportsTools } = effectiveModelFields(model);
 
-  const reasoning = MODEL_REASONING[model.name] ?? DEFAULT_REASONING;
+  const reasoning = reasoningConfigFor(model.name);
   const reasoningSummaryFormat = reasoning.levels.length > 1 ? "experimental" : "none";
 
   return {
@@ -177,7 +222,7 @@ export function buildCodexFirerouterCatalogEntry(modelId = FIREROUTER_ROUTER_ID)
   return {
     ...buildCodexCatalogEntry({
       name: FIREROUTER_ROUTER_ID,
-      displayName: exact ? (spec?.label ?? "FireRouter") : prettyModelName(stored),
+      displayName: exact ? (spec?.label ?? "FireRouter") : firerouterDisplayName(stored),
       description: FIREROUTER_TAGLINE,
       contextLength: spec?.capabilities.contextWindow ?? 0,
       supportsImageInput: spec?.capabilities.vision ?? false,
@@ -188,17 +233,45 @@ export function buildCodexFirerouterCatalogEntry(modelId = FIREROUTER_ROUTER_ID)
   };
 }
 
+export const AUTO_TAGLINE = "Routes each request across Fireworks open models.";
+export const AUTO_INSTANT_TAGLINE =
+  "Routes each request across the fastest Fireworks open models.";
+
+/** Codex catalog row for `auto` / `auto-*`, built from that mix's spec. */
+export function buildCodexAutoCatalogEntry(modelId = AUTO_MODEL_ID) {
+  const spec = lookupModelSpec(modelId);
+  const stored = canonicalAutoModelId(modelId) || shortFireworksModelRef(modelId);
+  return {
+    ...buildCodexCatalogEntry({
+      name: stored,
+      displayName: autoDisplayName(stored),
+      description: stored === AUTO_INSTANT_MODEL_ID ? AUTO_INSTANT_TAGLINE : AUTO_TAGLINE,
+      contextLength: spec?.capabilities.contextWindow ?? 0,
+      supportsImageInput: spec?.capabilities.vision ?? false,
+      supportsTools: spec?.capabilities.toolCalling ?? true,
+    }),
+    slug: stored,
+  };
+}
+
 /**
- * When the active model is a firerouter* pattern missing from the catalog,
- * append a FireRouter-equivalent metadata row so Codex can resolve context.
+ * Models the gateway serves without a serverless catalog row (`firerouter*`
+ * patterns, `auto` / `auto-*`) get a spec-derived metadata row appended so Codex can
+ * resolve their context window.
  */
-export function ensureCodexFirerouterPatternEntry(catalog, modelId) {
-  if (!isFirerouterGatewayPattern(modelId) || codexCatalogContainsModel(catalog, modelId)) {
+export function ensureCodexOffCatalogEntry(catalog, modelId) {
+  if (codexCatalogContainsModel(catalog, modelId)) {
+    return catalog;
+  }
+  const entry = isFirerouterModelPattern(modelId)
+    ? buildCodexFirerouterCatalogEntry(modelId)
+    : (isAutoModelId(modelId) ? buildCodexAutoCatalogEntry(modelId) : null);
+  if (!entry) {
     return catalog;
   }
   return {
     ...(catalog ?? {}),
-    models: [...(catalog?.models ?? []), buildCodexFirerouterCatalogEntry(modelId)],
+    models: [...(catalog?.models ?? []), entry],
   };
 }
 

--- a/packages/setup-cli/lib/harnesses/codex/core.mjs
+++ b/packages/setup-cli/lib/harnesses/codex/core.mjs
@@ -29,7 +29,7 @@ import {
   buildCodexCatalogFromSnapshot,
   codexCatalogContainsModel,
   codexModelExclusionReason,
-  ensureCodexFirerouterPatternEntry,
+  ensureCodexOffCatalogEntry,
 } from "./catalog.mjs";
 import {
   buildServerlessCatalogSnapshot,
@@ -456,7 +456,7 @@ export async function enableCodexFireworks({
   let effectiveCatalogPath = "";
   let catalogWritten = false;
   if (catalog && catalogPath) {
-    const catalogToWrite = ensureCodexFirerouterPatternEntry(catalog, storedModel);
+    const catalogToWrite = ensureCodexOffCatalogEntry(catalog, storedModel);
     await writeCodexCatalogFile(catalogPath, catalogToWrite);
     if (codexCatalogContainsModel(catalogToWrite, storedModel)) {
       effectiveCatalogPath = CODEX_CATALOG_TOML_REF;
@@ -468,7 +468,7 @@ export async function enableCodexFireworks({
     && snapshotReferencesFireworksCatalog(snapshot.raw)
   ) {
     const existingCatalog = await readCodexCatalogIfValid(catalogPath);
-    const catalogToWrite = ensureCodexFirerouterPatternEntry(existingCatalog, storedModel);
+    const catalogToWrite = ensureCodexOffCatalogEntry(existingCatalog, storedModel);
     if (catalogToWrite !== existingCatalog && catalogToWrite) {
       await writeCodexCatalogFile(catalogPath, catalogToWrite);
     }

--- a/packages/setup-cli/lib/harnesses/codex/ide-running.mjs
+++ b/packages/setup-cli/lib/harnesses/codex/ide-running.mjs
@@ -1,0 +1,45 @@
+import { ensureIdeStopped, isIdeRunning, quitInstruction } from "../../io/ide-running.mjs";
+
+/* -------------------------------------------------------------------------- */
+/* Running-ChatGPT guard — the ChatGPT app shares ~/.codex/config.toml and the  */
+/* fireworks-model-catalog.json that `codex on`/`off` writes, but it loads the  */
+/* model catalog into memory at boot. Writing while it's open leaves its        */
+/* dropdown stale (the "custom" provider with no Fireworks models to pick)      */
+/* until the user quits & reopens, so we refuse — with a --force escape.         */
+/* -------------------------------------------------------------------------- */
+
+export const CHATGPT_PROCESS_SPEC = {
+  darwinPattern: "ChatGPT.app/Contents/MacOS/ChatGPT",
+  // The official ChatGPT app's Linux build ships the same Electron shell; the
+  // binary casing varies by distribution, so match either. Ignore Electron
+  // helper/GPU/utility children (`--type=…`); only the main process is named
+  // bare. Mirrors the Cursor/VS Code Linux spec.
+  linuxPattern: "[/](chatgpt|ChatGPT)([[:space:]]|$)",
+  linuxCmdlineMatches: (cmdline) => !/\s--type=/.test(cmdline),
+  windowsImage: "ChatGPT\\.exe",
+};
+
+export const CHATGPT_RUNNING_MESSAGE =
+  `The ChatGPT app is running. ${quitInstruction("the ChatGPT app")} `
+  + "so it reloads the Fireworks model catalog, then rerun. Or pass --force to write anyway (not recommended).";
+
+/**
+ * @returns {boolean} true if the ChatGPT app GUI process is running.
+ */
+export function isChatGptRunning() {
+  return isIdeRunning(CHATGPT_PROCESS_SPEC);
+}
+
+/**
+ * Wait for the ChatGPT app to be quit before writing config/catalog.
+ * Interactive: when the app is running and stdin is a TTY, prints a "quit it"
+ * message and re-prompts (waiting for Enter) until it's no longer running, then
+ * returns so the caller's write proceeds. `force` skips the wait (warns
+ * instead). Non-interactive throws `CHATGPT_RUNNING_MESSAGE`. fireconnect does
+ * not close or reopen the app — the user does.
+ * @param {{ force?: boolean }} [opts]
+ */
+export async function ensureChatGptStopped({ force = false } = {}) {
+  return ensureIdeStopped(CHATGPT_PROCESS_SPEC, CHATGPT_RUNNING_MESSAGE, { force, label: "the ChatGPT app" });
+}
+

--- a/packages/setup-cli/lib/harnesses/codex/index.mjs
+++ b/packages/setup-cli/lib/harnesses/codex/index.mjs
@@ -24,7 +24,7 @@ import {
   printCodexRestartHint,
   readCodexTomlIfExists,
 } from "./core.mjs";
-import { DEFAULT_AZURE_MODEL } from "../../fireworks/azure-core.mjs";
+import { DEFAULT_AZURE_MODEL, AZURE_PROVIDER_LABEL } from "../../fireworks/azure-core.mjs";
 import { isFireworksKey } from "../../keys/key-type.mjs";
 import { finishEnvHarnessOn } from "../../harness/env-hook.mjs";
 import { defineHarnessProfile } from "../../harness/engine.mjs";
@@ -33,6 +33,7 @@ import {
   ensureHomeForHarness,
 } from "../../harness/context.mjs";
 import { codexModelExclusionReason } from "./catalog.mjs";
+import { ensureChatGptStopped } from "./ide-running.mjs";
 import { HARNESS } from "../../harness/id.mjs";
 import { harnessStatusKeySource } from "../../keys/api-key.mjs";
 import { existsSync } from "node:fs";
@@ -70,15 +71,22 @@ export default defineHarnessProfile({
         storedBaseUrl: typeof table?.base_url === "string" ? table.base_url : "",
       };
     },
-    enable: ({ ctx, paths, apiKey, apiKeyFromFlag, baseUrl }) => enableCodexAzure({
-      configPath: paths.configPath,
-      dataDir: paths.dataDir,
-      apiKey,
-      apiKeyFromFlag,
-      baseUrl,
-      modelId: ctx.main,
+    enable: async ({ ctx, paths, apiKey, apiKeyFromFlag, baseUrl }) => {
+      await ensureChatGptStopped({ force: ctx.force });
+      return enableCodexAzure({
+        configPath: paths.configPath,
+        dataDir: paths.dataDir,
+        apiKey,
+        apiKeyFromFlag,
+        baseUrl,
+        modelId: ctx.main,
+      });
+    },
+    restart: () => printCodexRestartHint({
+      resume: true,
+      providerId: CODEX_AZURE_PROVIDER_ID,
+      providerLabel: AZURE_PROVIDER_LABEL,
     }),
-    restart: () => printCodexRestartHint(),
   },
   getExistingHarnessKey: async (_ctx, paths) => {
     const { doc } = await readCodexTomlIfExists(paths.configPath);
@@ -97,6 +105,7 @@ export default defineHarnessProfile({
   },
   // Codex reads keys from the environment (env_key/env_http_headers).
   enable: async ({
+    ctx,
     paths,
     apiKeyRef,
     effectiveKey,
@@ -106,6 +115,7 @@ export default defineHarnessProfile({
     telemetryHeaders,
     includeFirerouter,
   }) => {
+    await ensureChatGptStopped({ force: ctx.force });
     const exclusionReason = codexModelExclusionReason(modelId);
     if (exclusionReason) {
       throw new Error(exclusionReason);
@@ -132,13 +142,16 @@ export default defineHarnessProfile({
   },
   restartHint: () => printCodexRestartHint(),
 
+  // Stop the app before `off` rewrites config.toml/removes the catalog — it
+  // caches the model list at boot. Mirrors Cursor/VS Code's `prepareOff`.
+  prepareOff: (ctx) => ensureChatGptStopped({ force: ctx.force }),
   disable: async ({ paths, wasEnabled }) => disableCodexFireworks({
     configPath: paths.configPath,
     dataDir: paths.dataDir,
     catalogPath: paths.catalogPath,
     wasEnabled,
   }),
-  restartHintOff: () => printCodexRestartHint(),
+  restartHintOff: () => printCodexRestartHint({ resume: false }),
   async providerStatus(ctx) {
     ensureHomeForHarness(ctx, HARNESS.CODEX);
     const { configPath } = codexPathsFor(ctx);

--- a/packages/setup-cli/lib/harnesses/cursor/core.mjs
+++ b/packages/setup-cli/lib/harnesses/cursor/core.mjs
@@ -7,7 +7,7 @@ import {
   defaultMainModel,
   fullFireworksResourceId,
   isFireworksModelId,
-  isFirerouterModel,
+  isFirerouterModelPattern,
   normalizeModelId,
   shortFireworksModelRef,
 } from "../../fireworks/model-id.mjs";
@@ -866,7 +866,7 @@ export async function enableCursorFireworks({ dbPath, dataDir, apiKey, modelId, 
     && (!previousKeyType || previousKeyType === resolvedKeyType)
     && currentModel
     && currentModel !== "default"
-    && !isFirerouterModel(currentModel)
+    && !isFirerouterModelPattern(currentModel)
     && servable(currentModel);
   const resolvedModel = shortFireworksModelRef(
     preserveModeSelections

--- a/packages/setup-cli/lib/harnesses/cursor/index.mjs
+++ b/packages/setup-cli/lib/harnesses/cursor/index.mjs
@@ -6,7 +6,10 @@ import {
 import {
   printStructuredHarnessStatus,
 } from "../../harness/status-display.mjs";
-import { isFirerouterModel } from "../../fireworks/model-id.mjs";
+import {
+  firerouterRequiresAnthropicKey,
+  isFirerouterModelPattern,
+} from "../../fireworks/model-id.mjs";
 import {
   loadRegisterableModels,
 } from "../../fireworks/models.mjs";
@@ -51,6 +54,13 @@ import {
 const CURSOR_FIREROUTER_AZURE_UNSUPPORTED =
   "FireRouter is not supported in Cursor Azure mode.";
 
+// Cursor can't forward a local Anthropic BYOK key (byok: "none"), so an
+// Anthropic-requiring firerouter selection is refused up front.
+const CURSOR_FIREROUTER_ANTHROPIC_REQUIRED_MESSAGE =
+  "This FireRouter selection routes to an Anthropic model, which needs an "
+  + "Anthropic API key Cursor can't forward. Anthropic BYOK support on the "
+  + "Fireworks platform is coming soon.";
+
 function rejectCursorFirerouterWorkspaceByok() {
   throw new Error(FIREROUTER_WORKSPACE_BYOK_REQUIRED_MESSAGE);
 }
@@ -59,18 +69,29 @@ function rejectCursorFirerouterAzure() {
   throw new Error(CURSOR_FIREROUTER_AZURE_UNSUPPORTED);
 }
 
-async function ensureCursorFirerouterAllowed(apiKey) {
+function rejectCursorFirerouterAnthropicKey() {
+  throw new Error(CURSOR_FIREROUTER_ANTHROPIC_REQUIRED_MESSAGE);
+}
+
+/**
+ * Resolve whether Cursor may use FireRouter for this key. Workspace BYOK can
+ * provision provider keys server-side (including Anthropic). Fails open when
+ * the control-plane probe is unavailable — except for Anthropic-requiring
+ * selections with no key, which are refused (Cursor can't forward a local key).
+ * @param {string} apiKey
+ * @param {boolean} requiresAnthropicKey
+ * @returns {Promise<{enabled: boolean, unavailable: boolean}>}
+ */
+async function cursorFirerouterAllowed(apiKey, requiresAnthropicKey) {
   const key = apiKey?.trim() ?? "";
   if (!key) {
-    return;
+    return { enabled: !requiresAnthropicKey, unavailable: true };
   }
   const lookup = await resolveWorkspaceByokStatus(key);
   if (lookup.unavailable) {
-    return;
+    return { enabled: true, unavailable: true };
   }
-  if (!lookup.enabled) {
-    rejectCursorFirerouterWorkspaceByok();
-  }
+  return { enabled: lookup.enabled, unavailable: false };
 }
 
 /**
@@ -97,14 +118,22 @@ async function isCursorAzureOnRequest(ctx) {
 }
 
 async function cursorResolveOnContext(ctx) {
-  if (!isFirerouterModel(ctx.main)) {
+  if (!isFirerouterModelPattern(ctx.main)) {
     return ctx;
   }
   if (await isCursorAzureOnRequest(ctx)) {
     rejectCursorFirerouterAzure();
   }
+  const requiresAnthropicKey = firerouterRequiresAnthropicKey(ctx.main);
   const apiKey = await harnessFullKey(ctx, cursorResolveKey);
-  await ensureCursorFirerouterAllowed(apiKey);
+  const allowed = await cursorFirerouterAllowed(apiKey, requiresAnthropicKey);
+  if (allowed.enabled) {
+    return ctx;
+  }
+  if (requiresAnthropicKey) {
+    rejectCursorFirerouterAnthropicKey();
+  }
+  rejectCursorFirerouterWorkspaceByok();
   return ctx;
 }
 
@@ -133,7 +162,7 @@ export default defineHarnessProfile({
       };
     },
     enable: async ({ ctx, paths, apiKey, baseUrl }) => {
-      if (isFirerouterModel(ctx.main)) {
+      if (isFirerouterModelPattern(ctx.main)) {
         rejectCursorFirerouterAzure();
       }
       await relocateLegacyCursorBackups({ home: ctx.home, dataDir: paths.dataDir });
@@ -146,7 +175,7 @@ export default defineHarnessProfile({
         modelId: ctx.main,
       });
     },
-    restart: () => printRestartHint("Quit & reopen Cursor for the change to take effect."),
+    restart: () => printRestartHint("Quit & reopen Cursor IDE for the change to take effect."),
   },
   enable: async ({ ctx, paths, effectiveKey, keyType, modelId, includeFirerouter = false }) => {
     // Register the preferred catalog; firerouter is workspace-BYOK-gated. A
@@ -194,7 +223,7 @@ export default defineHarnessProfile({
       printNote(`Warning: ${secretEncryptionUnavailableMessage("cursor")}`);
     }
   },
-  restartHint: () => printRestartHint("Quit & reopen Cursor for the change to take effect."),
+  restartHint: () => printRestartHint("Quit & reopen Cursor IDE for the change to take effect."),
 
   // Cursor stores its key in a SQLite secret (no shell env hook), and must be
   // stopped before writing.
@@ -208,7 +237,7 @@ export default defineHarnessProfile({
       wasEnabled,
     });
   },
-  restartHintOff: () => printRestartHint("Quit & reopen Cursor for full effect."),
+  restartHintOff: () => printRestartHint("Quit & reopen Cursor IDE for full effect."),
   async providerStatus(ctx) {
     ensureHomeForHarness(ctx, HARNESS.CURSOR);
     const paths = cursorPathsFor(ctx);

--- a/packages/setup-cli/lib/harnesses/cursor/sqlite.mjs
+++ b/packages/setup-cli/lib/harnesses/cursor/sqlite.mjs
@@ -36,7 +36,7 @@ const CURSOR_PROCESS_SPEC = {
 };
 
 const CURSOR_RUNNING_MESSAGE =
-  `Cursor is running. ${quitInstruction("Cursor")} so the write isn't overwritten by Cursor's in-memory state, then rerun. Or pass --force to write anyway (not recommended).`;
+  `Cursor IDE is running. ${quitInstruction("Cursor IDE")} so the write isn't overwritten by Cursor's in-memory state, then rerun. Or pass --force to write anyway (not recommended).`;
 
 /**
  * @returns {boolean} true if the Cursor GUI process is currently running.

--- a/packages/setup-cli/lib/harnesses/opencode/core.mjs
+++ b/packages/setup-cli/lib/harnesses/opencode/core.mjs
@@ -17,8 +17,8 @@ import {
   defaultMainModel,
   fireworksModelSlug,
   fullFireworksResourceId,
-  isFirerouterGatewayPattern,
-  isFirerouterModel,
+  isAutoModelId,
+  isFirerouterModelPattern,
   normalizeModelId,
   shortFireworksModelRef,
 } from "../../fireworks/model-id.mjs";
@@ -29,7 +29,7 @@ import {
   resolveFireworksModelLabel,
   ROUTER_SPEC_ALIASES,
 } from "../../fireworks/model-specs.mjs";
-import { prettyModelName } from "../../fireworks/models.mjs";
+import { autoDisplayName, firerouterDisplayName, prettyModelName } from "../../fireworks/models.mjs";
 import { lookupFireworksPricing } from "../../fireworks/pricing.mjs";
 import {
   assumedModelsDevListed,
@@ -89,16 +89,16 @@ export const OPENCODE_AZURE_PROVIDER_ID = "fireworks-azure";
 
 /**
  * Whether FireConnect should write a provider.models entry for this model.
- * FireRouter, ROUTER_SPEC_ALIASES "latest" routers, and catalog models absent
- * from models.dev need provider overrides (display name, modalities, limits).
- * Standard catalog entries on models.dev only need config.model.
+ * FireRouter, `auto` / `auto-*`, ROUTER_SPEC_ALIASES "latest" routers, and catalog models
+ * absent from models.dev need provider overrides (display name, modalities,
+ * limits). Standard catalog entries on models.dev only need config.model.
  * @param {string} modelId
  */
 export function opencodeNeedsProviderModelOverride(modelId) {
   if (!modelId || typeof modelId !== "string") {
     return false;
   }
-  if (isFirerouterGatewayPattern(modelId)) {
+  if (isFirerouterModelPattern(modelId) || isAutoModelId(modelId)) {
     return true;
   }
   const slug = fireworksModelSlug(normalizeModelId(modelId));
@@ -144,8 +144,11 @@ export function opencodeConfigModelRef(modelId) {
 }
 
 function opencodeFireworksDisplayName(modelId) {
-  if (isFirerouterModel(modelId)) {
-    return "FireRouter";
+  if (isFirerouterModelPattern(modelId)) {
+    return firerouterDisplayName(modelId);
+  }
+  if (isAutoModelId(modelId)) {
+    return autoDisplayName(modelId);
   }
   const liveLabel = resolveFireworksModelLabel(modelId);
   if (liveLabel) {
@@ -417,7 +420,14 @@ export async function enableOpencodeFireworks({
   // requests through to Anthropic. Drop any stale one when none is supplied
   // (e.g. switching firerouter → a direct model). x-openai-api-key is dropped
   // too, to clean up configs written before OpenAI BYOK was removed.
-  const byokHeaderNames = ["x-anthropic-api-key", "x-openai-api-key"];
+  // x-fireworks-api-key is dropped because the Fireworks key belongs in
+  // options.apiKey, never in a header; stripping it here clears stale keys left
+  // in headers by older releases.
+  const byokHeaderNames = [
+    "x-anthropic-api-key",
+    "x-openai-api-key",
+    "x-fireworks-api-key",
+  ];
   const priorHeaders = Object.fromEntries(
     Object.entries(existing.options?.headers ?? {}).filter(
       ([name]) => !byokHeaderNames.includes(name.toLowerCase()),
@@ -458,7 +468,7 @@ export async function enableOpencodeFireworks({
     return out;
   };
   let models;
-  if (isFirerouterGatewayPattern(storedModel)) {
+  if (isFirerouterModelPattern(storedModel)) {
     models = buildModels([storedModel]);
   } else if (catalog.length) {
     models = buildModels([storedModel, ...catalog]);

--- a/packages/setup-cli/lib/harnesses/pi/core.mjs
+++ b/packages/setup-cli/lib/harnesses/pi/core.mjs
@@ -36,7 +36,7 @@ import {
   cachedFireworksModelIds,
   managedPiFireworksModelIds,
   mergePiFireworksRouterModels,
-  PI_ENABLED_MODELS,
+  piEnabledModels,
 } from "./fireworks-models.mjs";
 import { stripFireconnectTelemetryHeaders } from "../../telemetry/request-headers.mjs";
 
@@ -517,9 +517,9 @@ export async function enablePiFireworks({
     defaultModel: storedModel,
     // Scope Pi's picker to FireConnect's router rows only, hiding Pi's built-in
     // concrete Fireworks models (which surface because they share the fireworks
-    // provider auth). A concrete --model selection still works as defaultModel;
-    // it just isn't pickable. See PI_FIREWORKS_ROUTER_SCOPE.
-    enabledModels: PI_ENABLED_MODELS,
+    // provider auth), plus the active model when it sits outside that scope.
+    // See piEnabledModels.
+    enabledModels: piEnabledModels(storedModel),
   });
   await writeAuthFile(authPath, {
     ...auth,

--- a/packages/setup-cli/lib/harnesses/pi/fireworks-models.mjs
+++ b/packages/setup-cli/lib/harnesses/pi/fireworks-models.mjs
@@ -10,10 +10,10 @@ import {
 import {
   fireworksModelSlug,
   fullFireworksResourceId,
-  isFirerouterGatewayPattern,
-  isFirerouterModel,
+  isAutoModelId,
+  isFirerouterModelPattern,
 } from "../../fireworks/model-id.mjs";
-import { prettyModelName, preferLatestAliases } from "../../fireworks/models.mjs";
+import { autoDisplayName, firerouterDisplayName, prettyModelName, preferLatestAliases } from "../../fireworks/models.mjs";
 import { getServerlessCatalogSnapshot } from "../../fireworks/serverless-catalog-cache.mjs";
 import { mergeFireconnectTelemetryHeaders } from "../../telemetry/request-headers.mjs";
 
@@ -52,8 +52,11 @@ function withPiModelDefaults(model) {
 }
 
 function piFireworksDisplayName(modelId) {
-  if (isFirerouterModel(modelId)) {
-    return "FireRouter";
+  if (isFirerouterModelPattern(modelId)) {
+    return firerouterDisplayName(modelId);
+  }
+  if (isAutoModelId(modelId)) {
+    return autoDisplayName(modelId);
   }
   const liveLabel = resolveFireworksModelLabel(modelId);
   if (liveLabel) {
@@ -105,12 +108,30 @@ export function buildPiCustomFireworksModelEntry(modelId, name, reasoning = true
 export const PI_FIREWORKS_ROUTER_SCOPE = "fireworks/accounts/fireworks/routers/*";
 export const PI_ENABLED_MODELS = [PI_FIREWORKS_ROUTER_SCOPE];
 
+const PI_ROUTER_ID_PREFIX = "accounts/fireworks/routers/";
+
+/**
+ * Pi resolves `defaultModel` through `enabledModels` and silently substitutes
+ * its own built-in default when the model falls outside that scope — which then
+ * 404s, because Pi's default (kimi-k2p5-turbo) is long gone from the gateway.
+ * So any active model that isn't a router-path id (`auto`, a concrete serverless
+ * model, a custom deployment) is enabled explicitly alongside the router scope.
+ * @param {string} activeModelId id as stored in Pi's config
+ */
+export function piEnabledModels(activeModelId) {
+  const stored = fullFireworksResourceId(activeModelId ?? "");
+  if (!stored || stored.startsWith(PI_ROUTER_ID_PREFIX)) {
+    return [...PI_ENABLED_MODELS];
+  }
+  return [...PI_ENABLED_MODELS, `${PI_PROVIDER}/${stored}`];
+}
+
 function isRouterCatalogId(id) {
   if (!id || typeof id !== "string") {
     return false;
   }
   // firerouter* gateway patterns (incl. slash-bearing like firerouter/x).
-  if (isFirerouterGatewayPattern(id)) {
+  if (isFirerouterModelPattern(id)) {
     return true;
   }
   // Router aliases / suffixed router slugs, by the same heuristic
@@ -130,9 +151,9 @@ function piModelsToRegister(resolvedModel, catalogModelIds = []) {
     .filter(isRouterCatalogId);
   const entries = routerCatalog.map((id) => ({ id, name: piFireworksDisplayName(id), reasoning: true }));
   // Always include the active model so a `--model <id>` that isn't in the router
-  // catalog (e.g. a concrete direct model or a custom deployment) is still
-  // registered — it becomes defaultModel. It is hidden from the picker by the
-  // router-only enabledModels scope, but Pi can still use it as the default.
+  // catalog (e.g. `auto`, a concrete direct model, or a custom deployment) is
+  // still registered — it becomes defaultModel, and piEnabledModels adds it to
+  // the scope so Pi actually uses it.
   const resolvedCanonical = fullFireworksResourceId(resolvedModel);
   if (resolvedCanonical
     && !entries.some((entry) => fullFireworksResourceId(entry.id) === resolvedCanonical)) {
@@ -204,7 +225,7 @@ export function mergePiFireworksRouterModels(config, resolvedModel, managedHeade
   // catalog exactly — no accumulation. User-added entries are left untouched.
   // Offline (empty catalog, direct mode) we skip this and merge, so a transient
   // catalog fetch failure doesn't wipe the picker.
-  const rebuilding = isFirerouterGatewayPattern(resolvedModel)
+  const rebuilding = isFirerouterModelPattern(resolvedModel)
     || catalogModelIds.some((id) => typeof id === "string" && id.startsWith("accounts/"));
   if (rebuilding && previousManagedIds.length) {
     const prior = new Set(previousManagedIds.map(fullFireworksResourceId));

--- a/packages/setup-cli/lib/harnesses/vscode/core.mjs
+++ b/packages/setup-cli/lib/harnesses/vscode/core.mjs
@@ -6,8 +6,10 @@ import os from "node:os";
 import path from "node:path";
 import {
   defaultMainModel,
+  firerouterRequiresAnthropicKey,
+  isAutoModelId,
+  isFirerouterModelPattern,
   fullFireworksResourceId,
-  isFirerouterModel,
   normalizeModelId,
   shortFireworksModelRef,
 } from "../../fireworks/model-id.mjs";
@@ -18,7 +20,7 @@ import {
   MISSING_FIREWORKS_API_KEY_MESSAGE,
 } from "../../keys/key-type.mjs";
 import { resolveModelDisplayMetadata } from "../../fireworks/model-display.mjs";
-import { FIREPASS_ROUTER_ID, prettyModelName } from "../../fireworks/models.mjs";
+import { FIREPASS_ROUTER_ID, autoDisplayName, firerouterDisplayName, prettyModelName } from "../../fireworks/models.mjs";
 import {
   AZURE_API_KEY_ENV,
   AZURE_API_KEY_ENV_REF,
@@ -308,7 +310,7 @@ export function fireconnectRegisteredModels(arr) {
  */
 export function vscodeStoredByokHeaders(arr) {
   const provider = findFireconnectProvider(arr);
-  const model = (provider?.models ?? []).find((m) => isFirerouterModel(m.id));
+  const model = (provider?.models ?? []).find((m) => firerouterRequiresAnthropicKey(m.id));
   if (!model) {
     return {};
   }
@@ -332,7 +334,11 @@ export function vscodeStoredByokHeaders(arr) {
 export function buildModelEntry(modelId) {
   return {
     id: shortFireworksModelRef(modelId),
-    name: prettyModelName(modelId),
+    name: isFirerouterModelPattern(modelId)
+      ? firerouterDisplayName(modelId)
+      : isAutoModelId(modelId)
+        ? autoDisplayName(modelId)
+        : prettyModelName(modelId),
     url: VSCODE_FIREWORKS_MODEL_URL,
     ...resolveModelDisplayMetadata(modelId),
   };
@@ -873,40 +879,6 @@ export async function disableVscodeFireworks({
     await writeChatLanguageModels(vscodePath, next);
   }
   return "stripped";
-}
-
-/**
- * Flip the fireconnect-owned provider's `apiType` from `"responses"` to
- * `"chat-completions"` — the upgrade migration for installs configured when
- * direct Fireworks routing used the Responses wire. No-ops (returns `false`)
- * when there is no fireconnect provider, when it is already chat-completions
- * (Azure included), or when VS Code is running (its exit rewrite would
- * discard the edit). The secret store is untouched — the `apiKey` reference
- * and the `state.vscdb` row stay as they are.
- *
- * `isRunning` is injectable so the guard is unit-testable without a real IDE.
- * @param {{ home?: string, vscodePath?: string, isRunning?: () => boolean }} opts
- * @returns {Promise<boolean>} whether the file was rewritten
- */
-export async function migrateVscodeResponsesApiType({
-  home = "",
-  vscodePath = "",
-  isRunning = isVscodeRunning,
-} = {}) {
-  const jsonPath = vscodePath || chatLanguageModelsPath({ home });
-  const arr = await readChatLanguageModels(jsonPath);
-  const provider = findFireconnectProvider(arr);
-  if (!provider || provider.apiType !== "responses") {
-    return false;
-  }
-  if (isRunning()) {
-    return false;
-  }
-  await writeChatLanguageModels(
-    jsonPath,
-    arr.map((p) => (p === provider ? { ...p, apiType: "chat-completions" } : p)),
-  );
-  return true;
 }
 
 /**

--- a/packages/setup-cli/lib/harnesses/vscode/request-headers.mjs
+++ b/packages/setup-cli/lib/harnesses/vscode/request-headers.mjs
@@ -1,4 +1,7 @@
-import { isFirerouterModel } from "../../fireworks/model-id.mjs";
+import {
+  firerouterRequiresAnthropicKey,
+  isFirerouterModelPattern,
+} from "../../fireworks/model-id.mjs";
 import {
   ANTHROPIC_BYOK_BODY_FIELD,
   ANTHROPIC_BYOK_HEADER,
@@ -14,15 +17,25 @@ export function withFireconnectRequestHeaders(
   model,
   { telemetryHeaders = {}, byokHeaders = {} } = {},
 ) {
-  const firerouter = isFirerouterModel(model.id);
+  // Attach byokHeaders (incl. routing-preference) for any firerouter selection;
+  // strip the Anthropic BYOK key when the selection doesn't route to Anthropic.
+  const firerouter = isFirerouterModelPattern(model.id);
+  const needsAnthropicKey = firerouterRequiresAnthropicKey(model.id);
   const priorHeaders = Object.fromEntries(
     Object.entries(model.requestHeaders ?? {}).filter(
       ([name]) => !BYOK_HEADER_NAMES.has(name.toLowerCase()),
     ),
   );
+  const attachedByok = firerouter
+    ? Object.fromEntries(
+        Object.entries(byokHeaders).filter(
+          ([name]) => needsAnthropicKey || name.toLowerCase() !== ANTHROPIC_BYOK_HEADER,
+        ),
+      )
+    : {};
   const requestHeaders = {
     ...mergeFireconnectTelemetryHeaders(priorHeaders, telemetryHeaders),
-    ...(firerouter ? byokHeaders : {}),
+    ...attachedByok,
   };
   const next = { ...model };
   if (Object.keys(requestHeaders).length) {
@@ -31,7 +44,7 @@ export function withFireconnectRequestHeaders(
     delete next.requestHeaders;
   }
   const anthropicKey = byokHeaders[ANTHROPIC_BYOK_HEADER];
-  if (firerouter && anthropicKey) {
+  if (needsAnthropicKey && anthropicKey) {
     next[ANTHROPIC_BYOK_BODY_FIELD] = anthropicKey;
   } else {
     delete next[ANTHROPIC_BYOK_BODY_FIELD];

--- a/packages/setup-cli/lib/harnesses/vscode/upgrade-migrations.mjs
+++ b/packages/setup-cli/lib/harnesses/vscode/upgrade-migrations.mjs
@@ -1,0 +1,41 @@
+import {
+  chatLanguageModelsPath,
+  findFireconnectProvider,
+  isVscodeRunning,
+  readChatLanguageModels,
+  writeChatLanguageModels,
+} from "./core.mjs";
+
+/**
+ * Flip the fireconnect-owned provider's `apiType` from `"responses"` to
+ * `"chat-completions"` — the upgrade migration for installs configured when
+ * direct Fireworks routing used the Responses wire. No-ops (returns `false`)
+ * when there is no fireconnect provider, when it is already chat-completions
+ * (Azure included), or when VS Code is running (its exit rewrite would
+ * discard the edit). The secret store is untouched — the `apiKey` reference
+ * and the `state.vscdb` row stay as they are.
+ *
+ * `isRunning` is injectable so the guard is unit-testable without a real IDE.
+ * @param {string} home
+ * @param {{ vscodePath?: string, isRunning?: () => boolean }} [options]
+ * @returns {Promise<boolean>} whether the file was rewritten
+ */
+export async function migrateVscodeResponsesApiType(home, {
+  vscodePath = "",
+  isRunning = isVscodeRunning,
+} = {}) {
+  const jsonPath = vscodePath || chatLanguageModelsPath({ home });
+  const arr = await readChatLanguageModels(jsonPath);
+  const provider = findFireconnectProvider(arr);
+  if (!provider || provider.apiType !== "responses") {
+    return false;
+  }
+  if (isRunning()) {
+    return false;
+  }
+  await writeChatLanguageModels(
+    jsonPath,
+    arr.map((p) => (p === provider ? { ...p, apiType: "chat-completions" } : p)),
+  );
+  return true;
+}

--- a/packages/setup-cli/lib/keys/builtin-file-secret-store.mjs
+++ b/packages/setup-cli/lib/keys/builtin-file-secret-store.mjs
@@ -200,6 +200,23 @@ export async function builtinSetPassword(service, account, password) {
 }
 
 /**
+ * Write and readback-verify a secret in the builtin encrypted-file store.
+ *
+ * @param {string} service
+ * @param {string} account
+ * @param {string} password
+ */
+export async function storeBuiltinFileSecretVerified(service, account, password) {
+  const trimmed = password?.trim() ?? "";
+  await builtinSetPassword(service, account, trimmed);
+  const readback = await builtinGetPassword(service, account);
+  if (!readback || readback.trim() !== trimmed) {
+    const where = secretsFilePath() ?? "the encrypted file store";
+    throw new Error(`Storage verification failed: the key could not be read back from ${where}.`);
+  }
+}
+
+/**
  * @param {string} service
  * @param {string} account
  */

--- a/packages/setup-cli/lib/keys/keyring-timeout.mjs
+++ b/packages/setup-cli/lib/keys/keyring-timeout.mjs
@@ -1,0 +1,43 @@
+/** Match cross-keychain's secret-tool backend command timeout. */
+export const KEYRING_OP_TIMEOUT_MS = 10_000;
+
+export class KeyringTimeoutError extends Error {
+  /**
+   * @param {string} label Short operation name for error messages.
+   * @param {number} [timeoutMs]
+   */
+  constructor(label, timeoutMs = KEYRING_OP_TIMEOUT_MS) {
+    super(`Keyring operation timed out after ${timeoutMs}ms (${label})`);
+    this.name = "KeyringTimeoutError";
+    this.label = label;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Bound a cross-keychain / libsecret call so a dead OS keyring cannot hang the
+ * CLI indefinitely (common on SSH sessions without an unlocked gnome-keyring).
+ *
+ * Note: this unblocks the caller only; the underlying subprocess is not
+ * cancelled and may continue until the OS keyring responds.
+ *
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {string} label Short operation name for error messages.
+ * @returns {Promise<T>}
+ */
+export async function withKeyringTimeout(promise, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new KeyringTimeoutError(label));
+        }, KEYRING_OP_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/setup-cli/lib/keys/secret-backend-detect.mjs
+++ b/packages/setup-cli/lib/keys/secret-backend-detect.mjs
@@ -1,0 +1,32 @@
+export const ENCRYPTED_FILE_BACKEND_LABEL = "Encrypted file (AES-256-GCM, 0600)";
+
+const DEFAULT_FILE_UNAVAILABLE_ERROR =
+  "HOME is not set and XDG_DATA_HOME is unset. Set HOME (or XDG_DATA_HOME) to a writable path so the encrypted-file store can be created.";
+
+/**
+ * @param {string | null} fileLocation
+ * @param {{ forced?: boolean, error?: string, unavailableError?: string }} [options]
+ * @returns {{
+ *   backend: "file" | "unavailable",
+ *   label: string,
+ *   location?: string,
+ *   forced?: boolean,
+ *   error?: string,
+ * }}
+ */
+export function fileBackendDetectionResult(fileLocation, options = {}) {
+  if (!fileLocation) {
+    return {
+      backend: "unavailable",
+      label: "Unavailable",
+      error: options.unavailableError ?? options.error ?? DEFAULT_FILE_UNAVAILABLE_ERROR,
+    };
+  }
+  return {
+    backend: "file",
+    label: ENCRYPTED_FILE_BACKEND_LABEL,
+    location: fileLocation,
+    ...(options.forced !== undefined ? { forced: options.forced } : {}),
+    ...(options.error ? { error: options.error } : {}),
+  };
+}

--- a/packages/setup-cli/lib/keys/secret-fallbacks.mjs
+++ b/packages/setup-cli/lib/keys/secret-fallbacks.mjs
@@ -1,0 +1,158 @@
+import { accent, warn as uiWarn } from "../ui.mjs";
+import {
+  builtinFileStoreAvailable,
+  secretsFilePath,
+  storeBuiltinFileSecretVerified,
+} from "./builtin-file-secret-store.mjs";
+import {
+  deletePlaintextSecret,
+  plaintextSecretPath,
+  plaintextSecretStoreAvailable,
+  readPlaintextSecret,
+  writePlaintextSecret,
+} from "./plaintext-secret-store.mjs";
+import { isKeyStorageForcedNull } from "./storage-env.mjs";
+
+/**
+ * @typedef {object} SecretFallbackDeps
+ * @property {(home?: string) => string} resolveHome
+ * @property {(resolvedHome: string, fn: () => Promise<void>) => Promise<void>} withHomeScopedEnv
+ * @property {(home: string, storage: "keychain" | "file" | "plaintext", reason?: string, options?: { required?: boolean }) => Promise<void>} persistKeyStorageCache
+ * @property {(home: string) => Promise<void>} clearKeyStorageCache
+ * @property {(home?: string) => Promise<void>} deleteSecretFromSecureBackend
+ * @property {(resolvedHome: string, account: string, value: string) => void} primeSecureReadCache
+ * @property {() => void} clearLastReadError
+ * @property {string} secretService
+ * @property {string} secretAccount
+ */
+
+/**
+ * @param {SecretFallbackDeps} deps
+ */
+export function createSecretFallbackHandlers(deps) {
+  /**
+   * @param {string} value
+   * @param {string} home
+   * @param {unknown} cause
+   * @param {string} [account]
+   * @returns {Promise<boolean>}
+   */
+  async function storeSecretInFileFallback(value, home, cause, account = deps.secretAccount) {
+    const trimmed = value?.trim() ?? "";
+    const resolvedHome = deps.resolveHome(home);
+    if (!builtinFileStoreAvailable()) {
+      return false;
+    }
+
+    try {
+      await deps.withHomeScopedEnv(resolvedHome, async () => {
+        await storeBuiltinFileSecretVerified(deps.secretService, account, trimmed);
+      });
+    } catch {
+      return false;
+    }
+
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    try {
+      await deps.persistKeyStorageCache(resolvedHome, "file", reason, { required: true });
+    } catch (error) {
+      await deps.clearKeyStorageCache(resolvedHome);
+      throw error;
+    }
+    deps.clearLastReadError();
+    deps.primeSecureReadCache(resolvedHome, account, trimmed);
+
+    const location = secretsFilePath() ?? "~/.local/share/keyring/secrets.json";
+    console.warn(uiWarn(
+      `OS keychain storage was unavailable (${reason}); stored the Fireworks API key `
+        + `in an encrypted file at ${location} (AES-256-GCM, 0600). Run ${accent("fireconnect upgrade")} once an OS `
+        + "keychain is available to move it back to secure storage.",
+    ));
+    try {
+      await deletePlaintextSecret(resolvedHome);
+    } catch {
+      // Secure file storage + cache are authoritative.
+    }
+    return true;
+  }
+
+  /**
+   * @param {string} value
+   * @param {string} home
+   * @param {unknown} cause
+   */
+  async function storeSecretInPlaintextFallback(value, home, cause) {
+    const trimmed = value?.trim() ?? "";
+    const previousPlaintext = await readPlaintextSecret(home);
+    await writePlaintextSecret(home, trimmed);
+    const readback = (await readPlaintextSecret(home))?.trim() ?? "";
+    if (readback !== trimmed) {
+      throw new Error(
+        "Storage verification failed: the key could not be read back from the plaintext fallback file.",
+      );
+    }
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    try {
+      await deps.persistKeyStorageCache(home, "plaintext", reason, { required: true });
+    } catch (error) {
+      try {
+        if (previousPlaintext?.trim()) {
+          await writePlaintextSecret(home, previousPlaintext);
+        } else {
+          await deletePlaintextSecret(home);
+        }
+      } catch {
+        // Rollback is best-effort; surface the cache persist failure.
+      }
+      throw error;
+    }
+    try {
+      await deps.deleteSecretFromSecureBackend(home);
+    } catch {
+      // Best-effort; getSecret/hasSecret ignore lingering secure copies once
+      // plaintext fallback has committed (cache carries the fallback reason).
+    }
+    deps.clearLastReadError();
+    const location = plaintextSecretPath(home) ?? "~/.fireconnect/.api-key";
+    console.warn(uiWarn(
+      `secure storage was unavailable (${reason}); stored the Fireworks API key `
+        + `in a plaintext file at ${location} (0600). Run ${accent("fireconnect upgrade")} once an OS `
+        + "keychain is available to move it back to secure storage.",
+    ));
+  }
+
+  /**
+   * secure → encrypted file → plaintext ladder shared by setSecret and reprobe.
+   *
+   * @param {string} value
+   * @param {string} [home]
+   * @param {(value: string, home?: string) => Promise<void>} storeSecure
+   * @returns {Promise<"secure" | "file" | "plaintext">}
+   */
+  async function storeSecretWithFallbacks(value, home, storeSecure) {
+    const trimmed = value?.trim() ?? "";
+    const resolvedHome = deps.resolveHome(home);
+    try {
+      await storeSecure(trimmed, home);
+      return "secure";
+    } catch (error) {
+      if (isKeyStorageForcedNull()) {
+        throw error;
+      }
+      if (await storeSecretInFileFallback(trimmed, resolvedHome, error)) {
+        return "file";
+      }
+      if (!plaintextSecretStoreAvailable(resolvedHome)) {
+        throw error;
+      }
+      await storeSecretInPlaintextFallback(trimmed, resolvedHome, error);
+      return "plaintext";
+    }
+  }
+
+  return {
+    storeSecretInFileFallback,
+    storeSecretInPlaintextFallback,
+    storeSecretWithFallbacks,
+  };
+}

--- a/packages/setup-cli/lib/keys/secret-store.mjs
+++ b/packages/setup-cli/lib/keys/secret-store.mjs
@@ -1,14 +1,13 @@
 import { mkdir, readFile, unlink } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
-import { accent, warn as uiWarn } from "../ui.mjs";
 import {
   builtinDeletePassword,
   builtinFileStoreAvailable,
   builtinGetPassword,
   builtinHasPassword,
-  builtinSetPassword,
   secretsFilePath,
+  storeBuiltinFileSecretVerified,
 } from "./builtin-file-secret-store.mjs";
 import { ensureCliDependencies } from "../system/ensure-cli-deps.mjs";
 import {
@@ -17,7 +16,6 @@ import {
   plaintextSecretPath,
   plaintextSecretStoreAvailable,
   readPlaintextSecret,
-  writePlaintextSecret,
 } from "./plaintext-secret-store.mjs";
 import {
   clearKeyStorageCache,
@@ -27,8 +25,8 @@ import {
 } from "./storage-cache.mjs";
 import {
   FIRECONNECT_KEY_STORAGE_ENV,
+  effectiveKeyStorageOverride,
   formatKeyStorageOverrideHint,
-  isKeyStorageForcedNull,
   readKeyStorageOverride,
 } from "./storage-env.mjs";
 
@@ -38,6 +36,10 @@ export {
 } from "./storage-env.mjs";
 
 import { writeFileAtomic } from "../io/atomic-write.mjs";
+import { KeyringTimeoutError, withKeyringTimeout } from "./keyring-timeout.mjs";
+import { shouldPreferFileBackendOnLinux } from "../config/secret-storage-policy.mjs";
+import { fileBackendDetectionResult } from "./secret-backend-detect.mjs";
+import { createSecretFallbackHandlers } from "./secret-fallbacks.mjs";
 
 export const SECRET_SERVICE = "FireworksAI";
 export const SECRET_ACCOUNT = "fireworks-api-key";
@@ -271,6 +273,7 @@ export function resetSecretStoreForTests() {
   memoryStoreHomeOverride = null;
   keychainModule = null;
   keychainModulePromise = null;
+  fallbackHandlers = null;
   secureReadCache.clear();
   void clearKeyStorageCache();
   if (weSetCrossKeychainBackendEnv) {
@@ -371,7 +374,7 @@ async function secureBackendKind(home) {
   if (!keychain) {
     return "file";
   }
-  const forced = readKeyStorageOverride();
+  const forced = effectiveKeyStorageOverride();
   if (forced === FILE_BACKEND_ID) {
     return "file";
   }
@@ -398,12 +401,7 @@ async function storeSecretInSecureBackend(value, home, account = SECRET_ACCOUNT)
     const keychain = await loadKeychainModule();
     if (!keychain) {
       if (useBuiltinFileFallback()) {
-        await builtinSetPassword(SECRET_SERVICE, account, trimmed);
-        const readback = await builtinGetPassword(SECRET_SERVICE, account);
-        if (!readback || readback.trim() !== trimmed) {
-          const where = secretsFilePath() ?? "the encrypted file store";
-          throw new Error(`Storage verification failed: the key could not be read back from ${where}.`);
-        }
+        await storeBuiltinFileSecretVerified(SECRET_SERVICE, account, trimmed);
         lastReadError = null;
         secureReadCache.set(secureCacheKey(resolvedHome, account), trimmed);
         return;
@@ -416,7 +414,10 @@ async function storeSecretInSecureBackend(value, home, account = SECRET_ACCOUNT)
 
     try {
       await ensureBackendEnv(keychain);
-      await keychain.setPassword(SECRET_SERVICE, account, trimmed);
+      await withKeyringTimeout(
+        keychain.setPassword(SECRET_SERVICE, account, trimmed),
+        "setPassword",
+      );
     } catch (error) {
       throw friendlySecretError(error, home);
     }
@@ -430,7 +431,10 @@ async function storeSecretInSecureBackend(value, home, account = SECRET_ACCOUNT)
     if ((await secureBackendKind(home)) !== "keychain") {
       let readback = null;
       try {
-          readback = await keychain.getPassword(SECRET_SERVICE, account);
+        readback = await withKeyringTimeout(
+          keychain.getPassword(SECRET_SERVICE, account),
+          "getPassword",
+        );
       } catch (error) {
         throw friendlySecretError(error, home);
       }
@@ -478,7 +482,10 @@ async function readSecretFromSecureBackend(home, account = SECRET_ACCOUNT) {
 
     try {
       await ensureBackendEnv(keychain);
-      const value = await keychain.getPassword(SECRET_SERVICE, account);
+      const value = await withKeyringTimeout(
+        keychain.getPassword(SECRET_SERVICE, account),
+        "getPassword",
+      );
       lastReadError = null;
       secureReadCache.set(cacheKey, value ?? null);
       return value;
@@ -519,61 +526,14 @@ async function deleteSecretFromSecureBackend(home, account = SECRET_ACCOUNT) {
 
     try {
       await ensureBackendEnv(keychain);
-      await keychain.deletePassword(SECRET_SERVICE, account);
+      await withKeyringTimeout(
+        keychain.deletePassword(SECRET_SERVICE, account),
+        "deletePassword",
+      );
     } catch {
       // Missing entry is fine.
     }
   });
-}
-
-/**
- * @param {string} value
- * @param {string} home
- * @param {unknown} cause
- */
-async function storeSecretInPlaintextFallback(value, home, cause) {
-  const trimmed = value?.trim() ?? "";
-  const previousPlaintext = await readPlaintextSecret(home);
-  await writePlaintextSecret(home, trimmed);
-  const readback = (await readPlaintextSecret(home))?.trim() ?? "";
-  if (readback !== trimmed) {
-    throw new Error(
-      "Storage verification failed: the key could not be read back from the plaintext fallback file.",
-    );
-  }
-  const reason = cause instanceof Error ? cause.message : String(cause);
-  try {
-    await persistKeyStorageCache(home, "plaintext", reason, { required: true });
-  } catch (error) {
-    try {
-      if (previousPlaintext?.trim()) {
-        await writePlaintextSecret(home, previousPlaintext);
-      } else {
-        await deletePlaintextSecret(home);
-      }
-    } catch {
-      // Rollback is best-effort; surface the cache persist failure.
-    }
-    throw error;
-  }
-  try {
-    await deleteSecretFromSecureBackend(home);
-  } catch {
-    // Best-effort; getSecret/hasSecret ignore lingering secure copies once
-    // plaintext fallback has committed (cache carries the fallback reason).
-  }
-  lastReadError = null;
-  // Never let a secure→plaintext downgrade be silent: persisting the key in
-  // cleartext (0600) removes the keychain/encrypted-store guarantee, so warn
-  // on stderr at the moment it happens. Callers that print their own
-  // backend-aware summary (login, <harness> on) still do; this guarantees the
-  // warning even on the automatic migration paths that don't.
-  const location = plaintextSecretPath(home) ?? "~/.fireconnect/.api-key";
-  console.warn(uiWarn(
-    `secure storage was unavailable (${reason}); stored the Fireworks API key `
-      + `in a plaintext file at ${location} (0600). Run ${accent("fireconnect upgrade")} once an OS `
-      + "keychain is available to move it back to secure storage.",
-  ));
 }
 
 /**
@@ -622,6 +582,30 @@ async function finalizeSecureSecretWrite(resolvedHome, home) {
   } catch {
     // Secure storage + cache are authoritative once the cache is updated.
   }
+}
+
+/** @type {ReturnType<typeof createSecretFallbackHandlers> | null} */
+let fallbackHandlers = null;
+
+function getFallbackHandlers() {
+  if (!fallbackHandlers) {
+    fallbackHandlers = createSecretFallbackHandlers({
+      resolveHome,
+      withHomeScopedEnv,
+      persistKeyStorageCache,
+      clearKeyStorageCache,
+      deleteSecretFromSecureBackend,
+      primeSecureReadCache: (resolvedHome, account, value) => {
+        secureReadCache.set(secureCacheKey(resolvedHome, account), value);
+      },
+      clearLastReadError: () => {
+        lastReadError = null;
+      },
+      secretService: SECRET_SERVICE,
+      secretAccount: SECRET_ACCOUNT,
+    });
+  }
+  return fallbackHandlers;
 }
 
 function isTestSecretStoreContext() {
@@ -702,7 +686,11 @@ function pickNativeBackendId(backends) {
  * @param {typeof import("cross-keychain")} keychain
  */
 async function ensureBackendEnv(keychain) {
-  const forced = readKeyStorageOverride();
+  const forced = effectiveKeyStorageOverride();
+  if (!forced && shouldPreferFileBackendOnLinux()) {
+    applyCrossKeychainBackend(FILE_BACKEND_ID);
+    return;
+  }
   if (!forced) {
     return;
   }
@@ -793,6 +781,12 @@ function friendlySecretError(error, home) {
         + "Set HOME to a writable directory and re-run `fireconnect configure`.",
     );
   }
+  if (err instanceof KeyringTimeoutError || name === "KeyringTimeoutError") {
+    return new Error(
+      "The OS keychain did not respond in time (common on SSH without an unlocked keyring). "
+        + `Use ${formatKeyStorageOverrideHint("file")} or export FIREWORKS_API_KEY for this session.`,
+    );
+  }
   const detail = err?.message ? ` ${err.message}` : "";
   return new Error(`Could not store the API key in the secret store.${detail}`);
 }
@@ -840,13 +834,9 @@ export async function detectSecretBackend(home = process.env.HOME ?? "") {
   const keychain = await loadKeychainModule();
   if (!keychain) {
     if (builtinFileStoreAvailable()) {
-      const fileLocation = secretsFilePath();
-      return {
-        backend: "file",
-        label: "Encrypted file (AES-256-GCM, 0600)",
-        location: fileLocation ?? undefined,
+      return fileBackendDetectionResult(secretsFilePath(), {
         error: "The cross-keychain secret module could not be loaded; using the built-in encrypted-file fallback. Reinstall FireConnect (`fireconnect upgrade`) to restore full keychain support.",
-      };
+      });
     }
     return {
       backend: "unavailable",
@@ -855,7 +845,8 @@ export async function detectSecretBackend(home = process.env.HOME ?? "") {
     };
   }
 
-  const forced = readKeyStorageOverride();
+  const forced = effectiveKeyStorageOverride();
+  const explicit = readKeyStorageOverride();
   // Prefer cross-keychain's own data root so the reported location matches
   // where its file backend actually writes (it uses os.homedir()/XDG, which can
   // differ from the process.env.HOME fallback in keychainFileDataRoot).
@@ -871,19 +862,10 @@ export async function detectSecretBackend(home = process.env.HOME ?? "") {
   const fileLocation = dataRoot ? path.join(dataRoot, "secrets.json") : null;
 
   if (forced === FILE_BACKEND_ID) {
-    if (!fileLocation) {
-      return {
-        backend: "unavailable",
-        label: "Unavailable",
-        error: `${formatKeyStorageOverrideHint("file")} but HOME is not set and XDG_DATA_HOME is unset. Set HOME or XDG_DATA_HOME to a writable path.`,
-      };
-    }
-    return {
-      backend: "file",
-      label: "Encrypted file (AES-256-GCM, 0600)",
-      location: fileLocation,
-      forced: true,
-    };
+    return fileBackendDetectionResult(fileLocation, {
+      forced: explicit === FILE_BACKEND_ID,
+      unavailableError: `${formatKeyStorageOverrideHint("file")} but HOME is not set and XDG_DATA_HOME is unset. Set HOME or XDG_DATA_HOME to a writable path.`,
+    });
   }
   if (forced === NULL_BACKEND_ID) {
     return {
@@ -919,7 +901,10 @@ export async function detectSecretBackend(home = process.env.HOME ?? "") {
     };
   }
 
-  // auto
+  // auto — SSH/WSL remote Linux uses encrypted file instead of libsecret.
+  if (shouldPreferFileBackendOnLinux()) {
+    return fileBackendDetectionResult(fileLocation);
+  }
   if (nativeId) {
     return {
       backend: "keychain",
@@ -927,18 +912,7 @@ export async function detectSecretBackend(home = process.env.HOME ?? "") {
     };
   }
   if (hasFile) {
-    if (!fileLocation) {
-      return {
-        backend: "unavailable",
-        label: "Unavailable",
-        error: "HOME is not set and XDG_DATA_HOME is unset. Set HOME (or XDG_DATA_HOME) to a writable path so the encrypted-file store can be created.",
-      };
-    }
-    return {
-      backend: "file",
-      label: "Encrypted file (AES-256-GCM, 0600)",
-      location: fileLocation,
-    };
+    return fileBackendDetectionResult(fileLocation);
   }
   if (plaintextSecretStoreAvailable(home) && await hasPlaintextSecret(home)) {
     return {
@@ -1029,17 +1003,14 @@ export async function setSecret(value, home) {
   }
 
   const resolvedHome = resolveHome(home);
-  try {
-    await storeSecretInSecureBackend(trimmed, home);
-  } catch (error) {
-    if (isKeyStorageForcedNull() || !plaintextSecretStoreAvailable(resolvedHome)) {
-      throw error;
-    }
-    await storeSecretInPlaintextFallback(trimmed, resolvedHome, error);
-    return;
+  const outcome = await getFallbackHandlers().storeSecretWithFallbacks(
+    trimmed,
+    home,
+    storeSecretInSecureBackend,
+  );
+  if (outcome === "secure") {
+    await finalizeSecureSecretWrite(resolvedHome, home);
   }
-
-  await finalizeSecureSecretWrite(resolvedHome, home);
 }
 
 /**
@@ -1145,15 +1116,18 @@ export async function reprobeKeyStorage(home = process.env.HOME ?? "") {
   keychainModulePromise = null;
 
   if (plaintextKey) {
-    try {
-      await storeSecretInSecureBackend(plaintextKey, resolvedHome);
-    } catch (error) {
-      await storeSecretInPlaintextFallback(plaintextKey, resolvedHome, error);
-      return { migrated: false, backend: await detectSecretBackend(resolvedHome) };
+    const outcome = await getFallbackHandlers().storeSecretWithFallbacks(
+      plaintextKey,
+      resolvedHome,
+      storeSecretInSecureBackend,
+    );
+    if (outcome === "secure") {
+      await finalizeSecureSecretWrite(resolvedHome, resolvedHome);
     }
-
-    await finalizeSecureSecretWrite(resolvedHome, resolvedHome);
-    return { migrated: true, backend: await detectSecretBackend(resolvedHome) };
+    return {
+      migrated: outcome !== "plaintext",
+      backend: await detectSecretBackend(resolvedHome),
+    };
   }
 
   const backend = await detectSecretBackend(resolvedHome);

--- a/packages/setup-cli/lib/keys/storage-env.mjs
+++ b/packages/setup-cli/lib/keys/storage-env.mjs
@@ -13,6 +13,12 @@ export function readKeyStorageOverride() {
     || "";
 }
 
+/** Effective override; tests default to file storage instead of the OS keychain. */
+export function effectiveKeyStorageOverride() {
+  return readKeyStorageOverride()
+    || (process.env.FIRECONNECT_TEST === "1" ? "file" : "");
+}
+
 /**
  * @returns {boolean}
  */

--- a/packages/setup-cli/lib/keys/sync.mjs
+++ b/packages/setup-cli/lib/keys/sync.mjs
@@ -8,7 +8,6 @@ import {
 } from "../harnesses/deepseek/core.mjs";
 import { opencodeConfigPath, refreshOpencodeGatewayKey } from "../harnesses/opencode/core.mjs";
 import { piAuthPath, refreshPiGatewayKey } from "../harnesses/pi/core.mjs";
-import { migrateVscodeResponsesApiType } from "../harnesses/vscode/core.mjs";
 import {
   FIREWORKS_API_KEY_KEYCHAIN_REF,
   readGlobalConfig,
@@ -117,13 +116,13 @@ export async function syncBakedKeysAfterStore(home, fireworksKey) {
 }
 
 /**
- * Post-upgrade reconciliation for harness configs: rebake every enabled
- * Fireworks harness config to plaintext literals (including legacy
- * env-reference auth), repair a stale global `{env:FIREWORKS_API_KEY}` ref
- * when keychain holds the secret, migrate a pre-chat-completions VS Code
- * provider (`apiType: "responses"`), and reconcile the shell hook (Anthropic
- * export for Codex BYOK; no FIREWORKS export — websearch MCP bakes its
- * Bearer token).
+ * Post-upgrade key reconciliation: rebake every enabled Fireworks harness
+ * config to plaintext literals (including legacy env-reference auth), repair
+ * a stale global `{env:FIREWORKS_API_KEY}` ref when keychain holds the secret,
+ * and reconcile the shell hook (Anthropic export for Codex BYOK; no FIREWORKS
+ * export — websearch MCP bakes its Bearer token).
+ *
+ * Key-independent harness migrations live in `system/forward-migrations.mjs`.
  * Never throws.
  * @param {string} home
  * @returns {Promise<string[]>}
@@ -148,18 +147,6 @@ export async function reconcileHarnessConfigOnUpgrade(home) {
     }
   } catch {
     // Best-effort config repair — rebake may still use the keychain secret directly.
-  }
-  try {
-    // VS Code's provider apiType lives in chatLanguageModels.json (no baked
-    // key), so it isn't part of the baked-key sync below — flip pre-0.9.2
-    // "responses" providers to chat-completions here instead. Runs before key
-    // resolution: the migration is key-independent and must not be skipped
-    // when keychain/key lookup fails (that path returns early).
-    if (await migrateVscodeResponsesApiType({ home })) {
-      notes.push("Updated VS Code's Fireworks provider to the chat-completions API — restart VS Code to pick it up.");
-    }
-  } catch {
-    // Best-effort VS Code migration — never fail upgrade over chatLanguageModels.json I/O.
   }
   let key = "";
   try {

--- a/packages/setup-cli/lib/keys/verify-api-key.mjs
+++ b/packages/setup-cli/lib/keys/verify-api-key.mjs
@@ -1,5 +1,6 @@
 import process from "node:process";
 import { FIREWORKS_GATEWAY_URL } from "../fireworks/models.mjs";
+import { fireworksGatewayFetchSignal } from "../fireworks/gateway-fetch.mjs";
 
 /**
  * @typedef {Object} VerifyResult
@@ -31,6 +32,7 @@ export async function verifyFireworksApiKey(apiKey, { gatewayUrl = "" } = {}) {
   try {
     response = await fetch(`${base}/verifyApiKey`, {
       headers: { Authorization: `Bearer ${apiKey}` },
+      signal: fireworksGatewayFetchSignal(),
     });
   } catch (error) {
     const cause = error?.cause;

--- a/packages/setup-cli/lib/system/ensure-cli-deps.mjs
+++ b/packages/setup-cli/lib/system/ensure-cli-deps.mjs
@@ -1,10 +1,8 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
-
-/** Runtime npm dependencies the CLI imports at startup (via ui, secret store, etc.). */
-export const RUNTIME_DEPENDENCIES = ["cross-keychain", "ansis"];
 
 /**
  * Absolute path to packages/setup-cli (where package.json and node_modules live).
@@ -35,10 +33,26 @@ export function crossKeychainInstalled(setupDir = resolveSetupCliDir()) {
 
 /**
  * @param {string} [setupDir]
+ * @returns {string[] | null}
+ */
+export function runtimeDependencyNames(setupDir = resolveSetupCliDir()) {
+  const pkgPath = path.join(setupDir, "package.json");
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    return Object.keys(pkg.dependencies ?? {});
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string} [setupDir]
  * @returns {boolean}
  */
 export function runtimeDepsInstalled(setupDir = resolveSetupCliDir()) {
-  return RUNTIME_DEPENDENCIES.every((dep) => dependencyInstalled(dep, setupDir));
+  const dependencies = runtimeDependencyNames(setupDir);
+  return dependencies !== null
+    && dependencies.every((dep) => dependencyInstalled(dep, setupDir));
 }
 
 /**
@@ -69,7 +83,12 @@ export function ensureCliDependencies(setupDir = resolveSetupCliDir()) {
     execFileSync(
       npm,
       ["install", "--omit=dev", "--no-fund", "--no-audit"],
-      { cwd: setupDir, stdio: "pipe", encoding: "utf8" },
+      {
+        cwd: setupDir,
+        env: { ...process.env, FIRECONNECT_SKIP_POSTINSTALL_FINALIZE: "1" },
+        stdio: "pipe",
+        encoding: "utf8",
+      },
     );
   } catch {
     return false;

--- a/packages/setup-cli/lib/system/environment.mjs
+++ b/packages/setup-cli/lib/system/environment.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import process from "node:process";
 
 import { readLocalVersion } from "./version.mjs";
+import { shouldPreferFileBackendOnLinux, remoteSecretStorageDetail } from "../config/secret-storage-policy.mjs";
 
 /**
  * Detect the host environment (OS, distro/WSL, Node, shell, secret-storage
@@ -105,6 +106,13 @@ export function detectSecretStorage() {
   }
   if (platform === "win32") {
     return { backend: "windows-credential-manager", strong: true };
+  }
+  if (shouldPreferFileBackendOnLinux()) {
+    return {
+      backend: "file",
+      strong: true,
+      detail: remoteSecretStorageDetail(),
+    };
   }
   if (binaryAvailable("secret-tool", ["--version"])) {
     return { backend: "secret-service", strong: true };

--- a/packages/setup-cli/lib/system/finalize-install.mjs
+++ b/packages/setup-cli/lib/system/finalize-install.mjs
@@ -5,6 +5,7 @@ import process from "node:process";
 import { reconcileHarnessConfigOnUpgrade } from "../keys/sync.mjs";
 import { reprobeKeyStorage } from "../keys/secret-store.mjs";
 import { ensureCliDependencies, resolveSetupCliDir } from "./ensure-cli-deps.mjs";
+import { runHarnessForwardMigrations } from "./forward-migrations.mjs";
 
 /**
  * Shared post-bootstrap repair for `install.sh` and `fireconnect upgrade`.
@@ -13,7 +14,7 @@ import { ensureCliDependencies, resolveSetupCliDir } from "./ensure-cli-deps.mjs
  * after the CLI bits are on disk goes through this path:
  *   1. ensure runtime npm deps
  *   2. re-probe secret storage / migrate plaintext → secure
- *   3. reconcile harness configs (rebake keys, VS Code apiType, shell hook)
+ *   3. run key-independent harness migrations, then rebake keys / shell hook
  *
  * Never throws for reconcile/shell failures (best-effort). Dep install and
  * key-storage probe may throw only if callers choose to surface them — this
@@ -26,6 +27,7 @@ import { ensureCliDependencies, resolveSetupCliDir } from "./ensure-cli-deps.mjs
  *   log?: (...args: unknown[]) => void,
  *   ensureDeps?: typeof ensureCliDependencies,
  *   reprobe?: typeof reprobeKeyStorage,
+ *   migrate?: typeof runHarnessForwardMigrations,
  *   reconcile?: typeof reconcileHarnessConfigOnUpgrade,
  * }} [options]
  * @returns {Promise<{ notes: string[], migrated: boolean, setupDir: string }>}
@@ -37,6 +39,7 @@ export async function finalizeInstallOrUpgrade({
   log = console.log,
   ensureDeps = ensureCliDependencies,
   reprobe = reprobeKeyStorage,
+  migrate = runHarnessForwardMigrations,
   reconcile = reconcileHarnessConfigOnUpgrade,
 } = {}) {
   const notes = [];
@@ -67,6 +70,15 @@ export async function finalizeInstallOrUpgrade({
       }
     } catch {
       // Best-effort: install/upgrade must not abort after the CLI is already on disk.
+    }
+
+    try {
+      for (const note of await migrate(home)) {
+        log(note);
+        notes.push(note);
+      }
+    } catch {
+      // Best-effort forward migrations.
     }
 
     try {

--- a/packages/setup-cli/lib/system/forward-migrations.mjs
+++ b/packages/setup-cli/lib/system/forward-migrations.mjs
@@ -1,0 +1,53 @@
+import { migrateClaudeToolSearchOnUpgrade } from "../harnesses/claude/upgrade-migrations.mjs";
+import { migrateVscodeResponsesApiType } from "../harnesses/vscode/upgrade-migrations.mjs";
+
+/**
+ * Key-independent harness config migrations for install/upgrade finalize.
+ *
+ * Kept out of `keys/sync.mjs` so key rebake stays a key path. Each step is
+ * best-effort: a failed migration never skips the rest or aborts finalize.
+ *
+ * @type {Array<{
+ *   run: (home: string) => Promise<boolean>,
+ *   success: string,
+ *   failure: string,
+ * }>}
+ */
+const HARNESS_FORWARD_MIGRATIONS = [
+  {
+    run: migrateVscodeResponsesApiType,
+    success: "Updated VS Code's Fireworks provider to the chat-completions API — restart VS Code to pick it up.",
+    failure: "Couldn't migrate VS Code's Fireworks provider — restart VS Code, then re-run fireconnect upgrade.",
+  },
+  {
+    run: migrateClaudeToolSearchOnUpgrade,
+    success: "Enabled MCP tool search for Claude Code (ENABLE_TOOL_SEARCH) — restart Claude Code to pick it up.",
+    failure: "Couldn't enable MCP tool search for Claude Code — re-run fireconnect claude on.",
+  },
+];
+
+async function migrationNote({ run, success, failure }, home) {
+  try {
+    return await run(home) ? success : "";
+  } catch {
+    return failure;
+  }
+}
+
+/**
+ * @param {string} home
+ * @returns {Promise<string[]>}
+ */
+export async function runHarnessForwardMigrations(home) {
+  if (!home) {
+    return [];
+  }
+  const notes = [];
+  for (const migrate of HARNESS_FORWARD_MIGRATIONS) {
+    const note = await migrationNote(migrate, home);
+    if (note) {
+      notes.push(note);
+    }
+  }
+  return notes;
+}

--- a/packages/setup-cli/lib/system/postinstall-finalize.mjs
+++ b/packages/setup-cli/lib/system/postinstall-finalize.mjs
@@ -1,0 +1,66 @@
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { runUpgradeFinalize } from "./upgrade-finalize.mjs";
+
+const THIS_FILE = fileURLToPath(import.meta.url);
+
+/**
+ * Recognize only the durable curl-installer layout. Package lifecycle scripts
+ * also run in development checkouts and global npm installs; those must never
+ * mutate a user's harness settings.
+ *
+ * @param {string} setupDir absolute packages/setup-cli path
+ * @returns {{ home: string, installDir: string } | null}
+ */
+export function durableInstallContext(setupDir) {
+  const resolvedSetup = path.resolve(setupDir);
+  if (
+    path.basename(resolvedSetup) !== "setup-cli"
+    || path.basename(path.dirname(resolvedSetup)) !== "packages"
+  ) {
+    return null;
+  }
+  const installDir = path.dirname(path.dirname(resolvedSetup));
+  const fireconnectDir = path.dirname(installDir);
+  if (
+    path.basename(installDir) !== "cli"
+    || path.basename(fireconnectDir) !== ".fireconnect"
+  ) {
+    return null;
+  }
+  return {
+    home: path.dirname(fireconnectDir),
+    installDir,
+  };
+}
+
+/**
+ * Bootstrap the fresh-process finalizer for clients whose old upgrader cannot
+ * re-exec after replacing its own checkout. Failure propagates through npm so
+ * the old upgrader reports that postflight did not complete.
+ *
+ * @param {{
+ *   setupDir?: string,
+ *   finalize?: typeof runUpgradeFinalize,
+ * }} [dependencies]
+ */
+export async function runPostinstallFinalize({
+  setupDir = path.resolve(path.dirname(THIS_FILE), "..", ".."),
+  finalize = runUpgradeFinalize,
+} = {}) {
+  if (process.env.FIRECONNECT_SKIP_POSTINSTALL_FINALIZE === "1") {
+    return false;
+  }
+  const context = durableInstallContext(setupDir);
+  if (!context) {
+    return false;
+  }
+  await finalize(context.home, context.installDir);
+  return true;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(THIS_FILE)) {
+  await runPostinstallFinalize();
+}

--- a/packages/setup-cli/lib/system/release-notes.json
+++ b/packages/setup-cli/lib/system/release-notes.json
@@ -1,6 +1,26 @@
 {
   "releases": [
     {
+      "version": "0.9.5",
+      "highlights": [
+        "Session costs in your Claude prompt. A new status line shows which models ran, what they cost at Fireworks rates, and cache savings. Your own status line is left alone — `fireconnect claude off` restores everything.",
+        "ChatGPT desktop app support. `fireconnect chatgpt` and `fireconnect codex` share one config, so you route both through Fireworks with a single command. Quit the app first so its model list refreshes.",
+        "Smart router mixes (preview): pin `auto` for the default mix or `auto-instant` for latency-first routing — for example, `fireconnect claude --sonnet auto-instant`. Every `auto-*` slug works the same way.",
+        "Simpler Claude model setup. The wizard lets you pick a model per slot instead of toggling fast profiles. New installs default to Sonnet on `deepseek-pro-latest`, Opus on `glm-latest`, and Fable on vision-capable `glm-flash-latest`. FireRouter still lands on Opus at first connect when your key supports it.",
+        "Faster `fireconnect model list`. Results are cached for an hour, work offline, show when they were last updated, and `--refresh` pulls the latest. Smart Routers lists `auto`, `auto-instant`, and FireRouter."
+      ],
+      "improvements": [
+        "MCP tool search works through the Fireworks gateway again — upgrade applies the fix automatically.",
+        "`fireconnect claude demo` and the status line use the same pricing, so their numbers always match.",
+        "`fireconnect upgrade` repairs missing dependencies; partial installs recover instead of crashing.",
+        "Linux SSH/WSL: keys store in an encrypted file with timeouts on keyring and network calls — no more hangs.",
+        "`fireconnect claude status` shows every slot, including defaults you never explicitly set.",
+        "GLM 5.3 and GLM 5.3 Flash added. Stale pins no longer hide newer releases; US-only pricing corrected.",
+        "Claude picker lists `auto` on every slot and `auto-instant` on Sonnet only."
+      ],
+      "footer": "Already on Claude? Upgrade keeps your slot picks — run `fireconnect claude --interactive` to adopt the new defaults. Legacy pins like `deepseek-v4-flash` move to `deepseek-flash-latest` on your next `fireconnect claude on`."
+    },
+    {
       "version": "0.9.4",
       "highlights": [
         "`fireconnect claude demo`: improved cost calculation and racing experience.",

--- a/packages/setup-cli/lib/system/upgrade-finalize.mjs
+++ b/packages/setup-cli/lib/system/upgrade-finalize.mjs
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { finalizeInstallOrUpgrade } from "./finalize-install.mjs";
+
+/**
+ * Post-reset upgrade finalize. When the durable CLI is on disk, spawn it in a
+ * fresh process so migrations load from the updated checkout rather than the
+ * old process's ESM module cache. Fall back to in-process finalize when the
+ * installed CLI is missing (dev trees, tests).
+ *
+ * @param {string} home
+ * @param {string} installDir
+ * @param {{
+ *   execFile?: typeof execFileSync,
+ *   exists?: typeof existsSync,
+ *   finalizeInProcess?: typeof finalizeInstallOrUpgrade,
+ * }} [dependencies]
+ */
+export async function runUpgradeFinalize(home, installDir, {
+  execFile = execFileSync,
+  exists = existsSync,
+  finalizeInProcess = finalizeInstallOrUpgrade,
+} = {}) {
+  const updatedCli = path.join(installDir, "packages/setup-cli/bin/fireconnect.mjs");
+  if (!exists(updatedCli)) {
+    await finalizeInProcess({ home, installDir });
+    return;
+  }
+
+  execFile(process.execPath, [updatedCli, "finalize-install"], {
+    env: { ...process.env, HOME: home },
+    stdio: "inherit",
+  });
+}

--- a/packages/setup-cli/package-lock.json
+++ b/packages/setup-cli/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@fireconnect/cli",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fireconnect/cli",
-      "version": "0.9.3",
+      "version": "0.9.4",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ansis": "^4.3.1",

--- a/packages/setup-cli/package.json
+++ b/packages/setup-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireconnect/cli",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "FireConnect CLIs for using Fireworks models with Claude Code",
   "type": "module",
   "bin": {
@@ -14,6 +14,7 @@
     "node": ">=18"
   },
   "scripts": {
+    "postinstall": "node ./lib/system/postinstall-finalize.mjs",
     "test": "node --import ./test/global-setup.mjs --test \"test/**/*.test.mjs\""
   },
   "dependencies": {

--- a/packages/setup-cli/test/auth/login-commands.test.mjs
+++ b/packages/setup-cli/test/auth/login-commands.test.mjs
@@ -279,14 +279,14 @@ describe("fireconnect login / logout", () => {
   it("login re-points the key baked into Claude's Fireworks settings", async () => {
     await withTempHome("login-router-refresh-", async (home) => {
       // A router-mode settings file from before this sign-in: stale key,
-      // legacy header name (pre-rename), plus lines that must survive.
+      // plus lines that must survive.
       const settingsPath = path.join(home, ".claude", "settings.json");
       await mkdir(path.dirname(settingsPath), { recursive: true });
       await writeFile(settingsPath, JSON.stringify({
         env: {
           ANTHROPIC_BASE_URL: "https://api.fireworks.ai/inference",
           ANTHROPIC_MODEL: "accounts/fireworks/routers/firerouter[1m]",
-          ANTHROPIC_CUSTOM_HEADERS: "X-FireRouter-Fireworks-Key: fw_stale_key_000000000000000000\nx-routing-preference: 3",
+          ANTHROPIC_CUSTOM_HEADERS: "X-Fireworks-Api-Key: fw_stale_key_000000000000000000\nx-routing-preference: 3",
           ANTHROPIC_AUTH_TOKEN: "sk-ant-keep",
         },
       }));

--- a/packages/setup-cli/test/cli/cli-commands.test.mjs
+++ b/packages/setup-cli/test/cli/cli-commands.test.mjs
@@ -24,6 +24,7 @@ import {
   readOpencodeConfig,
   runCli,
   runCliJson,
+  seedServerlessCatalogCache,
   SK_ANT_KEY,
   withTempHome,
   writeClaudeSettings,
@@ -34,6 +35,7 @@ import {
 import { writeGlobalConfig } from "../../lib/config/global-config.mjs";
 
 const CLAUDE_STORED_MAIN_MODEL = `${KIMI_FAST_LATEST}[1m]`;
+const CLAUDE_STORED_FABLE_MODEL = "glm-flash-latest[1m]";
 const CLAUDE_STORED_GLM_MODEL = `${GLM_FAST_LATEST}[1m]`;
 const CLAUDE_STORED_DS_FLASH_MODEL = "deepseek-flash-latest[1m]";
 const CLAUDE_STORED_FIREROUTER_MODEL = "firerouter[1m]";
@@ -104,6 +106,7 @@ describe("harness help matches supported command features", () => {
   test("documents optional usage and VS Code FireRouter options", async () => {
     const root = await runCli(["help"]);
     assert.match(root.stdout, /usage/);
+    assert.match(root.stdout, /--refresh/);
 
     const vscode = await runCli(["help", "vscode"]);
     assert.match(vscode.stdout, /--routing-preference/);
@@ -218,7 +221,7 @@ describe("unexpected input guidance", () => {
 });
 
 describe("fireconnect claude on", () => {
-  test("fw_ leaves main and Sonnet native, routes Opus via FireRouter, pins the rest", async () => {
+  test("fw_ leaves main native, routes Opus via FireRouter, pins Sonnet and the rest", async () => {
     await withTempHome("on-fw", async (home) => {
       const result = await runCli(
         ["claude", "on", "--api-key", FW_CLAUDE_KEY],
@@ -237,13 +240,13 @@ describe("fireconnect claude on", () => {
       assert.equal(settings.env?.ANTHROPIC_MODEL, undefined);
       assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, CLAUDE_STORED_FIREROUTER_MODEL);
       assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL_NAME, "FireRouter");
-      // Sonnet is native (unpinned): the alias env keys are never written.
-      assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL, undefined);
-      assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL_NAME, undefined);
+      // FireRouter on Opus moves GLM to Sonnet.
+      assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL, "glm-latest[1m]");
+      assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL_NAME, "GLM 5.3 (Latest)");
       assert.equal(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL, CLAUDE_STORED_DS_FLASH_MODEL);
       assert.equal(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME, "DeepSeek V4 Flash (0731) (Latest)");
-      assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, CLAUDE_STORED_MAIN_MODEL);
-      assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL_NAME, "Kimi K3 Fast (Latest)");
+      assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, CLAUDE_STORED_FABLE_MODEL);
+      assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL_NAME, "GLM 5.3 Flash (Latest)");
       // Subagent takes the Haiku model, with the [1m] tag stripped.
       assert.equal(settings.env.CLAUDE_CODE_SUBAGENT_MODEL, "deepseek-flash-latest");
       assert.equal(settings.env.ANTHROPIC_CUSTOM_MODEL_OPTION, undefined);
@@ -251,6 +254,7 @@ describe("fireconnect claude on", () => {
       assert.equal(settings.env.DISABLE_TELEMETRY, "1");
       assert.equal(settings.env.DO_NOT_TRACK, "1");
       assert.equal(settings.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC, "1");
+      assert.equal(settings.env.ENABLE_TOOL_SEARCH, "true");
       assert.equal(Object.hasOwn(settings.env, "CLAUDE_CODE_DISABLE_1M_CONTEXT"), false);
     });
   });
@@ -302,7 +306,7 @@ describe("fireconnect claude on", () => {
       assert.equal(settings.model, undefined);
       assert.equal(settings.env?.ANTHROPIC_MODEL, undefined);
       assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, "firerouter[1m]");
-      assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, CLAUDE_STORED_MAIN_MODEL);
+      assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, CLAUDE_STORED_FABLE_MODEL);
       assert.equal(settings.env.ANTHROPIC_API_KEY, SK_ANT_KEY);
       assert.doesNotMatch(settings.env.ANTHROPIC_CUSTOM_HEADERS, /x-anthropic-api-key/i);
       assert.equal(settings.env.ANTHROPIC_BASE_URL, FIREWORKS_INFERENCE_URL);
@@ -352,7 +356,7 @@ describe("fireconnect opencode on", () => {
           ...expectedOpencodeLatestRouterEntry("Kimi K3 Fast (Latest)", 1_040_000, 131_072),
           // Metered per-Mtok rates, so OpenCode can report spend. Fire Pass is a
           // subscription and gets no cost block — see the fpk_ case below.
-          cost: { input: 6, output: 30, cache_read: 0.6 },
+          cost: { input: 4.5, output: 22.5, cache_read: 0.45 },
           modalities: { input: ["text", "image"] },
         },
       );
@@ -388,6 +392,8 @@ describe("fireconnect model list", () => {
         { home, env: NO_ENV_KEY },
       );
       assert.equal(json.keyType, "firepass");
+      assert.equal(json.source, "firepass");
+      assert.equal(json.updatedAt, null);
       assert.equal(json.count, 4);
       assert.deepEqual(
         json.models.map((entry) => entry.shortId),
@@ -446,6 +452,35 @@ describe("fireconnect model list", () => {
       assert.doesNotMatch(result.stdout, /kimi-k2p6-turbo/);
       assert.doesNotMatch(result.stdout, /kimi-latest/);
       assert.doesNotMatch(result.stdout, /\bKIND\b/);
+      assert.match(result.stdout, /Last updated: bundled with FireConnect/);
+      assert.match(result.stdout, /fireconnect model list --refresh/);
+    });
+  });
+
+  test("--json --refresh reports stale when the gateway is unreachable", async () => {
+    await withTempHome("ml-refresh-stale", async (home) => {
+      seedServerlessCatalogCache(home, [{
+        id: "accounts/fireworks/models/cached-model",
+        shortId: "cached-model",
+        displayName: "Cached Model",
+        kind: "serverless",
+      }]);
+
+      const { code, stderr, json } = await runCliJson(
+        ["model", "list", "--api-key", FW_CLAUDE_KEY, "--refresh", "--json"],
+        {
+          home,
+          env: {
+            ...NO_ENV_KEY,
+            FIRECONNECT_GATEWAY_URL: "http://127.0.0.1:9",
+          },
+        },
+      );
+
+      assert.equal(code, 0, stderr);
+      assert.equal(json.source, "stale");
+      assert.match(json.updatedAt, /^\d{4}-\d{2}-\d{2}T/);
+      assert.ok(json.models.some((entry) => entry.shortId === "cached-model"));
     });
   });
 
@@ -476,7 +511,7 @@ describe("fireconnect <harness> status", () => {
       const { json } = await runCliJson(["claude", "status", "--json"], { home, env: NO_ENV_KEY });
       assert.equal(json.defaults.main, "claude-default");
       assert.equal(json.defaults.opus, DEFAULT_OPUS_MODEL);
-      // Sonnet is native by default too.
+      // Sonnet defaults to deepseek-pro-latest.
       assert.equal(json.defaults.sonnet, DEFAULT_SONNET_MODEL);
       assert.equal(json.defaults.haiku, DEFAULT_HAIKU_MODEL);
     });

--- a/packages/setup-cli/test/cli/harness-option-validation.test.mjs
+++ b/packages/setup-cli/test/cli/harness-option-validation.test.mjs
@@ -64,14 +64,17 @@ describe("harness option validation", () => {
 
   it("rejects FireRouter options a harness cannot forward", async () => {
     await withTempHome("option-firerouter-capability-", async (home) => {
+      // Bare firerouter routes to an Anthropic primary; Cursor can't forward a
+      // local Anthropic key, so it's refused with the Anthropic-key message
+      // (which also points to workspace BYOK as the remedy).
       await rejects(
         home,
         ["cursor", "on", "--api-key", "fw_test_key_12345", "--model", "firerouter"],
-        /Ask the Fireworks team to enable FireRouter for your account/,
+        /Anthropic API key Cursor can't forward/,
       );
       await rejects(
         home,
-        ["cursor", "on", "--model", "firerouter", "--anthropic-api-key", "sk-ant-test"],
+        ["cursor", "on", "--model", "firerouter/kimi-k3", "--anthropic-api-key", "sk-ant-test"],
         /--anthropic-api-key is not supported by this harness/,
       );
       await rejects(
@@ -157,6 +160,7 @@ describe("harness option validation", () => {
     await withTempHome("option-command-scope-", async (home) => {
       await rejects(home, ["pi", "status", "--session", "abc"], /applies only to .*claude usage/);
       await rejects(home, ["opencode", "on", "--json"], /--json is supported by/);
+      await rejects(home, ["claude", "on", "--refresh"], /--refresh applies only to .*model list/);
       await rejects(home, ["codex", "status", "--db-path", "/tmp/state.vscdb"], /--db-path is supported only by Cursor/);
       await rejects(home, ["cursor", "status", "--config-path", "/tmp/config"], /--config-path is supported only by/);
       await rejects(home, ["vscode", "status", "--settings-path", "/tmp/settings"], /--settings-path is supported only by/);

--- a/packages/setup-cli/test/cli/harness-output-contract.test.mjs
+++ b/packages/setup-cli/test/cli/harness-output-contract.test.mjs
@@ -71,7 +71,7 @@ describe("compact harness command output", () => {
       console.log = original;
     }
     assert.equal(lines[0], "Also in your model list: glm-latest, firerouter");
-    assert.match(lines[1], /FireRouter is on\. Picks a model for each request/);
+    assert.match(lines[1], /FireRouter is on\. Routes each request between Claude and open models/);
     assert.equal(lines[2], "Also in your model list: glm-latest");
     assert.match(lines[3], /FireRouter wasn't turned on \(no Anthropic API key\)/);
     assert.match(lines[3], /fireconnect pi --model firerouter/);
@@ -80,10 +80,12 @@ describe("compact harness command output", () => {
     assert.match(lines[5], /couldn't verify workspace BYOK \(network down\)/);
     assert.match(lines[6], /FireRouter needs a regular Fireworks API key/);
     assert.equal(lines[7], "Restart Claude Code to use the new setup.");
-    assert.equal(lines[8], "Restart Codex to use the new setup.");
-    assert.equal(lines[9], "Restart Pi to use the new setup.");
-    assert.equal(lines[10], "Restart DeepSeek Harness to use the new setup.");
-    assert.equal(lines[11], "Restart OpenCode to use the new setup.");
+    assert.match(lines[8], /Quit & reopen the ChatGPT app/);
+    assert.match(lines[9], /^To resume existing Codex sessions with Fireworks:\n/);
+    assert.match(lines[9], /^ {2}codex resume <id> -c model_provider="fireworks-ai"/m);
+    assert.equal(lines[10], "Restart Pi to use the new setup.");
+    assert.equal(lines[11], "Restart DeepSeek Harness to use the new setup.");
+    assert.equal(lines[12], "Restart OpenCode to use the new setup.");
   });
 
   it("prints outcome, FireRouter help, and one apply action for routine on", async () => {
@@ -147,12 +149,12 @@ describe("compact harness command output", () => {
       const lines = nonemptyLines(result.stdout);
       assert.equal(lines.length, 5, result.stdout);
       assert.match(lines[0], /OpenCode → Fireworks · firerouter/);
-      assert.match(lines[1], /FireRouter is on\. Picks a model for each request/);
+      assert.match(lines[1], /FireRouter is on\. Routes each request between Claude and open models/);
       assert.match(lines[2], /Change routing: fireconnect opencode --model firerouter --routing-preference balanced/);
       assert.match(lines[3], /Other levels: max-intelligence \(1\).*max-savings \(5\)/);
       assert.equal(lines[4], "Restart OpenCode to use the new setup.");
       assert.doesNotMatch(result.stdout, /→ FireRouter|Choose models|Models added:|FireRouter default/);
-      assert.match(result.stdout, /FireRouter is on\. Picks a model for each request/);
+      assert.match(result.stdout, /FireRouter is on\. Routes each request between Claude and open models/);
       assert.match(result.stdout, /Change routing: fireconnect opencode --model firerouter --routing-preference balanced/);
     });
   });
@@ -173,7 +175,7 @@ describe("compact harness command output", () => {
       const lines = nonemptyLines(result.stdout);
       assert.equal(lines.length, 5, result.stdout);
       assert.match(lines[0], /OpenCode → Fireworks · firerouter/);
-      assert.match(lines[1], /FireRouter is on\. Picks a model for each request/);
+      assert.match(lines[1], /FireRouter is on\. Routes each request between Claude and open models/);
       assert.match(lines[2], /Change routing: fireconnect opencode --model firerouter --routing-preference balanced/);
       assert.match(lines[3], /Other levels: max-intelligence \(1\).*more-savings \(4\), max-savings \(5\)/);
       assert.equal(lines[4], "Restart OpenCode to use the new setup.");
@@ -198,11 +200,11 @@ describe("compact harness command output", () => {
       assert.equal(lines[0], "✓ Claude Code → Fireworks");
       assert.doesNotMatch(result.stdout, /Claude Code → Fireworks ·/);
       assert.match(result.stdout, /Model mapping/);
-      // Main is never pinned, so it has no mapping row; Sonnet stays native.
+      // Main is never pinned, so it has no mapping row; Sonnet uses the Fireworks default.
       assert.doesNotMatch(result.stdout, /Main\s+→/);
-      assert.match(result.stdout, /Sonnet\s+→ Claude default/);
+      assert.match(result.stdout, /Sonnet\s+→ glm-latest/);
       assert.match(result.stdout, /Opus\s+→ firerouter/);
-      assert.match(result.stdout, /FireRouter is on\. Picks a model for each request/);
+      assert.match(result.stdout, /FireRouter is on\. Routes each request between Claude and open models/);
       assert.doesNotMatch(result.stdout, /no Anthropic key found/);
       assert.match(result.stdout, /Change routing: fireconnect claude --opus firerouter --routing-preference balanced/);
       assert.match(result.stdout, /Other levels: max-intelligence \(1\)/);
@@ -233,7 +235,7 @@ describe("compact harness command output", () => {
       assert.doesNotMatch(result.stdout, /Claude Code → Fireworks ·/);
       assert.match(result.stdout, /Model mapping/);
       assert.match(result.stdout, /Opus\s+→ firerouter/);
-      assert.match(result.stdout, /FireRouter is on\. Picks a model for each request/);
+      assert.match(result.stdout, /FireRouter is on\. Routes each request between Claude and open models/);
       assert.match(
         lines.find((line) => line.startsWith("Change routing:")),
         /Change routing: fireconnect claude --opus firerouter --routing-preference balanced/,
@@ -256,7 +258,7 @@ describe("compact harness command output", () => {
       );
       assert.equal(result.code, 0, result.stderr);
       assert.match(result.stdout, /Codex → Fireworks · firerouter/);
-      assert.match(result.stdout, /FireRouter is on\. Picks a model for each request/);
+      assert.match(result.stdout, /FireRouter is on\. Routes each request between Claude and open models/);
       assert.doesNotMatch(result.stdout, /Routing:/);
     });
   });

--- a/packages/setup-cli/test/cli/parse-args.test.mjs
+++ b/packages/setup-cli/test/cli/parse-args.test.mjs
@@ -73,6 +73,15 @@ describe("parseCli", () => {
     assert.equal(parsed.command, "model");
     assert.equal(parsed.modelSubcommand, "list");
     assert.equal(parsed.ctx.search, "glm");
+    assert.equal(parsed.ctx.refresh, false);
+  });
+
+  it("parses model list --refresh", () => {
+    const parsed = parseCli(["model", "list", "--refresh"]);
+    assert.equal(parsed.kind, "global");
+    assert.equal(parsed.command, "model");
+    assert.equal(parsed.modelSubcommand, "list");
+    assert.equal(parsed.ctx.refresh, true);
   });
 
   it("parses bare harness as on", () => {
@@ -80,6 +89,27 @@ describe("parseCli", () => {
     assert.equal(parsed.kind, "harness");
     assert.equal(parsed.route.harnessId, "claude");
     assert.equal(parsed.route.verb, "on");
+  });
+
+  it("aliases chatgpt to the codex harness", () => {
+    const parsed = parseCli(["chatgpt", "on"]);
+    assert.equal(parsed.kind, "harness");
+    assert.equal(parsed.route.harnessId, "codex");
+    assert.equal(parsed.route.verb, "on");
+  });
+
+  it("aliases bare chatgpt to codex on", () => {
+    const parsed = parseCli(["chatgpt"]);
+    assert.equal(parsed.kind, "harness");
+    assert.equal(parsed.route.harnessId, "codex");
+    assert.equal(parsed.route.verb, "on");
+  });
+
+  it("passes the typed chatgpt help topic through for display", () => {
+    const parsed = parseCli(["help", "chatgpt"]);
+    assert.equal(parsed.kind, "global");
+    assert.equal(parsed.command, "help");
+    assert.equal(parsed.helpTopic, "chatgpt");
   });
 
   it("parses harness verb", () => {
@@ -290,6 +320,10 @@ describe("parseCli typo suggestions", () => {
   it("suggests the nearest command", () => {
     assert.throws(() => parseCli(["cluade", "on"]), /Did you mean: claude\?/);
     assert.throws(() => parseCli(["confgure"]), /Did you mean: configure\?/);
+  });
+
+  it("suggests harness aliases, which help advertises as top-level commands", () => {
+    assert.throws(() => parseCli(["chatgtp", "on"]), /Did you mean: chatgpt\?/);
   });
 
   it("suggests the nearest flag", () => {

--- a/packages/setup-cli/test/demo/claude-runner.test.mjs
+++ b/packages/setup-cli/test/demo/claude-runner.test.mjs
@@ -1,7 +1,77 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { parseStreamJson } from "../../lib/demo/claude-runner.mjs";
+import {
+  parseStreamJson,
+  priceClaudeUsage,
+} from "../../lib/demo/claude-runner.mjs";
+import { computeClaudeUsageCost } from "../../lib/harnesses/claude/usage/pricing.mjs";
+import {
+  getServerlessCatalogSnapshot,
+  setServerlessCatalogSnapshot,
+} from "../../lib/fireworks/serverless-catalog-cache.mjs";
+
+test("demo and transcript/statusline pricing use the same serverless rates", () => {
+  const usage = {
+    input_tokens: 17_319,
+    cache_read_input_tokens: 0,
+    output_tokens: 11,
+  };
+  const demo = priceClaudeUsage({
+    model: "glm-5p3[1m]",
+    resolvedModel: "accounts/fireworks/models/glm-5p3",
+    usage,
+  });
+  const transcript = computeClaudeUsageCost("accounts/fireworks/models/glm-5p3", usage);
+
+  assert.equal(demo.cost, 0.024295);
+  assert.equal(demo.cost, transcript.cost);
+  assert.deepEqual(demo.rates, transcript.rates);
+});
+
+test("demo returns no price when neither selected nor resolved model has a rate", () => {
+  const pricing = priceClaudeUsage({
+    model: "firerouter",
+    resolvedModel: "accounts/fireworks/models/not-in-the-catalog",
+    usage: { input_tokens: 10_000, output_tokens: 100 },
+  });
+  assert.equal(pricing.cost, null);
+  assert.equal(pricing.rates, null);
+});
+
+test("demo prices FireRouter from its served backend even if the router has a catalog rate", () => {
+  const previousSnapshot = getServerlessCatalogSnapshot();
+  setServerlessCatalogSnapshot({
+    entries: [],
+    pricingById: new Map([[
+      "accounts/fireworks/routers/firerouter",
+      {
+        slug: "firerouter",
+        label: "FireRouter",
+        input: 99,
+        cachedInput: 99,
+        output: 99,
+        tier: "standard",
+        source: "test",
+      },
+    ]]),
+    inputModalitiesById: new Map(),
+    routerBaseModelById: new Map(),
+    contextLengthById: new Map(),
+    supportsToolsById: new Map(),
+  });
+  try {
+    const pricing = priceClaudeUsage({
+      model: "firerouter[1m]",
+      resolvedModel: "accounts/fireworks/models/glm-5p3",
+      usage: { input_tokens: 1_000_000, output_tokens: 0 },
+    });
+    assert.equal(pricing.cost, 1.4);
+    assert.equal(pricing.rates.label, "GLM 5.3");
+  } finally {
+    setServerlessCatalogSnapshot(previousSnapshot);
+  }
+});
 
 test("parseStreamJson: text_delta yields a delta", () => {
   const out = parseStreamJson({
@@ -86,11 +156,10 @@ test("parseStreamJson: result event usage under total_usage shape", () => {
   assert.equal(out.outputTokens, 9);
 });
 
-test("parseStreamJson: result event carries Claude Code's authoritative costUsd", () => {
+test("parseStreamJson: result event preserves Claude Code's diagnostic costUsd", () => {
   // Claude Code reports its own cost via total_cost_usd (and a per-model
-  // modelUsage breakdown). This is authoritative — esp. for firerouter, where
-  // the underlying routed model is opaque so our rate-table estimate would only
-  // be a static guess. Prefer total_cost_usd; fall back to summing modelUsage.
+  // modelUsage breakdown). Keep it for diagnostics, but the demo must price the
+  // result usage through the resolved model's provider rates instead.
   const out = parseStreamJson({
     type: "result",
     result: "done",

--- a/packages/setup-cli/test/demo/demo-integration.test.mjs
+++ b/packages/setup-cli/test/demo/demo-integration.test.mjs
@@ -33,6 +33,8 @@ function fakeStdout({ columns = 100, rows = 24 } = {}) {
 
 const header = (provider, model, costLabel, rates) => ({ provider, model, costLabel, rates });
 
+const plainText = (out) => out._buf.out.replace(/\x1b\[[0-9;]*m/g, "");
+
 // ── TUI ─────────────────────────────────────────────────────────────────────
 
 test("tui: split layout renders two columns with a divider and the right number of rows", () => {
@@ -134,40 +136,75 @@ test("tui: freeze() keeps a running cost estimate until finish() reconciles", ()
   r.stop();
 });
 
-test("tui: pushThinking renders reasoning above output in dim style", () => {
+test("tui: a router with no pre-run rate never shows a proxy dollar amount", () => {
   const out = fakeStdout({ columns: 100, rows: 24 });
   const r = new SplitPaneRenderer({
     incumbent: header("Anthropic", "Claude", "list price", { inputPerMillion: 3, outputPerMillion: 15 }),
-    fireworks: header("Fireworks", "GLM 5.2 Fast", "serverless", { inputPerMillion: 2.1, outputPerMillion: 6.6 }),
+    fireworks: header("Fireworks", "FireRouter", "measured", {
+      inputPerMillion: null,
+      outputPerMillion: null,
+      cacheWrite1hPerMillion: null,
+      cacheWrite5mPerMillion: null,
+      cacheReadPerMillion: null,
+    }),
     stdout: out,
   });
   r.start();
-  r.pushThinking("fireworks", "Plan the HTML layout first.");
-  r.pushDelta("fireworks", "<html><body>ok</body></html>");
+  r.setTokens("fireworks", { inputTokens: 10_000, outputTokens: 100 });
+  r.pushDelta("fireworks", "working");
   r.render();
-  const plain = out._buf.out.replace(/\x1b\[[0-9;]*m/g, "");
-  const thinkingIdx = plain.indexOf("Plan the HTML layout first.");
-  const outputIdx = plain.indexOf("<html><body>ok</body></html>");
-  assert.ok(thinkingIdx >= 0, "thinking trace should render in the pane");
-  assert.ok(outputIdx >= 0, "output should render in the pane");
-  assert.ok(thinkingIdx < outputIdx, "thinking should appear before final output");
+  const running = out._buf.out.replace(/\x1b\[[0-9;]*m/g, "");
+  assert.match(running, /— so far/);
+
+  r.finish("fireworks", {
+    ok: true,
+    inputTokens: 10_000,
+    outputTokens: 100,
+    seconds: 1,
+    cost: null,
+  });
   r.stop();
+  const finished = out._buf.out.replace(/\x1b\[[0-9;]*m/g, "");
+  assert.match(finished, /— measured/);
 });
 
-test("tui: long thinking does not crowd out streaming code output", () => {
+test("tui: reasoning streams into the pane until output arrives, then recedes above it", (t) => {
   const out = fakeStdout({ columns: 100, rows: 24 });
   const r = new SplitPaneRenderer({
     incumbent: header("Anthropic", "Claude", "list price", { inputPerMillion: 3, outputPerMillion: 15 }),
     fireworks: header("Fireworks", "GLM 5.2 Fast", "serverless", { inputPerMillion: 2.1, outputPerMillion: 6.6 }),
     stdout: out,
   });
+  t.after(() => r.stop());
+  r.start();
+  r.pushThinking("fireworks", "Plan the HTML layout first.");
+  r.render();
+  assert.match(plainText(out), /Plan the HTML layout first\./, "reasoning-only pane shows the trace");
+
+  out._buf.out = "";
+  r.pushDelta("fireworks", "<html><body>ok</body></html>");
+  r.render();
+  const plain = plainText(out);
+  const reasoningIdx = plain.indexOf("reasoning…");
+  const outputIdx = plain.indexOf("<html><body>ok</body></html>");
+  assert.ok(reasoningIdx >= 0, "reasoning indicator should render once output exists");
+  assert.ok(outputIdx >= 0, "output should render in the pane");
+  assert.ok(reasoningIdx < outputIdx, "reasoning should appear above the output");
+});
+
+test("tui: long thinking does not crowd out streaming code output", (t) => {
+  const out = fakeStdout({ columns: 100, rows: 24 });
+  const r = new SplitPaneRenderer({
+    incumbent: header("Anthropic", "Claude", "list price", { inputPerMillion: 3, outputPerMillion: 15 }),
+    fireworks: header("Fireworks", "GLM 5.2 Fast", "serverless", { inputPerMillion: 2.1, outputPerMillion: 6.6 }),
+    stdout: out,
+  });
+  t.after(() => r.stop());
   r.start();
   r.pushThinking("fireworks", "x".repeat(5000));
   r.pushDelta("fireworks", "<html><body>visible code</body></html>");
   r.render();
-  const plain = out._buf.out.replace(/\x1b\[[0-9;]*m/g, "");
-  assert.match(plain, /visible code/, "code output must remain visible when thinking is long");
-  r.stop();
+  assert.match(plainText(out), /visible code/, "code output must remain visible when thinking is long");
 });
 
 test("tui: freeze(side, false) immediately shows failed ✗", () => {
@@ -374,6 +411,24 @@ test("browser: compare.html is self-contained and inlines both apps", () => {
   assert.match(html, /4×/);
 });
 
+test("browser: unavailable pricing is not rendered as a zero-cost comparison", () => {
+  const result = sampleResult();
+  result.fireworks.cost = null;
+  result.summary.costSavedFraction = Number.NaN;
+  const html = buildCompareHtml({
+    result,
+    incumbentAppHtml: "<html><body>INC</body></html>",
+    fireworksAppHtml: "<html><body>FW</body></html>",
+    incumbentRunnable: true,
+    fireworksRunnable: true,
+    incumbentLabel: "Claude Sonnet 5",
+    fireworksLabel: "FireRouter",
+    copySummary: "cost not comparable",
+  });
+  assert.match(html, /Cost: <b>not comparable<\/b> — pricing unavailable/);
+  assert.doesNotMatch(html, /At 1,000 generations: \$20\.2 → \$0/);
+});
+
 test("browser: cost strip attributes the win to the cheaper model with a rebased percent", () => {
   // Incumbent model is cheaper (costSavedFraction < 0). The strip must say
   // the incumbent model is X% cheaper — rebased to the fireworks cost so the
@@ -571,6 +626,10 @@ async function pathExistsForTest(p) {
 test("providerListPricing: known anthropic + openai models resolve real rates", () => {
   const a = providerListPricing({ provider: "anthropic", modelId: "claude-sonnet-5" });
   assert.equal(a.inputPerMillion, 2);
+  assert.equal(a.cacheWrite5mPerMillion, 2.5);
+  assert.equal(a.cacheWrite1hPerMillion, 4);
+  assert.equal(a.cacheReadPerMillion, 0.2);
+  assert.equal(a.outputPerMillion, 10);
   assert.equal(a.estimated, false);
   const o = providerListPricing({ provider: "openai", modelId: "gpt-4o" });
   assert.equal(o.inputPerMillion, 2.5);
@@ -579,7 +638,7 @@ test("providerListPricing: known anthropic + openai models resolve real rates", 
 
 test("providerListPricing: opus 4.5+ uses current $5/$25 rate, not legacy $15/$75", () => {
   // Opus 4.5–4.8 are all $5/$25 per platform.claude.com/pricing (verified
-  // 2026-08-19). The old $15/$75 was Opus 4.1 and Opus 4 (both retired legacy);
+  // 2026-08-30). The old $15/$75 was Opus 4.1 and Opus 4 (both retired legacy);
   // a stale table would inflate incumbent cost 3x and skew the demo's cost-saved
   // fraction.
   for (const id of ["claude-opus-4-8", "claude-opus-4-5", "opus"]) {
@@ -593,6 +652,17 @@ test("providerListPricing: opus 4.5+ uses current $5/$25 rate, not legacy $15/$7
     const legacy = providerListPricing({ provider: "anthropic", modelId: id });
     assert.equal(legacy.inputPerMillion, 15, `${id} legacy input`);
     assert.equal(legacy.outputPerMillion, 75, `${id} legacy output`);
+  }
+});
+
+test("providerListPricing: fast mode uses the published Opus 5/4.8 rate", () => {
+  for (const id of ["claude-opus-5", "claude-opus-4-8", "opus"]) {
+    const r = providerListPricing({ provider: "anthropic", modelId: id, speed: "fast" });
+    assert.equal(r.inputPerMillion, 10, `${id} fast input`);
+    assert.equal(r.cacheWrite5mPerMillion, 12.5, `${id} fast 5m write`);
+    assert.equal(r.cacheWrite1hPerMillion, 20, `${id} fast 1h write`);
+    assert.equal(r.cacheReadPerMillion, 1, `${id} fast cache read`);
+    assert.equal(r.outputPerMillion, 50, `${id} fast output`);
   }
 });
 

--- a/packages/setup-cli/test/demo/demo-models.test.mjs
+++ b/packages/setup-cli/test/demo/demo-models.test.mjs
@@ -67,6 +67,9 @@ test("demoModelRates: resolves pricing for Fireworks, FireRouter, and Anthropic 
   assert.ok(fw.inputPerMillion > 0);
   const fr = demoModelRates("firerouter");
   assert.ok(fr);
+  assert.equal(fr.inputPerMillion, null);
+  assert.equal(fr.outputPerMillion, null);
+  assert.equal(fr.estimated, true);
   const anth = demoModelRates("opus");
   assert.ok(anth);
   assert.match(anth.label, /via Anthropic/);

--- a/packages/setup-cli/test/demo/demo-pure.test.mjs
+++ b/packages/setup-cli/test/demo/demo-pure.test.mjs
@@ -166,8 +166,19 @@ test("costSavedFraction: fireworks more expensive yields negative (honestly)", (
   assert.equal(costSavedFraction({ incumbentCost: 0.05, fireworksCost: 0.10 }), -1);
 });
 
+test("costSavedFraction: unavailable cost is not comparable", () => {
+  assert.equal(
+    Number.isNaN(costSavedFraction({ incumbentCost: 0.05, fireworksCost: null })),
+    true,
+  );
+});
+
 test("costPerGenerations: linear extrapolation", () => {
   assert.equal(costPerGenerations({ cost: 0.01, generations: 1000 }), 10);
+});
+
+test("costPerGenerations: unavailable cost stays unavailable", () => {
+  assert.equal(costPerGenerations({ cost: null, generations: 1000 }), null);
 });
 
 test("buildResult: summary flags driven by real numbers", () => {

--- a/packages/setup-cli/test/demo/demo-setup-form.test.mjs
+++ b/packages/setup-cli/test/demo/demo-setup-form.test.mjs
@@ -10,8 +10,11 @@ import {
   renderFormLines,
   estimateRaceCost,
 } from "../../lib/demo/setup-form.mjs";
-import { CUSTOM_MATCHUP_ID } from "../../lib/demo/demo-matchups.mjs";
-import { CUSTOM_DEMO_PROMPT_ID } from "../../lib/demo/presets.mjs";
+import { CUSTOM_MATCHUP_ID, demoMatchupOptionIds } from "../../lib/demo/demo-matchups.mjs";
+import { CUSTOM_DEMO_PROMPT_ID, demoPromptOptionIds } from "../../lib/demo/presets.mjs";
+
+const CUSTOM_MATCHUP_INDEX = demoMatchupOptionIds().indexOf(CUSTOM_MATCHUP_ID);
+const CUSTOM_PROMPT_INDEX = demoPromptOptionIds().indexOf(CUSTOM_DEMO_PROMPT_ID);
 
 const DEFAULTS = {
   promptSource: "preset",
@@ -37,6 +40,27 @@ function advanceToConfirm(s) {
   return cur;
 }
 
+/**
+ * Cycle a wizard picker to its custom option. `right` wraps, so the walk is
+ * bounded by the option count rather than looping until a hardcoded index.
+ */
+function cycleTo(s, indexOf, target, optionCount) {
+  let cur = s;
+  for (let step = 0; step < optionCount && indexOf(cur) !== target; step += 1) {
+    cur = applyKey(cur, "right");
+  }
+  assert.equal(indexOf(cur), target);
+  return cur;
+}
+
+function selectCustomMatchup(s) {
+  return cycleTo(s, (cur) => cur.matchupIndex, CUSTOM_MATCHUP_INDEX, demoMatchupOptionIds().length);
+}
+
+function selectCustomPrompt(s) {
+  return cycleTo(s, (cur) => cur.promptIndex, CUSTOM_PROMPT_INDEX, demoPromptOptionIds().length);
+}
+
 test("createFormState: starts on matchup step", () => {
   const s = state();
   assert.equal(s.step, "matchup");
@@ -51,23 +75,20 @@ test("applyKey: preset matchup enter advances to game step", () => {
 });
 
 test("applyKey: custom matchup stays on step 1 with inline model pickers", () => {
-  let s = state();
-  while (s.matchupIndex !== 3) {
-    s = applyKey(s, "right");
-  }
+  let s = selectCustomMatchup(state());
   assert.equal(CUSTOM_MATCHUP_ID, "custom");
   assert.equal(s.step, "matchup");
   s = applyKey(s, "down");
   assert.equal(s.focus, "models");
   s = applyKey(s, "right");
-  assert.equal(s.matchupIndex, 3);
+  assert.equal(s.matchupIndex, CUSTOM_MATCHUP_INDEX);
 });
 
 test("applyKey: editing models switches preset to custom", () => {
   let s = state();
   s = applyKey(s, "down");
   s = applyKey(s, "right");
-  assert.equal(s.matchupIndex, 3);
+  assert.equal(s.matchupIndex, CUSTOM_MATCHUP_INDEX);
 });
 
 test("applyKey: same model blocked on confirm", () => {
@@ -83,7 +104,7 @@ test("applyKey: s swaps models on confirm", () => {
   s = applyKey(s, "s");
   assert.equal(s.leftModel, "glm-fast-latest");
   assert.equal(s.rightModel, "opus");
-  assert.equal(s.matchupIndex, 3);
+  assert.equal(s.matchupIndex, CUSTOM_MATCHUP_INDEX);
   assert.equal(formResult(s, { defaults: DEFAULTS }).matchupPresetId, "custom");
 });
 
@@ -94,10 +115,7 @@ test("applyKey: confirm b goes back to game step", () => {
 });
 
 test("applyKey: q inserts into custom prompt text", () => {
-  let s = advanceToGame(state());
-  while (s.promptIndex !== 4) {
-    s = applyKey(s, "right");
-  }
+  let s = selectCustomPrompt(advanceToGame(state()));
   s = applyKey(s, "q");
   assert.equal(s.quit, false);
   assert.equal(s.customPromptText, "q");
@@ -123,20 +141,14 @@ test("applyKey: confirm enter finishes", () => {
 });
 
 test("applyKey: custom game requires text", () => {
-  let s = advanceToGame(state());
-  while (s.promptIndex !== 4) {
-    s = applyKey(s, "right");
-  }
+  let s = selectCustomPrompt(advanceToGame(state()));
   s = applyKey(s, "enter");
   assert.equal(s.step, "game");
   assert.match(s.error, /custom task/i);
 });
 
 test("formResult: custom prompt preserved", () => {
-  let s = advanceToGame(state());
-  while (s.promptIndex !== 4) {
-    s = applyKey(s, "right");
-  }
+  let s = selectCustomPrompt(advanceToGame(state()));
   for (const ch of "build timer") {
     s = applyKey(s, ch);
   }

--- a/packages/setup-cli/test/firerouter/firerouter-core.test.mjs
+++ b/packages/setup-cli/test/firerouter/firerouter-core.test.mjs
@@ -31,7 +31,7 @@ describe("firerouter-core", () => {
   it("does not infer router mode from stale headers on direct Fireworks URL", () => {
     const env = {
       ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL,
-      ANTHROPIC_CUSTOM_HEADERS: "X-FireRouter-Fireworks-Key: fw_test",
+      ANTHROPIC_CUSTOM_HEADERS: "X-Stale-Fireworks-Key: fw_test",
     };
     assert.equal(firerouterStatusFromEnv(env), "other");
     assert.equal(providerStatusFromEnv(env), "fireworks");
@@ -49,13 +49,6 @@ describe("firerouter-core", () => {
     assert.equal(
       replaceFireworksKeyInCustomHeaders(current, "fw_new"),
       "X-Fireworks-Api-Key: fw_new\nx-routing-preference: 3\nX-User-Header: keep-me",
-    );
-  });
-
-  it("migrates a legacy-named Fireworks header while swapping the key", () => {
-    assert.equal(
-      replaceFireworksKeyInCustomHeaders("X-FireRouter-Fireworks-Key: fw_old", "fw_new"),
-      "X-Fireworks-Api-Key: fw_new",
     );
   });
 

--- a/packages/setup-cli/test/firerouter/firerouter-model.test.mjs
+++ b/packages/setup-cli/test/firerouter/firerouter-model.test.mjs
@@ -4,7 +4,8 @@ import assert from "node:assert/strict";
 import {
   FIREROUTER_MODEL_ID,
   FIREROUTER_ROUTER_ID,
-  isFirerouterGatewayPattern,
+  firerouterRequiresAnthropicKey,
+  isFirerouterModelPattern,
   isFirerouterModel,
   normalizeModelId,
 } from "../../lib/fireworks/model-id.mjs";
@@ -17,6 +18,8 @@ import {
   resolveFirerouterByokKeys,
 } from "../../lib/firerouter/core.mjs";
 import {
+  catalogWithAutomaticFirerouter,
+  firerouterDisplayName,
   preferLatestAliases,
   registerableModelIds,
 } from "../../lib/fireworks/models.mjs";
@@ -56,11 +59,66 @@ describe("firerouter model recognition", () => {
 
   it("matches firerouter* gateway patterns on any path segment", () => {
     for (const id of ["firerouter", "firerouter[1m]", "firerouter/x", "FireRouter/x", "firerouterx", "accounts/fireworks/routers/firerouter"]) {
-      assert.equal(isFirerouterGatewayPattern(id), true, id);
+      assert.equal(isFirerouterModelPattern(id), true, id);
     }
     for (const id of ["glm-fast-latest", "accounts/fireworks/routers/glm-latest", "", null, undefined]) {
-      assert.equal(isFirerouterGatewayPattern(id), false, String(id));
+      assert.equal(isFirerouterModelPattern(id), false, String(id));
     }
+  });
+
+  it("firerouterRequiresAnthropicKey: true for bare firerouter and any Claude/Opus member", () => {
+    // Bare firerouter's primary is Claude Opus 5 (fails closed without the key).
+    for (const id of [
+      "firerouter",
+      "firerouter[1m]",
+      "accounts/fireworks/routers/firerouter",
+      "firerouter/claude-opus-5/kimi-k3-fast",
+      "firerouter/claude-sonnet-5",
+      "firerouter/kimi-k3/claude-opus-5",
+      // Bare Claude picker aliases resolve to Anthropic models.
+      "firerouter/sonnet",
+      "firerouter/haiku",
+      "firerouter/fable",
+      "firerouter/opus",
+      "firerouter/claude",
+    ]) {
+      assert.equal(firerouterRequiresAnthropicKey(id), true, id);
+    }
+    // Pure-Fireworks selections route Fireworks models only — no Anthropic key.
+    for (const id of [
+      "firerouter/kimi-k3/glm-5p2-fast",
+      "firerouter/glm-latest",
+      "firerouter/deepseek-v4-flash",
+      "kimi-fast-latest",
+      "accounts/fireworks/routers/glm-latest",
+      "",
+      null,
+      undefined,
+    ]) {
+      assert.equal(firerouterRequiresAnthropicKey(id), false, String(id));
+    }
+  });
+
+  it("firerouterDisplayName constructs a label from the slash path", () => {
+    assert.equal(firerouterDisplayName("firerouter"), "FireRouter");
+    assert.equal(firerouterDisplayName("firerouter[1m]"), "FireRouter");
+    assert.equal(firerouterDisplayName("accounts/fireworks/routers/firerouter"), "FireRouter");
+    assert.equal(
+      firerouterDisplayName("firerouter/claude-opus-5/kimi-k3-fast"),
+      "FireRouter · Claude Opus 5 · Kimi K3 Fast",
+    );
+    assert.equal(
+      firerouterDisplayName("firerouter/kimi-k3/glm-5p2-fast"),
+      "FireRouter · Kimi K3 · GLM 5.2 Fast",
+    );
+    // Canonical multi-segment ref: the accounts/fireworks/routers prefix is
+    // stripped, not pretty-named.
+    assert.equal(
+      firerouterDisplayName("accounts/fireworks/routers/firerouter/kimi-k3"),
+      "FireRouter · Kimi K3",
+    );
+    // Non-firerouter ids fall back to the bare brand label.
+    assert.equal(firerouterDisplayName("kimi-fast-latest"), "FireRouter");
   });
 
   it("normalizeModelId keeps gateway slugs short (no accounts/fireworks expansion)", () => {
@@ -107,10 +165,24 @@ describe("firerouter routing plan", () => {
     assert.deepEqual(resolveFirerouterPlan({ main: "firerouter" }), {
       mainModel: "firerouter",
       isFirerouter: true,
+      requiresAnthropicKey: true,
     });
     assert.deepEqual(resolveFirerouterPlan({ main: "accounts/fireworks/routers/firerouter" }), {
       mainModel: "accounts/fireworks/routers/firerouter",
       isFirerouter: true,
+      requiresAnthropicKey: true,
+    });
+    // A multi-model slug is a firerouter selection; requiresAnthropicKey tracks
+    // whether an Anthropic model is in the path.
+    assert.deepEqual(resolveFirerouterPlan({ main: "firerouter/claude-opus-5/kimi-k3-fast" }), {
+      mainModel: "firerouter/claude-opus-5/kimi-k3-fast",
+      isFirerouter: true,
+      requiresAnthropicKey: true,
+    });
+    assert.deepEqual(resolveFirerouterPlan({ main: "firerouter/kimi-k3/glm-5p2-fast" }), {
+      mainModel: "firerouter/kimi-k3/glm-5p2-fast",
+      isFirerouter: true,
+      requiresAnthropicKey: false,
     });
   });
 
@@ -118,18 +190,20 @@ describe("firerouter routing plan", () => {
     assert.deepEqual(resolveFirerouterPlan({ main: "glm-fast-latest" }), {
       mainModel: "glm-fast-latest",
       isFirerouter: false,
+      requiresAnthropicKey: false,
     });
   });
 
   it("resolveFirerouterPlan never auto-defaults to firerouter (no --model → harness default)", () => {
-    assert.deepEqual(resolveFirerouterPlan({ main: "" }), { mainModel: "", isFirerouter: false });
-    assert.deepEqual(resolveFirerouterPlan({}), { mainModel: "", isFirerouter: false });
+    assert.deepEqual(resolveFirerouterPlan({ main: "" }), { mainModel: "", isFirerouter: false, requiresAnthropicKey: false });
+    assert.deepEqual(resolveFirerouterPlan({}), { mainModel: "", isFirerouter: false, requiresAnthropicKey: false });
   });
 
   it("resolveFirerouterPlan: Fire Pass with no model is fine (returns the harness default)", () => {
     assert.deepEqual(resolveFirerouterPlan({ main: "" }, { keyType: "firepass" }), {
       mainModel: "",
       isFirerouter: false,
+      requiresAnthropicKey: false,
     });
   });
 
@@ -362,6 +436,46 @@ describe("firerouter routing plan", () => {
     );
   });
 
+  it("registerableModelIds never lists the auto model id", () => {
+    const glmLatest = { shortId: "glm-latest", id: "accounts/fireworks/routers/glm-latest" };
+    // An auto row could arrive keyed either way, so both forms must drop out.
+    for (const autoRow of [
+      { shortId: "auto", id: "auto" },
+      { shortId: "", id: "accounts/fireworks/routers/auto" },
+    ]) {
+      const catalog = [glmLatest, autoRow];
+      assert.deepEqual(
+        registerableModelIds(catalog, "fireworks", { includeFirerouter: true }),
+        [
+          FIREROUTER_ROUTER_ID,
+          "accounts/fireworks/routers/glm-latest",
+        ],
+        autoRow.id,
+      );
+      assert.deepEqual(
+        registerableModelIds(catalog, "fireworks"),
+        ["accounts/fireworks/routers/glm-latest"],
+        autoRow.id,
+      );
+    }
+  });
+
+  it("keeps a catalog-supplied firerouter row when auto is also present", () => {
+    // The "already present" branch must compare against the auto-free list:
+    // otherwise an auto row makes the lengths differ and the whole unfiltered
+    // catalog (auto included, firerouter unmoved) gets returned.
+    const catalog = [
+      { shortId: "auto", id: "auto" },
+      { shortId: "firerouter", id: FIREROUTER_ROUTER_ID },
+      { shortId: "glm-latest", id: "accounts/fireworks/routers/glm-latest" },
+    ];
+    assert.deepEqual(
+      catalogWithAutomaticFirerouter(catalog, "fireworks", { includeFirerouter: true })
+        .map((entry) => entry.id),
+      [FIREROUTER_ROUTER_ID, "accounts/fireworks/routers/glm-latest"],
+    );
+  });
+
   it("also auto-registers for a valid Anthropic env key on forwarding harnesses", () => {
     const base = { autoFirerouter: true, keyType: "fireworks" };
     assert.equal(shouldAutoIncludeFirerouter({
@@ -526,9 +640,11 @@ describe("firerouter BYOK", () => {
     });
   });
 
-  const planFor = ({ isFirerouter = false } = {}) => ({
+  const planFor = ({ isFirerouter = false, requiresAnthropicKey } = {}) => ({
     mainModel: isFirerouter ? FIREROUTER_MODEL_ID : "accounts/fireworks/routers/glm-fast-latest",
     isFirerouter,
+    // Bare `firerouter` (the default firerouter plan) requires an Anthropic key.
+    requiresAnthropicKey: requiresAnthropicKey ?? isFirerouter,
   });
 
   it("resolveFirerouterByokHeaders returns {} for a non-firerouter plan", async () => {

--- a/packages/setup-cli/test/fireworks/firepass-defaults.test.mjs
+++ b/packages/setup-cli/test/fireworks/firepass-defaults.test.mjs
@@ -85,11 +85,26 @@ describe("Fire Pass defaults", () => {
     assert.equal(normalizeModelId("kimi-latest"), "kimi-latest");
     assert.equal(normalizeModelId("minimax-latest"), "minimax-latest");
     assert.equal(normalizeModelId("qwen-plus-latest"), "qwen-plus-latest");
+    assert.equal(normalizeModelId("auto"), "auto");
+    assert.equal(normalizeModelId("Auto"), "auto");
+    assert.equal(normalizeModelId("auto[1m]"), "auto");
+    // Each mix keeps its own slug — normalizing to `auto` would silently swap a
+    // latency-first pin for the slower default mix.
+    assert.equal(normalizeModelId("auto-instant"), "auto-instant");
+    assert.equal(normalizeModelId("Auto-Instant[1m]"), "auto-instant");
+    // Refs that only contain an auto-shaped segment keep their full path.
+    assert.equal(
+      normalizeModelId("accounts/auto-corp/models/private-model"),
+      "accounts/auto-corp/models/private-model",
+    );
+    assert.equal(normalizeModelId("firerouter/auto-instant"), "firerouter/auto-instant");
   });
 
   test("fullFireworksResourceId expands slugs for catalog lookups", () => {
     assert.equal(fullFireworksResourceId("glm-fast-latest"), "accounts/fireworks/routers/glm-fast-latest");
     assert.equal(fullFireworksResourceId("deepseek-v4-flash"), "accounts/fireworks/models/deepseek-v4-flash");
+    assert.equal(fullFireworksResourceId("auto"), "auto");
+    assert.equal(fullFireworksResourceId("auto-instant"), "auto-instant");
     assert.equal(shortFireworksModelRef(`${fullFireworksResourceId("glm-fast-latest")}[1m]`), "glm-fast-latest[1m]");
     assert.equal(fireworksModelSlug("glm-fast-latest[1m]"), "glm-fast-latest");
     assert.equal(
@@ -103,6 +118,10 @@ describe("Fire Pass defaults", () => {
     assert.equal(isFireworksModelId("glm-fast-latest[1m]"), true);
     assert.equal(isFireworksModelId("deepseek-v4-flash"), true);
     assert.equal(isFireworksModelId("minimax-latest"), true);
+    assert.equal(isFireworksModelId("auto"), true);
+    assert.equal(isFireworksModelId("auto[1m]"), true);
+    assert.equal(isFireworksModelId("auto-instant"), true);
+    assert.equal(isFireworksModelId("auto-smart"), false);
     assert.equal(isFireworksModelId("claude-sonnet-5"), false);
     assert.equal(isFireworksModelId("unknown-user-model"), false);
   });
@@ -175,6 +194,13 @@ describe("Fire Pass defaults", () => {
     assert.equal(claudeCodeModelId("firerouter[1m]"), "firerouter[1m]");
     assert.equal(claudeCodeModelId("accounts/fireworks/routers/firerouter"), "accounts/fireworks/routers/firerouter[1m]");
     assert.equal(claudeCodeModelId("firerouter/x"), "firerouter/x[1m]");
+    // `auto` uses the same [1m] tag as other 1M Fireworks models; Claude Code
+    // strips the suffix before the gateway API call (bare `auto` on the wire).
+    assert.equal(claudeCodeModelId("auto"), "auto[1m]");
+    assert.equal(claudeCodeModelId("auto[1m]"), "auto[1m]");
+    assert.equal(modelQualifiesForClaudeCode1mContext("auto"), true);
+    assert.equal(claudeCodeModelId("auto-instant"), "auto-instant[1m]");
+    assert.equal(modelQualifiesForClaudeCode1mContext("auto-instant"), true);
     assert.equal(claudeCodeModelId("firerouter/x[1m]"), "firerouter/x[1m]");
     assert.equal(claudeCodeModelId("FireRouter/x"), "FireRouter/x[1m]");
     assert.equal(claudeCodeModelId("firerouterx"), "firerouterx[1m]");

--- a/packages/setup-cli/test/fireworks/fireworks-model-specs.test.mjs
+++ b/packages/setup-cli/test/fireworks/fireworks-model-specs.test.mjs
@@ -13,6 +13,7 @@ import {
   resolveRouterEntryDisplayName,
   resolveRouterSpecAliasTarget,
   resolveSpecSlug,
+  isAutoModelId,
   isFireworksRoutedModelRef,
 } from "../../lib/fireworks/model-specs.mjs";
 import { lookupFireworksPricing } from "../../lib/fireworks/pricing.mjs";
@@ -125,9 +126,9 @@ describe("fireworks-model-specs", () => {
       const spec = lookupModelSpec("kimi-fast-latest");
       assert.equal(spec?.label, "Kimi K3 Fast");
       assert.equal(spec?.pricing?.tier, "fast");
-      assert.equal(spec?.pricing?.input, 6.00);
-      assert.equal(lookupFireworksPricing("kimi-fast-latest")?.output, 30.00);
-      assert.equal(lookupFireworksModelCost("kimi-fast-latest")?.input, 6.00);
+      assert.equal(spec?.pricing?.input, 4.50);
+      assert.equal(lookupFireworksPricing("kimi-fast-latest")?.output, 22.50);
+      assert.equal(lookupFireworksModelCost("kimi-fast-latest")?.input, 4.50);
     } finally {
       setServerlessCatalogSnapshot(null);
     }
@@ -152,8 +153,8 @@ describe("fireworks-model-specs", () => {
     try {
       const pricing = lookupFireworksPricing("kimi-fast-latest");
       assert.equal(pricing?.tier, "fast");
-      assert.equal(pricing?.input, 6.00);
-      assert.equal(pricing?.output, 30.00);
+      assert.equal(pricing?.input, 4.50);
+      assert.equal(pricing?.output, 22.50);
     } finally {
       setServerlessCatalogSnapshot(null);
     }
@@ -213,9 +214,9 @@ describe("fireworks-model-specs", () => {
     const flashPricing = {
       slug: "deepseek-v4-flash-0731",
       label: "DeepSeek V4 Flash (0731)",
-      input: 0.14,
-      cachedInput: 0.028,
-      output: 0.28,
+      input: 0.22,
+      cachedInput: 0.007,
+      output: 0.66,
       tier: "standard",
       source: "api",
     };
@@ -245,8 +246,8 @@ describe("fireworks-model-specs", () => {
       assert.equal(spec?.label, "DeepSeek V4 Flash (0731)");
       // The dated pin carries the documented sibling rates as an offline
       // fallback; live catalog pricing still wins below.
-      assert.deepEqual(spec?.pricing, { input: 0.14, cachedInput: 0.028, output: 0.28 });
-      assert.equal(lookupFireworksPricing("deepseek-flash-latest")?.output, 0.28);
+      assert.deepEqual(spec?.pricing, { input: 0.22, cachedInput: 0.007, output: 0.66 });
+      assert.equal(lookupFireworksPricing("deepseek-flash-latest")?.output, 0.66);
       assert.equal(lookupFireworksPricing("deepseek-flash-latest")?.source, "api");
     } finally {
       setServerlessCatalogSnapshot(null);
@@ -289,7 +290,7 @@ describe("fireworks-model-specs", () => {
       assert.equal(spec?.label, "DeepSeek V4 Pro (0813)");
       // The dated pin carries the documented sibling rates as an offline
       // fallback; live catalog pricing still wins below.
-      assert.deepEqual(spec?.pricing, { input: 1.74, cachedInput: 0.145, output: 3.48 });
+      assert.deepEqual(spec?.pricing, { input: 1.32, cachedInput: 0.044, output: 3.96 });
       assert.equal(lookupFireworksPricing("deepseek-pro-latest")?.output, 3.96);
       assert.equal(lookupFireworksPricing("deepseek-pro-latest")?.source, "api");
     } finally {
@@ -386,9 +387,9 @@ describe("fireworks-model-specs", () => {
     try {
       const pricing = lookupFireworksPricing("kimi-fast-latest");
       assert.equal(pricing?.tier, "fast");
-      assert.equal(pricing?.input, 6.00);
-      assert.equal(pricing?.output, 30.00);
-      assert.equal(lookupFireworksModelCost("kimi-fast-latest")?.input, 6.00);
+      assert.equal(pricing?.input, 4.50);
+      assert.equal(pricing?.output, 22.50);
+      assert.equal(lookupFireworksModelCost("kimi-fast-latest")?.input, 4.50);
     } finally {
       setServerlessCatalogSnapshot(null);
     }
@@ -447,6 +448,7 @@ describe("fireworks-model-specs", () => {
 
     assert.equal(requiresFastTierPricing("kimi-fast-latest"), true);
     assert.equal(requiresFastTierPricing("kimi-k2p6-turbo"), true);
+    assert.equal(requiresFastTierPricing("glm-5p2-fast-us"), true);
     assert.equal(requiresFastTierPricing("kimi-latest"), false);
 
     assert.equal(pricingMatchesModelRefTier("kimi-fast-latest", fastPricing), true);
@@ -519,6 +521,37 @@ describe("fireworks-model-specs", () => {
     assert.equal(spec?.label, "FireRouter");
     assert.equal(spec?.capabilities.vision, true);
     const limits = lookupFireworksModelLimits("firerouter/x");
+    assert.equal(limits.contextWindow, 1_048_575);
+    assert.equal(limits.vision, true);
+  });
+
+  it("resolves auto from the static spec without a catalog row", () => {
+    const spec = lookupModelSpec("auto");
+    assert.equal(spec?.label, "Auto");
+    assert.equal(spec?.capabilities.vision, true);
+    const limits = lookupFireworksModelLimits("auto");
+    assert.equal(limits.contextWindow, 1_048_575);
+    assert.equal(limits.vision, true);
+  });
+
+  it("shares auto spec metadata for auto-* model ids", () => {
+    assert.equal(isAutoModelId("auto"), true);
+    assert.equal(isAutoModelId("Auto"), true);
+    assert.equal(isAutoModelId("auto[1m]"), true);
+    assert.equal(isAutoModelId("auto-instant"), true);
+    assert.equal(isAutoModelId("Auto-Instant[1m]"), true);
+    assert.equal(isAutoModelId("auto-fast"), true);
+    assert.equal(isAutoModelId("automatic"), false);
+    assert.equal(isAutoModelId("auto-smart"), false, "Cursor-native picker is not a Fireworks mix");
+    // A slash means the ref names something else that merely contains an
+    // auto-shaped segment; matching it would route to the wrong model.
+    assert.equal(isAutoModelId("accounts/auto-corp/models/private-model"), false);
+    assert.equal(isAutoModelId("accounts/fireworks/deployments/auto-instant"), false);
+    assert.equal(isAutoModelId("firerouter/auto-instant"), false);
+    const spec = lookupModelSpec("auto-instant");
+    assert.equal(spec?.label, "Auto");
+    assert.equal(spec?.capabilities.vision, true);
+    const limits = lookupFireworksModelLimits("auto-instant");
     assert.equal(limits.contextWindow, 1_048_575);
     assert.equal(limits.vision, true);
   });
@@ -618,6 +651,9 @@ describe("fireworks-model-specs", () => {
     assert.equal(isFireworksRoutedModelRef("kimi-fast-latest"), true);
     assert.equal(isFireworksRoutedModelRef("accounts/fireworks/models/glm-5p2"), true);
     assert.equal(isFireworksRoutedModelRef("firerouter"), true);
+    assert.equal(isFireworksRoutedModelRef("auto"), true);
+    assert.equal(isFireworksRoutedModelRef("auto-instant"), true);
+    assert.equal(isFireworksRoutedModelRef("auto-smart"), false);
     assert.equal(isFireworksRoutedModelRef("claude-sonnet-5"), false);
     assert.equal(isFireworksRoutedModelRef("unknown-user-model"), false);
   });

--- a/packages/setup-cli/test/fireworks/fireworks-models.test.mjs
+++ b/packages/setup-cli/test/fireworks/fireworks-models.test.mjs
@@ -1,18 +1,31 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, test } from "node:test";
 
 import {
+  autoCatalogEntry,
   buildPickerCatalogFromApiModels,
   buildServerlessCatalogSnapshot,
   fetchServerlessCatalogRaw,
   inputModalitiesFromModel,
+  loadServerlessCatalog,
   moneyToUsd,
   parseSkuPricing,
   SERVERLESS_CODING_USE_CASE,
   warmServerlessPricingCache,
 } from "../../lib/fireworks/models.mjs";
-import { organizeCatalogForDisplay } from "../../lib/fireworks/model-list.mjs";
-import { setServerlessCatalogSnapshot } from "../../lib/fireworks/serverless-catalog-cache.mjs";
+import {
+  catalogWithAutoEntry,
+  formatCatalogUpdatedAt,
+  organizeCatalogForDisplay,
+} from "../../lib/fireworks/model-list.mjs";
+import {
+  cacheServerlessCatalogSnapshot,
+  readCatalogCache,
+  setServerlessCatalogSnapshot,
+} from "../../lib/fireworks/serverless-catalog-cache.mjs";
 
 import { mockServerlessModel } from "../helpers.mjs";
 
@@ -42,6 +55,98 @@ describe("fireworks-models serverless catalog", () => {  test("fetchServerlessCa
     }
   });
 
+  /**
+   * Run `fn` against a throwaway HOME (so the catalog cache file is isolated)
+   * seeded with a fresh single-entry `stale` snapshot.
+   */
+  async function withSeededCatalogCache(fetchImpl, fn) {
+    const home = mkdtempSync(path.join(os.tmpdir(), "fc-catalog-refresh-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      const seededAt = cacheServerlessCatalogSnapshot({
+        entries: [{
+          id: "accounts/fireworks/models/stale",
+          shortId: "stale",
+          displayName: "Stale",
+          kind: "serverless",
+        }],
+        pricingById: new Map(),
+        inputModalitiesById: new Map(),
+        routerBaseModelById: new Map(),
+        contextLengthById: new Map(),
+        supportsToolsById: new Map(),
+      });
+      await fn(seededAt);
+    } finally {
+      globalThis.fetch = previousFetch;
+      process.env.HOME = prevHome;
+      setServerlessCatalogSnapshot(null);
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  test("loadServerlessCatalog refresh ignores a fresh cache and refetches", async () => {
+    let fetches = 0;
+    const fetchImpl = async () => {
+      fetches += 1;
+      return {
+        ok: true,
+        json: async () => ({ models: [mockServerlessModel()] }),
+      };
+    };
+
+    await withSeededCatalogCache(fetchImpl, async (seededAt) => {
+      const cached = await loadServerlessCatalog({ apiKey: "fw_test_key" });
+      assert.equal(cached.source, "cache");
+      assert.equal(cached.updatedAt, seededAt);
+      assert.equal(fetches, 0);
+      assert.equal(cached.catalog[0].shortId, "stale");
+
+      const refreshed = await loadServerlessCatalog({ apiKey: "fw_test_key", refresh: true });
+      assert.equal(refreshed.source, "network");
+      assert.equal(refreshed.updatedAt, readCatalogCache()?.cachedAt);
+      assert.equal(fetches, 1);
+      assert.ok(refreshed.catalog.some((entry) => entry.shortId === "glm-5p2"));
+      assert.equal(refreshed.catalog.some((entry) => entry.shortId === "stale"), false);
+      assert.ok(
+        readCatalogCache()?.snapshot.entries.some((entry) => entry.shortId === "glm-5p2"),
+        "refetch replaces the persisted snapshot",
+      );
+    });
+  });
+
+  // An offline refresh must not leave the user worse off than before: the old
+  // snapshot stays on disk so later commands (harness `on`, the picker) still
+  // have a catalog instead of hard-failing as a cold start.
+  test("loadServerlessCatalog refresh keeps the cached snapshot when the fetch fails", async () => {
+    const fetchImpl = async () => {
+      throw new Error("network unreachable");
+    };
+
+    await withSeededCatalogCache(fetchImpl, async (seededAt) => {
+      const result = await loadServerlessCatalog({ apiKey: "fw_test_key", refresh: true });
+      assert.equal(result.source, "stale");
+      assert.equal(result.updatedAt, seededAt);
+      assert.equal(result.catalog[0].shortId, "stale");
+      assert.equal(
+        readCatalogCache()?.snapshot.entries[0].shortId,
+        "stale",
+        "a failed refresh must not delete the cache file",
+      );
+    });
+  });
+
+  test("formatCatalogUpdatedAt uses the local timezone and includes its abbreviation", () => {
+    assert.equal(
+      formatCatalogUpdatedAt(Date.UTC(2026, 7, 29, 20, 28), "America/Los_Angeles"),
+      "Aug 29, 2026, 1:28 PM PDT",
+    );
+    assert.equal(formatCatalogUpdatedAt(null), "bundled with FireConnect");
+  });
+
   test("buildPickerCatalogFromApiModels derives routers from usage_identifier", () => {
     const catalog = buildPickerCatalogFromApiModels([
       mockServerlessModel(),
@@ -57,6 +162,43 @@ describe("fireworks-models serverless catalog", () => {  test("fetchServerlessCa
     assert.ok(ids.includes("accounts/fireworks/routers/glm-5p2-fast"));
     assert.ok(ids.includes("accounts/fireworks/routers/glm-latest"));
     assert.equal(ids.filter((id) => id.includes("/models/")).length, 2);
+  });
+
+  test("buildPickerCatalogFromApiModels adds documented US-only routers", () => {
+    const catalog = buildPickerCatalogFromApiModels([
+      mockServerlessModel(),
+      mockServerlessModel({
+        name: "accounts/fireworks/models/kimi-k3",
+        displayName: "Kimi K3",
+        serverlessModes: [],
+      }),
+      mockServerlessModel({
+        name: "accounts/fireworks/models/glm-5p3-flash",
+        displayName: "GLM 5.3 Flash",
+        serverlessModes: [],
+      }),
+    ]);
+    const byId = new Map(catalog.map((entry) => [entry.id, entry]));
+
+    assert.equal(
+      byId.get("accounts/fireworks/routers/glm-5p2-fast-us")?.displayName,
+      "GLM 5.2 Fast (US)",
+    );
+    assert.equal(
+      byId.get("accounts/fireworks/routers/kimi-k3-us")?.displayName,
+      "Kimi K3 (US)",
+    );
+    assert.equal(
+      byId.get("accounts/fireworks/routers/glm-5p3-flash-us")?.displayName,
+      "GLM 5.3 Flash (US)",
+    );
+
+    const sections = organizeCatalogForDisplay(catalog);
+    const usOnly = sections.find((section) => section.title === "US-ONLY ROUTERS");
+    assert.deepEqual(
+      usOnly?.entries.map((entry) => entry.shortId),
+      ["glm-5p2-fast-us", "glm-5p3-flash-us", "kimi-k3-us"],
+    );
   });
 
   test("buildServerlessCatalogSnapshot captures API pricing and modalities", () => {
@@ -473,6 +615,7 @@ describe("fireworks-models serverless catalog", () => {  test("fetchServerlessCa
     });
     const sections = organizeCatalogForDisplay([
       entry("firerouter", "routers"),
+      autoCatalogEntry(),
       entry("glm-5p1", "models"),
       entry("glm-5p2", "models"),
       entry("glm-5p2-fast", "routers"),
@@ -494,14 +637,43 @@ describe("fireworks-models serverless catalog", () => {  test("fetchServerlessCa
     ]));
 
     assert.deepEqual(idsBySection, {
-      "SMART ROUTER": ["firerouter"],
+      // auto leads the section so the default recommendation is listed first.
+      "SMART ROUTERS": ["auto", "firerouter"],
       "LATEST ROUTERS": ["glm-latest", "kimi-latest", "minimax-latest"],
       "FAST ROUTERS": ["glm-fast-latest", "kimi-fast-latest"],
       "INDIVIDUAL MODELS": ["glm-5p2", "kimi-k3", "minimax-m3"],
     });
   });
 
-  test("individual models only include bases targeted by -latest routers", () => {
+  test("model list synthesizes the auto rows, except on Fire Pass keys", () => {
+    const catalog = [{
+      id: "accounts/fireworks/routers/glm-latest",
+      shortId: "glm-latest",
+      displayName: "GLM 5.2 (Latest)",
+      kind: "serverless",
+    }];
+
+    const listed = catalogWithAutoEntry(catalog, "fireworks");
+    assert.deepEqual(listed.map((e) => e.shortId), ["auto", "auto-instant", "glm-latest"]);
+    assert.equal(listed[0].displayName, "Auto");
+    assert.equal(listed[1].displayName, "Auto Instant");
+
+    assert.deepEqual(
+      catalogWithAutoEntry(catalog, "firepass").map((e) => e.shortId),
+      ["glm-latest"],
+    );
+    // A gateway-supplied auto row must not be duplicated by the synthesized one,
+    // and it must not suppress the other auto routers either.
+    const withGatewayRow = [autoCatalogEntry(), ...catalog];
+    assert.deepEqual(
+      catalogWithAutoEntry(withGatewayRow, "fireworks").map((e) => e.shortId),
+      ["auto-instant", "auto", "glm-latest"],
+    );
+    const withAllGatewayRows = [autoCatalogEntry(), autoCatalogEntry("auto-instant"), ...catalog];
+    assert.equal(catalogWithAutoEntry(withAllGatewayRows, "fireworks"), withAllGatewayRows);
+  });
+
+  test("individual models list the newest version of every catalog family", () => {
     const entry = (shortId, kind, baseModelId = undefined) => ({
       id: `accounts/fireworks/${kind}/${shortId}`,
       shortId,
@@ -519,7 +691,8 @@ describe("fireworks-models serverless catalog", () => {  test("fetchServerlessCa
       // family alias, so it must not reappear.
       entry("deepseek-v4-flash", "models"),
       entry("glm-5p2", "models"),
-      // Standalone model with no -latest alias: excluded from INDIVIDUAL MODELS.
+      // Standalone model with no -latest alias: still listed, since harnesses
+      // can be pinned to it.
       entry("gpt-oss-120b", "models"),
     ]);
     const individual = sections.find((section) => section.title === "INDIVIDUAL MODELS")?.entries
@@ -529,6 +702,68 @@ describe("fireworks-models serverless catalog", () => {  test("fetchServerlessCa
       "deepseek-v4-flash-0731",
       "deepseek-v4-pro-0813",
       "glm-5p2",
+      "gpt-oss-120b",
     ]);
+  });
+
+  test("a -latest router pinned to an older version cannot hide a newer model", () => {
+    const entry = (shortId, kind, baseModelId = undefined) => ({
+      id: `accounts/fireworks/${kind}/${shortId}`,
+      shortId,
+      displayName: shortId,
+      kind: "serverless",
+      ...(baseModelId ? { baseModelId } : {}),
+    });
+    // glm-latest still resolves to 5p2 while the catalog already serves 5p3 —
+    // the state a stale ROUTER_SPEC_ALIASES entry leaves behind.
+    const sections = organizeCatalogForDisplay([
+      entry("glm-latest", "routers", "accounts/fireworks/models/glm-5p2"),
+      entry("glm-5p2", "models"),
+      entry("glm-5p3", "models"),
+      // Family the CLI has never seen, with no alias of its own.
+      entry("newfamily-2p1", "models"),
+      entry("newfamily-3", "models"),
+    ]);
+    const individual = sections.find((section) => section.title === "INDIVIDUAL MODELS")?.entries
+      .map(({ shortId }) => shortId);
+
+    assert.deepEqual(individual, ["glm-5p3", "newfamily-3"]);
+  });
+
+  test("a -flash-latest alias keeps Flash a family of its own", () => {
+    const entry = (shortId, kind, baseModelId = undefined) => ({
+      id: `accounts/fireworks/${kind}/${shortId}`,
+      shortId,
+      displayName: shortId,
+      kind: "serverless",
+      ...(baseModelId ? { baseModelId } : {}),
+    });
+    // Without glm-flash-latest, "glm-flash" prefix-collapses into "glm" and the
+    // Flash model loses to the higher-versioned sibling.
+    const withoutAlias = organizeCatalogForDisplay([
+      entry("glm-latest", "routers", "accounts/fireworks/models/glm-5p3"),
+      entry("glm-5p3", "models"),
+      entry("glm-5p2-flash", "models"),
+    ]);
+    assert.deepEqual(
+      withoutAlias.find((s) => s.title === "INDIVIDUAL MODELS")?.entries.map((e) => e.shortId),
+      ["glm-5p3"],
+    );
+
+    const withAlias = organizeCatalogForDisplay([
+      entry("glm-latest", "routers", "accounts/fireworks/models/glm-5p3"),
+      entry("glm-flash-latest", "routers", "accounts/fireworks/models/glm-5p2-flash"),
+      entry("glm-5p2", "models"),
+      entry("glm-5p3", "models"),
+      entry("glm-5p2-flash", "models"),
+    ]);
+    const bySection = Object.fromEntries(withAlias.map((s) => [
+      s.title,
+      s.entries.map((e) => e.shortId),
+    ]));
+    assert.deepEqual(bySection["LATEST ROUTERS"], ["glm-flash-latest", "glm-latest"]);
+    // Flash is a distinct model, not a speed tier: it must not land in FAST ROUTERS.
+    assert.equal(bySection["FAST ROUTERS"], undefined);
+    assert.deepEqual(bySection["INDIVIDUAL MODELS"], ["glm-5p2-flash", "glm-5p3"]);
   });
 });

--- a/packages/setup-cli/test/fireworks/fireworks-pricing.test.mjs
+++ b/packages/setup-cli/test/fireworks/fireworks-pricing.test.mjs
@@ -79,6 +79,27 @@ describe("fireworks-pricing", () => {
     assert.equal(pricing.output, 6.60);
   });
 
+  it("uses documented US-only pricing instead of cached global base rates", () => {
+    const kimiUs = lookupFireworksPricing("kimi-k3-us");
+    assert.equal(kimiUs?.slug, "kimi-k3-us");
+    assert.equal(kimiUs?.input, 3.30);
+    assert.equal(kimiUs?.cachedInput, 0.33);
+    assert.equal(kimiUs?.output, 16.50);
+
+    const glmFastUs = lookupFireworksPricing("glm-5p2-fast-us");
+    assert.equal(glmFastUs?.slug, "glm-5p2-fast-us");
+    assert.equal(glmFastUs?.tier, "fast");
+    assert.equal(glmFastUs?.input, 2.10);
+    assert.equal(glmFastUs?.cachedInput, 0.21);
+    assert.equal(glmFastUs?.output, 6.60);
+
+    const glmFlashUs = lookupFireworksPricing("glm-5p3-flash-us");
+    assert.equal(glmFlashUs?.slug, "glm-5p3-flash-us");
+    assert.equal(glmFlashUs?.input, 0.225);
+    assert.equal(glmFlashUs?.cachedInput, 0.045);
+    assert.equal(glmFlashUs?.output, 0.75);
+  });
+
   it("formats compact in/out pricing for tables", () => {
     const pricing = lookupFireworksPricing("accounts/fireworks/models/glm-5p2");
     assert.equal(formatPricingInOut(pricing), "$1.4 / $4.4");

--- a/packages/setup-cli/test/fireworks/model-display.test.mjs
+++ b/packages/setup-cli/test/fireworks/model-display.test.mjs
@@ -21,7 +21,7 @@ describe("model-display", () => {
     const catalog = resolveFireworksCatalog("accounts/fireworks/routers/glm-latest");
     assert.equal(display.maxInputTokens, catalog.limits.contextWindow);
     assert.equal(display.maxOutputTokens, catalog.limits.maxTokens);
-    assert.equal(catalog.limits.contextWindow, 1_048_575);
+    assert.equal(catalog.limits.contextWindow, 1_048_576);
   });
 
   it("resolves kimi vision models with image input enabled", () => {

--- a/packages/setup-cli/test/fireworks/model-servability.test.mjs
+++ b/packages/setup-cli/test/fireworks/model-servability.test.mjs
@@ -26,6 +26,20 @@ describe("model-servability isModelIdValidationApplicable", () => {
     assert.equal(isModelIdValidationApplicable("firerouter/balanced"), false);
   });
 
+  it("is false for the auto mix and auto-* variants", () => {
+    assert.equal(isModelIdValidationApplicable("auto"), false);
+    assert.equal(isModelIdValidationApplicable("Auto"), false);
+    assert.equal(isModelIdValidationApplicable("auto[1m]"), false);
+    assert.equal(isModelIdValidationApplicable("auto-instant"), false);
+    assert.equal(isModelIdValidationApplicable("auto-instant[1m]"), false);
+    assert.equal(isModelIdValidationApplicable("auto-smart"), true, "Cursor-native id still catalog-checked");
+    assert.equal(
+      isModelIdValidationApplicable("accounts/auto-corp/models/private-model"),
+      true,
+      "an auto-shaped account is not a gateway mix",
+    );
+  });
+
   it("is false for custom deployment ids", () => {
     assert.equal(
       isModelIdValidationApplicable("accounts/ahmadshahzad/deployments/ub9lvh50"),
@@ -110,6 +124,8 @@ describe("model-servability assertRequestedModelsServable", () => {
     globalThis.fetch = async () => { fetched = true; return { ok: true, json: async () => ({ models: [] }) }; };
     try {
       await assertRequestedModelServable("firerouter", { apiKey: "fw_test_key", keyType: "fireworks" });
+      await assertRequestedModelServable("auto", { apiKey: "fw_test_key", keyType: "fireworks" });
+      await assertRequestedModelServable("auto-instant", { apiKey: "fw_test_key", keyType: "fireworks" });
       await assertRequestedModelServable("accounts/u/deployments/x", { apiKey: "fw_test_key", keyType: "fireworks" });
       assert.equal(fetched, false);
     } finally {
@@ -160,7 +176,7 @@ describe("model-servability assertRequestedModelsServable", () => {
       // glm-5p2 + glm-latest are in the catalog; the bogus one must surface.
       await assert.rejects(
         () => assertRequestedModelsServable(
-          ["glm-5p2", "glm-latest", "firerouter", "", "not-a-real-model"],
+          ["glm-5p2", "glm-latest", "firerouter", "auto", "", "not-a-real-model"],
           { apiKey: "fw_test_key", keyType: "fireworks" },
         ),
         /not available on Fireworks/,

--- a/packages/setup-cli/test/fireworks/serverless-catalog-cache.test.mjs
+++ b/packages/setup-cli/test/fireworks/serverless-catalog-cache.test.mjs
@@ -17,6 +17,15 @@ const CACHE_MODULE = fileURLToPath(
   new URL("../../lib/fireworks/serverless-catalog-cache.mjs", import.meta.url),
 );
 
+const PRICING_MODULE = fileURLToPath(
+  new URL("../../lib/fireworks/pricing.mjs", import.meta.url),
+);
+
+// This spec is about the HOME-based default cache path, so it opts out of the
+// FIRECONNECT_CACHE_DIR override global-setup applies to every test process.
+// Isolation still holds: each case runs under its own temp HOME.
+delete process.env.FIRECONNECT_CACHE_DIR;
+
 function sampleSnapshot() {
   return {
     entries: [
@@ -85,6 +94,41 @@ describe("serverless-catalog-cache disk persistence", () => {
       assert.equal(loaded.pricing, 1.4);
       assert.equal(loaded.context, 1048576);
       assert.equal(loaded.tools, true);
+    });
+  });
+
+  it("prices from the persisted cache in a process that never loaded the catalog", () => {
+    // The status line helper is spawned per assistant message and makes no
+    // network calls, so the disk snapshot is the only live pricing it can see.
+    // Reading the module's in-memory binding instead of lazy-loading left it
+    // pricing from the static spec table alone — stale rates for a model whose
+    // published price moved, and reference rates for one the table lacks.
+    withTempHome(() => {
+      cacheServerlessCatalogSnapshot({
+        ...sampleSnapshot(),
+        pricingById: new Map([
+          ["accounts/fireworks/models/brand-new-model", {
+            slug: "brand-new-model",
+            label: "Brand New Model",
+            input: 0.7,
+            cachedInput: 0.07,
+            output: 2.1,
+            tier: "standard",
+            source: "",
+          }],
+        ]),
+      });
+
+      const child = spawnSync(process.execPath, ["--input-type=module", "-e", `
+        import { lookupFireworksPricing } from ${JSON.stringify(`file://${PRICING_MODULE}`)};
+        console.log(JSON.stringify(lookupFireworksPricing("accounts/fireworks/models/brand-new-model")));
+      `], { env: { ...process.env, HOME: process.env.HOME }, encoding: "utf8" });
+      assert.equal(child.status, 0, child.stderr);
+
+      const pricing = JSON.parse(child.stdout.trim());
+      assert.equal(pricing?.input, 0.7);
+      assert.equal(pricing?.output, 2.1);
+      assert.equal(pricing?.label, "Brand New Model");
     });
   });
 

--- a/packages/setup-cli/test/global-setup.mjs
+++ b/packages/setup-cli/test/global-setup.mjs
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -8,6 +10,17 @@ import { fileURLToPath } from "node:url";
 // inject ANSI escape sequences even though spawned stdout is piped.
 process.env.FORCE_COLOR = "0";
 process.env.NO_COLOR = "1";
+
+// Default every test process to the isolated secret store. Individual
+// secret-backend specs explicitly unset these and force file/null storage.
+process.env.FIRECONNECT_TEST ??= "1";
+process.env.FIRECONNECT_SECRET_STORE ??= "memory";
+
+// Point the persisted catalog cache at a throwaway dir for EVERY test process,
+// not just the ones that import test/helpers.mjs. Catalog lookups lazy-load this
+// file, so without it a spec that never touches the cache would read (and price
+// from) the developer's own ~/.fireconnect snapshot.
+process.env.FIRECONNECT_CACHE_DIR ??= mkdtempSync(path.join(os.tmpdir(), "fc-cache-global-"));
 
 // Preloaded via `--import` for every test process (see package.json `test`).
 //

--- a/packages/setup-cli/test/harnesses/claude/claude-auth-matrix.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-auth-matrix.test.mjs
@@ -13,7 +13,8 @@ import { FIRECONNECT_REFERER, runFireconnect, withTempHome, assertClaudeMainMode
 
 const FIREWORKS_KEY = "fw_claude_matrix_key_000000000000";
 const ANTHROPIC_KEY = "sk-ant-claude-matrix-byok";
-const KIMI_FABLE_MODEL = "kimi-fast-latest[1m]";
+const KIMI_FABLE_MODEL = "glm-flash-latest[1m]";
+const GLM_SONNET_MODEL = "glm-latest[1m]";
 const FIREROUTER_MODEL = "firerouter[1m]";
 const SUBSCRIPTION_SETTINGS = `${JSON.stringify({
   model: "sonnet",
@@ -129,8 +130,8 @@ describe("Claude subscription, BYOK, and FireRouter matrix", () => {
           settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL,
           expectedOpus,
         );
-        // Sonnet is native by default, so its alias env key is never written.
-        assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL, undefined);
+        // FireRouter on Opus moves GLM to Sonnet.
+        assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL, GLM_SONNET_MODEL);
         // Fable carries the vision model in every scenario now, so the old
         // firerouter-only shift is gone.
         assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, KIMI_FABLE_MODEL);
@@ -184,8 +185,8 @@ describe("Claude subscription, BYOK, and FireRouter matrix", () => {
         assert.equal(settings.model, undefined);
         assert.equal(settings.env?.ANTHROPIC_MODEL, undefined);
         assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, FIREROUTER_MODEL);
-        // Sonnet is native by default, so its alias env key is never written.
-        assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL, undefined);
+        // FireRouter on Opus moves GLM to Sonnet.
+        assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL, GLM_SONNET_MODEL);
         assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, KIMI_FABLE_MODEL);
         assert.equal(settings.env.ANTHROPIC_API_KEY, undefined);
         assert.equal(settings.env.ANTHROPIC_AUTH_TOKEN, undefined);

--- a/packages/setup-cli/test/harnesses/claude/claude-firerouter.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-firerouter.test.mjs
@@ -9,67 +9,13 @@ import {
   userSettingsPath,
 } from "../../../lib/harnesses/claude/core.mjs";
 import { refreshFirerouterClaudeKey } from "../../../lib/harnesses/claude/firerouter.mjs";
-import { FIREWORKS_BASE_URL } from "../../../lib/fireworks/model-id.mjs";
 import { readJsonIfExists, writeJson } from "../../../lib/io/json.mjs";
 import { FIRECONNECT_REFERER, runFireconnect, assertClaudeMainModel } from "../../helpers.mjs";
 
 const FIREWORKS_KEY = "fw_test_key_12345";
 const ANTHROPIC_KEY = "sk-ant-test-12345";
 const FIREROUTER_MODEL = "firerouter[1m]";
-const LEGACY_FIREROUTER_MODEL = "accounts/fireworks/routers/firerouter[1m]";
-const DIRECT_MAIN_MODEL = "kimi-fast-latest[1m]";
-const DIRECT_ALIAS_MODEL = "deepseek-pro-latest[1m]";
-const KIMI_FABLE_MODEL = "kimi-fast-latest[1m]";
-const LEGACY_FIREROUTER_BASE_URL = "https://router.fireworks.ai";
-const LEGACY_DESKTOP_GUARD_COMMAND = "node /old/fireconnect-desktop-guard.mjs";
-const USER_HOOK = {
-  matcher: "startup",
-  hooks: [{ type: "command", command: "echo user-hook" }],
-};
-
-function legacyRouterSettings() {
-  return {
-    model: LEGACY_FIREROUTER_MODEL,
-    env: {
-      ANTHROPIC_BASE_URL: LEGACY_FIREROUTER_BASE_URL,
-      ANTHROPIC_AUTH_TOKEN: ANTHROPIC_KEY,
-      ANTHROPIC_CUSTOM_HEADERS: [
-        `X-FireRouter-Fireworks-Key: ${FIREWORKS_KEY}`,
-        "X-User-Header: keep-me",
-      ].join("\n"),
-      CLAUDE_CODE_ATTRIBUTION_HEADER: "0",
-      CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1",
-      USER_ENV: "keep-me",
-    },
-    hooks: {
-      SessionStart: [
-        USER_HOOK,
-        {
-          matcher: "startup",
-          hooks: [{ type: "command", command: LEGACY_DESKTOP_GUARD_COMMAND }],
-        },
-      ],
-    },
-    permissions: {
-      allow: ["Bash(ls:*)"],
-      deny: ["Bash(rm:*)", "WebSearch", "WebFetch"],
-    },
-    unrelated: { keep: true },
-  };
-}
-
-function assertLegacyRouterIntentPreserved(settings) {
-  assertClaudeMainModel(settings, FIREROUTER_MODEL);
-  assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, FIREROUTER_MODEL);
-  assert.equal(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL, FIREROUTER_MODEL);
-  assert.equal(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL, FIREROUTER_MODEL);
-  assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, FIREROUTER_MODEL);
-  assert.equal(
-    settings.env.CLAUDE_CODE_SUBAGENT_MODEL,
-    "firerouter",
-  );
-  assert.equal(settings.env.CLAUDE_CODE_ATTRIBUTION_HEADER, undefined);
-}
+const OPUS_DEFAULT_MODEL = "glm-latest[1m]";
 
 function cliEnv(home) {
   return {
@@ -98,10 +44,10 @@ describe("Claude slot-level FireRouter", () => {
     assert.equal(settings.model, undefined);
     assert.equal(settings.env?.ANTHROPIC_MODEL, undefined);
     assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, FIREROUTER_MODEL);
-    // Sonnet stays native, so its alias env key is never written.
+    // FireRouter on Opus moves GLM to Sonnet.
     assert.equal(
       settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL,
-      undefined,
+      "glm-latest[1m]",
     );
     assert.equal(
       settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL,
@@ -241,227 +187,6 @@ describe("Claude slot-level FireRouter", () => {
     assert.equal(await readFile(settingsPath, "utf8"), original);
   });
 
-  it("preserves a legacy full-router mapping as explicit slot choices", async () => {
-    const home = await mkdtemp(path.join(os.tmpdir(), "fc-claude-legacy-router-"));
-    const settingsPath = userSettingsPath(home);
-    await writeJson(settingsPath, {
-      model: LEGACY_FIREROUTER_MODEL,
-      env: {
-        ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL,
-        ANTHROPIC_MODEL: LEGACY_FIREROUTER_MODEL,
-        ANTHROPIC_DEFAULT_OPUS_MODEL: LEGACY_FIREROUTER_MODEL,
-        ANTHROPIC_DEFAULT_FABLE_MODEL: LEGACY_FIREROUTER_MODEL,
-        ANTHROPIC_DEFAULT_SONNET_MODEL: "accounts/fireworks/routers/glm-latest[1m]",
-        ANTHROPIC_DEFAULT_HAIKU_MODEL: "accounts/fireworks/models/deepseek-v4-flash",
-        CLAUDE_CODE_SUBAGENT_MODEL: "accounts/fireworks/models/deepseek-v4-flash",
-        ANTHROPIC_API_KEY: "fireconnect",
-        ANTHROPIC_AUTH_TOKEN: ANTHROPIC_KEY,
-        ANTHROPIC_CUSTOM_HEADERS: `X-Fireworks-Api-Key: ${FIREWORKS_KEY}`,
-      },
-    });
-
-    const reon = await runFireconnect(["claude", "on"], cliEnv(home));
-    assert.equal(reon.code, 0, reon.stderr);
-    const settings = JSON.parse(await readFile(settingsPath, "utf8"));
-    assertClaudeMainModel(settings, FIREROUTER_MODEL);
-    assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, FIREROUTER_MODEL);
-    assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, FIREROUTER_MODEL);
-  });
-
-  it("upgrades a v0.8 router values backup through a clean v0.9 snapshot", async () => {
-    const home = await mkdtemp(path.join(os.tmpdir(), "fc-claude-v08-backup-upgrade-"));
-    const settingsPath = userSettingsPath(home);
-    const dataDir = path.join(home, ".fireconnect/claude");
-    const backupPath = providerBackupPath(dataDir);
-    await writeJson(settingsPath, legacyRouterSettings());
-    await writeJson(backupPath, {
-      values: {
-        ANTHROPIC_BASE_URL: "https://api.anthropic.com",
-        ANTHROPIC_AUTH_TOKEN: "sk-ant-original",
-        ANTHROPIC_CUSTOM_HEADERS: "X-User-Header: keep-me",
-      },
-      missing: [],
-      topLevel: {
-        values: { model: "sonnet" },
-        missing: ["effortLevel", "apiKeyHelper"],
-      },
-    });
-
-    const upgrade = await runFireconnect(["claude", "on"], cliEnv(home));
-    assert.equal(upgrade.code, 0, upgrade.stderr);
-
-    const enabled = JSON.parse(await readFile(settingsPath, "utf8"));
-    assertLegacyRouterIntentPreserved(enabled);
-    assert.match(enabled.env.ANTHROPIC_CUSTOM_HEADERS, /X-Fireworks-Api-Key: fw_test_key_12345/);
-    assert.doesNotMatch(enabled.env.ANTHROPIC_CUSTOM_HEADERS, /x-anthropic-api-key/i);
-    assert.equal(enabled.env.ANTHROPIC_API_KEY, undefined);
-    assert.equal(enabled.env.ANTHROPIC_AUTH_TOKEN, "sk-ant-original");
-    assert.match(enabled.env.ANTHROPIC_CUSTOM_HEADERS, /X-User-Header: keep-me/);
-    assert.deepEqual(enabled.permissions, {
-      allow: ["Bash(ls:*)"],
-      deny: ["Bash(rm:*)", "WebSearch", "WebFetch"],
-    });
-    assert.deepEqual(enabled.unrelated, { keep: true });
-    assert.deepEqual(enabled.hooks.SessionStart, [USER_HOOK]);
-    assert.equal(
-      enabled.hooks.SessionStart.filter(
-        (entry) => entry.hooks[0].command.includes("fireconnect-desktop-guard.mjs"),
-      ).length,
-      0,
-    );
-
-    const upgradedBackup = await readJsonIfExists(backupPath);
-    assert.equal(upgradedBackup.values, undefined);
-    assert.equal(upgradedBackup.configPath, settingsPath);
-    assert.equal(upgradedBackup.snapshot.existed, true);
-    const baseline = JSON.parse(upgradedBackup.snapshot.raw);
-    assert.deepEqual(baseline, {
-      model: "sonnet",
-      env: {
-        USER_ENV: "keep-me",
-        ANTHROPIC_BASE_URL: "https://api.anthropic.com",
-        ANTHROPIC_AUTH_TOKEN: "sk-ant-original",
-        ANTHROPIC_CUSTOM_HEADERS: "X-User-Header: keep-me",
-      },
-      hooks: { SessionStart: [USER_HOOK] },
-      permissions: {
-        allow: ["Bash(ls:*)"],
-        deny: ["Bash(rm:*)"],
-      },
-      unrelated: { keep: true },
-    });
-
-    const off = await runFireconnect(["claude", "off"], cliEnv(home));
-    assert.equal(off.code, 0, off.stderr);
-    assert.equal(await readFile(settingsPath, "utf8"), upgradedBackup.snapshot.raw);
-  });
-
-  it("upgrades a v0.8 direct values backup, preserving its mapping and migrating legacy deepseek-v4-flash slots", async () => {
-    const home = await mkdtemp(path.join(os.tmpdir(), "fc-claude-v08-direct-upgrade-"));
-    const settingsPath = userSettingsPath(home);
-    const dataDir = path.join(home, ".fireconnect/claude");
-    const backupPath = providerBackupPath(dataDir);
-    const legacyMapping = {
-      main: "accounts/fireworks/routers/glm-latest[1m]",
-      opus: "accounts/fireworks/routers/glm-latest[1m]",
-      sonnet: "accounts/fireworks/models/glm-5p1",
-      haiku: "accounts/fireworks/models/deepseek-v4-flash",
-      fable: "accounts/fireworks/routers/glm-latest[1m]",
-      subagent: "accounts/fireworks/models/deepseek-v4-flash",
-    };
-    const migratedMapping = {
-      main: "glm-latest[1m]",
-      opus: "glm-latest[1m]",
-      sonnet: "glm-5p1",
-      haiku: "deepseek-flash-latest[1m]",
-      fable: "glm-latest[1m]",
-      subagent: "deepseek-flash-latest",
-    };
-    await writeJson(settingsPath, {
-      model: legacyMapping.main,
-      apiKeyHelper: "/old/fireconnect key export --stored-only",
-      env: {
-        ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL,
-        ANTHROPIC_MODEL: legacyMapping.main,
-        ANTHROPIC_DEFAULT_OPUS_MODEL: legacyMapping.opus,
-        ANTHROPIC_DEFAULT_SONNET_MODEL: legacyMapping.sonnet,
-        ANTHROPIC_DEFAULT_HAIKU_MODEL: legacyMapping.haiku,
-        ANTHROPIC_DEFAULT_FABLE_MODEL: legacyMapping.fable,
-        CLAUDE_CODE_SUBAGENT_MODEL: legacyMapping.subagent,
-        CLAUDE_CODE_ATTRIBUTION_HEADER: "0",
-        CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1",
-        USER_ENV: "keep-me",
-      },
-      unrelated: { keep: true },
-    });
-    await writeJson(backupPath, {
-      values: {
-        ANTHROPIC_BASE_URL: "https://api.anthropic.com",
-        ANTHROPIC_API_KEY: "sk-ant-original",
-      },
-      missing: [],
-      topLevel: {
-        values: { model: "sonnet" },
-        missing: ["effortLevel", "apiKeyHelper"],
-      },
-    });
-
-    const upgrade = await runFireconnect(
-      ["claude", "on", "--api-key", FIREWORKS_KEY],
-      cliEnv(home),
-    );
-    assert.equal(upgrade.code, 0, upgrade.stderr);
-
-    const enabled = JSON.parse(await readFile(settingsPath, "utf8"));
-    assertClaudeMainModel(enabled, migratedMapping.main);
-    assert.equal(enabled.env.ANTHROPIC_DEFAULT_OPUS_MODEL, migratedMapping.opus);
-    assert.equal(enabled.env.ANTHROPIC_DEFAULT_SONNET_MODEL, migratedMapping.sonnet);
-    assert.equal(enabled.env.ANTHROPIC_DEFAULT_HAIKU_MODEL, migratedMapping.haiku);
-    assert.equal(enabled.env.ANTHROPIC_DEFAULT_FABLE_MODEL, migratedMapping.fable);
-    assert.equal(enabled.env.CLAUDE_CODE_SUBAGENT_MODEL, migratedMapping.subagent);
-    assert.equal(enabled.apiKeyHelper, undefined);
-
-    const upgradedBackup = await readJsonIfExists(backupPath);
-    assert.equal(upgradedBackup.values, undefined);
-    const baseline = JSON.parse(upgradedBackup.snapshot.raw);
-    assert.deepEqual(baseline, {
-      model: "sonnet",
-      env: {
-        USER_ENV: "keep-me",
-        ANTHROPIC_BASE_URL: "https://api.anthropic.com",
-        ANTHROPIC_API_KEY: "sk-ant-original",
-      },
-      unrelated: { keep: true },
-    });
-
-    const off = await runFireconnect(["claude", "off"], cliEnv(home));
-    assert.equal(off.code, 0, off.stderr);
-    assert.equal(await readFile(settingsPath, "utf8"), upgradedBackup.snapshot.raw);
-  });
-
-  it("upgrades a backup-less v0.8 router from a stripped best-effort baseline", async () => {
-    const home = await mkdtemp(path.join(os.tmpdir(), "fc-claude-v08-no-backup-upgrade-"));
-    const settingsPath = userSettingsPath(home);
-    const dataDir = path.join(home, ".fireconnect/claude");
-    const backupPath = providerBackupPath(dataDir);
-    const legacy = legacyRouterSettings();
-    legacy.model = "opus";
-    await writeJson(settingsPath, legacy);
-
-    const upgrade = await runFireconnect(
-      ["claude", "on", "--api-key", "fw_new_upgrade_key_12345"],
-      cliEnv(home),
-    );
-    assert.equal(upgrade.code, 0, upgrade.stderr);
-
-    const enabled = JSON.parse(await readFile(settingsPath, "utf8"));
-    assertLegacyRouterIntentPreserved(enabled);
-    assert.match(enabled.env.ANTHROPIC_CUSTOM_HEADERS, /X-Fireworks-Api-Key: fw_new_upgrade_key_12345/);
-    assert.match(enabled.env.ANTHROPIC_CUSTOM_HEADERS, /X-User-Header: keep-me/);
-    assert.deepEqual(enabled.permissions.deny, ["Bash(rm:*)", "WebSearch", "WebFetch"]);
-    assert.deepEqual(enabled.unrelated, { keep: true });
-
-    const upgradedBackup = await readJsonIfExists(backupPath);
-    assert.equal(upgradedBackup.snapshot.existed, true);
-    const baseline = JSON.parse(upgradedBackup.snapshot.raw);
-    assert.deepEqual(baseline, {
-      env: {
-        ANTHROPIC_CUSTOM_HEADERS: "X-User-Header: keep-me",
-        USER_ENV: "keep-me",
-      },
-      hooks: { SessionStart: [USER_HOOK] },
-      permissions: {
-        allow: ["Bash(ls:*)"],
-        deny: ["Bash(rm:*)"],
-      },
-      unrelated: { keep: true },
-    });
-
-    const off = await runFireconnect(["claude", "off"], cliEnv(home));
-    assert.equal(off.code, 0, off.stderr);
-    assert.equal(await readFile(settingsPath, "utf8"), upgradedBackup.snapshot.raw);
-  });
-
   it("supports a FireRouter primary without changing other aliases", async () => {
     const modelHome = await mkdtemp(path.join(os.tmpdir(), "fc-claude-model-router-"));
     const model = await runFireconnect(
@@ -476,13 +201,13 @@ describe("Claude slot-level FireRouter", () => {
     assert.equal(model.code, 0, model.stderr);
     let settings = JSON.parse(await readFile(userSettingsPath(modelHome), "utf8"));
     assertClaudeMainModel(settings, FIREROUTER_MODEL);
-    assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, DIRECT_ALIAS_MODEL);
+    assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, OPUS_DEFAULT_MODEL);
 
     const reon = await runFireconnect(["claude", "on"], cliEnv(modelHome));
     assert.equal(reon.code, 0, reon.stderr);
     settings = JSON.parse(await readFile(userSettingsPath(modelHome), "utf8"));
     assertClaudeMainModel(settings, FIREROUTER_MODEL);
-    assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, DIRECT_ALIAS_MODEL);
+    assert.equal(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL, OPUS_DEFAULT_MODEL);
   });
 
   it("rejects Fire Pass in primary or alias FireRouter slots", async () => {

--- a/packages/setup-cli/test/harnesses/claude/claude-harness.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-harness.test.mjs
@@ -81,9 +81,10 @@ describe("claude harness integration", () => {
     assert.equal(enabled.model, undefined);
     assert.equal(enabled.env?.ANTHROPIC_MODEL, undefined);
     assert.equal(enabled.env.ANTHROPIC_DEFAULT_OPUS_MODEL, "firerouter[1m]");
-    assert.equal(enabled.env.ANTHROPIC_DEFAULT_FABLE_MODEL, "kimi-fast-latest[1m]");
+    assert.equal(enabled.env.ANTHROPIC_DEFAULT_FABLE_MODEL, "glm-flash-latest[1m]");
     assert.equal(enabled.env.DISABLE_TELEMETRY, "1");
     assert.equal(enabled.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC, "1");
+    assert.equal(enabled.env.ENABLE_TOOL_SEARCH, "true");
     assert.equal(
       (await stat(settingsPath)).mode & 0o077,
       0,
@@ -110,6 +111,7 @@ describe("claude harness integration", () => {
     assert.equal(restored.env.ANTHROPIC_API_KEY, "sk-ant-original");
     assert.equal(restored.apiKeyHelper, undefined);
     assert.equal(Object.hasOwn(restored.env, "DISABLE_TELEMETRY"), false);
+    assert.equal(Object.hasOwn(restored.env, "ENABLE_TOOL_SEARCH"), false);
 
     const config = await readGlobalConfig(home);
     assert.equal(config.harnesses.claude.enabled, false);
@@ -463,7 +465,7 @@ describe("claude harness integration", () => {
     assert.equal(result.code, 0, result.stderr);
     assert.match(
       result.stdout,
-      /Text-only: deepseek-flash-latest, deepseek-pro-latest, glm-fast-latest · Avoid images; recover with \/rewind\./,
+      /Text-only: deepseek-flash-latest, deepseek-pro-latest, glm-fast-latest, glm-latest · Avoid images; recover with \/rewind\./,
     );
     assert.doesNotMatch(result.stdout, /Claude Code cannot mark models as text-only/);
   });
@@ -488,8 +490,14 @@ describe("claude harness integration", () => {
 
     const statusResult = await runFireconnect(["claude", "status"], { HOME: home });
     assert.equal(statusResult.code, 0, statusResult.stderr);
+    // status reports every slot's real value, not just overrides: main/sonnet
+    // were overridden, but the default-matching opus/haiku/fable slots appear
+    // too (each pinned to its default Fireworks model).
     assert.match(statusResult.stdout, /main\s+->\s+glm-fast-latest.*text-only/);
     assert.match(statusResult.stdout, /sonnet\s+->\s+kimi-latest.*vision/);
+    assert.match(statusResult.stdout, /opus\s+->\s+glm-latest/);
+    assert.match(statusResult.stdout, /haiku\s+->\s+deepseek-flash-latest.*text-only/);
+    assert.match(statusResult.stdout, /fable\s+->\s+glm-flash-latest.*vision/);
   });
 });
 

--- a/packages/setup-cli/test/harnesses/claude/claude-model-picker-precedence.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-model-picker-precedence.test.mjs
@@ -96,6 +96,35 @@ describe("mappingFromSettings", () => {
     assert.equal(mapping.subagent, "deepseek-v4-flash");
   });
 
+  // A bare `/model` picker alias (opus/sonnet/haiku/fable) is the user's own
+  // picker choice — it resolves at request time through the alias's env slot,
+  // which the slot rows report separately. It is NOT a FireConnect model pin,
+  // so it must read as native (unpinned) main, never as a Fireworks model id
+  // that `claude status` would surface as a bogus "main -> opus" override row.
+  for (const alias of ["opus", "sonnet", "haiku", "fable"]) {
+    it(`treats bare /model alias ${alias} as unpinned native main`, () => {
+      const mapping = mappingFromSettings({
+        model: `${alias}[1m]`,
+        env: {
+          ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL,
+          ANTHROPIC_DEFAULT_OPUS_MODEL: "firerouter[1m]",
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: "deepseek-flash-latest[1m]",
+        },
+      });
+      assert.equal(mapping.main, "claude-default");
+      assert.equal(mapping.opus, "firerouter");
+      assert.equal(mapping.haiku, "deepseek-flash-latest");
+    });
+  }
+
+  it("still reads a concrete top-level model (not an alias) as main", () => {
+    const mapping = mappingFromSettings({
+      model: "kimi-fast-latest[1m]",
+      env: { ANTHROPIC_DEFAULT_OPUS_MODEL: "firerouter[1m]" },
+    });
+    assert.equal(mapping.main, "kimi-fast-latest");
+  });
+
   it("detects legacy main env on Fireworks-routed settings", () => {
     assert.equal(hasLegacyAnthropicMainEnv({
       model: "kimi-fast-latest[1m]",

--- a/packages/setup-cli/test/harnesses/claude/claude-model-picker.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-model-picker.test.mjs
@@ -7,11 +7,20 @@ import {
   loadClaudeModelPickerCatalog,
   modelPickerBadges,
   rankClaudeModelsForSlot,
+  slotPickerRecommendations,
   suitableClaudeModelsForSlot,
 } from "../../../lib/harnesses/claude/model-picker.mjs";
+import {
+  CLAUDE_FIREWORKS_PINNED_DEFAULTS,
+  DEFAULT_FABLE_MODEL,
+} from "../../../lib/harnesses/claude/model-profile.mjs";
 
 const MODELS = [
+  { slug: "auto", label: "Auto", fast: false, contextWindow: 1_048_575, vision: true, auto: true },
+  { slug: "auto-instant", label: "Auto Instant", fast: false, contextWindow: 1_048_575, vision: true, auto: true },
   { slug: "glm-latest", label: "GLM Latest", fast: false, contextWindow: 1_000_000, vision: false },
+  { slug: "glm-flash-latest", label: "GLM Flash Latest", fast: true, contextWindow: 1_000_000, vision: true },
+  { slug: "kimi-latest", label: "Kimi Latest", fast: false, contextWindow: 1_000_000, vision: true },
   { slug: "kimi-fast-latest", label: "Kimi Fast Latest", fast: true, contextWindow: 262_000, vision: true },
   { slug: "deepseek-v4-flash", label: "DeepSeek V4 Flash", fast: true, contextWindow: 1_000_000, vision: false },
   { slug: "gpt-oss-120b", label: "GPT OSS 120B", fast: false, contextWindow: 131_000, vision: false },
@@ -20,6 +29,49 @@ const MODELS = [
 ];
 
 describe("Claude slot-aware model picker", () => {
+  it("leads each slot list with the canonical default from model-profile", () => {
+    assert.equal(slotPickerRecommendations("opus")[0], CLAUDE_FIREWORKS_PINNED_DEFAULTS.opus);
+    assert.equal(slotPickerRecommendations("sonnet")[0], CLAUDE_FIREWORKS_PINNED_DEFAULTS.sonnet);
+    assert.ok(slotPickerRecommendations("opus").includes("firerouter"));
+    assert.ok(slotPickerRecommendations("sonnet").includes("auto"));
+    assert.ok(slotPickerRecommendations("sonnet").includes("auto-instant"));
+    assert.ok(!slotPickerRecommendations("opus").includes("auto-instant"));
+  });
+
+  it("shows auto-instant in the Sonnet picker only", () => {
+    const sonnet = suitableClaudeModelsForSlot(MODELS, {
+      slot: "sonnet",
+      currentModel: CLAUDE_FIREWORKS_PINNED_DEFAULTS.sonnet,
+      recommendedModel: CLAUDE_FIREWORKS_PINNED_DEFAULTS.sonnet,
+    });
+    const haiku = suitableClaudeModelsForSlot(MODELS, {
+      slot: "haiku",
+      currentModel: CLAUDE_FIREWORKS_PINNED_DEFAULTS.haiku,
+      recommendedModel: CLAUDE_FIREWORKS_PINNED_DEFAULTS.haiku,
+    });
+    assert.ok(sonnet.some((model) => model.slug === "auto-instant"));
+    assert.ok(haiku.every((model) => model.slug !== "auto-instant"));
+  });
+
+  it("ranks slot recommendations after current and recommended, with minimax last", () => {
+    const ranked = rankClaudeModelsForSlot(MODELS, {
+      slot: "haiku",
+      currentModel: "",
+      recommendedModel: "",
+    });
+    const recommended = [
+      "auto",
+      "gpt-oss-120b",
+      "glm-flash-latest",
+      "qwen-plus-latest",
+      "minimax-latest",
+    ];
+    const rankedRecommendations = ranked
+      .filter((model) => recommended.includes(model.slug))
+      .map((model) => model.slug);
+    assert.deepEqual(rankedRecommendations, recommended);
+  });
+
   it("pins current and recommended models before slot recommendations", () => {
     const ranked = rankClaudeModelsForSlot(MODELS, {
       slot: "haiku",
@@ -27,19 +79,39 @@ describe("Claude slot-aware model picker", () => {
       recommendedModel: "deepseek-v4-flash",
     });
     assert.deepEqual(
-      ranked.slice(0, 3).map((model) => model.slug),
-      ["glm-latest", "deepseek-v4-flash", "kimi-fast-latest"],
+      ranked.slice(0, 4).map((model) => model.slug),
+      ["glm-latest", "deepseek-v4-flash", "auto", "gpt-oss-120b"],
     );
   });
 
-  it("keeps the initial suitable list concise", () => {
+  it("shows every slot recommendation in the initial picker list", () => {
     const suitable = suitableClaudeModelsForSlot(MODELS, {
       slot: "fable",
-      currentModel: "kimi-fast-latest",
-      recommendedModel: "kimi-fast-latest",
+      currentModel: DEFAULT_FABLE_MODEL,
+      recommendedModel: DEFAULT_FABLE_MODEL,
     });
-    assert.equal(suitable.length, 5);
-    assert.equal(suitable[0].slug, "kimi-fast-latest");
+    assert.deepEqual(
+      suitable.map((model) => model.slug),
+      slotPickerRecommendations("fable").filter((slug) => (
+        MODELS.some((model) => model.slug === slug)
+      )),
+    );
+  });
+
+  it("includes glm-latest on sonnet even when it is not the recommended default", () => {
+    const catalog = [
+      ...MODELS,
+      { slug: "kimi-latest", label: "Kimi Latest", fast: false, contextWindow: 1_000_000, vision: true },
+      { slug: "deepseek-flash-latest", label: "DeepSeek Flash", fast: false, contextWindow: 1_000_000, vision: false },
+      { slug: "claude-default", label: "Claude default", fast: false, contextWindow: 1_000_000, vision: true },
+    ];
+    const suitable = suitableClaudeModelsForSlot(catalog, {
+      slot: "sonnet",
+      currentModel: "kimi-latest",
+      recommendedModel: "kimi-latest",
+    });
+    assert.ok(suitable.some((model) => model.slug === "glm-latest"));
+    assert.ok(suitable.some((model) => model.slug === "claude-default"));
   });
 
   it("searches exact slugs and human labels", () => {
@@ -53,17 +125,44 @@ describe("Claude slot-aware model picker", () => {
     );
   });
 
+  it("labels auto with an open-model mix badge", () => {
+    assert.deepEqual(modelPickerBadges(MODELS[0], {
+      currentModel: "",
+      recommendedModel: "",
+    }), ["Open-model mix", "1.0M"]);
+  });
+
   it("formats concise capability badges", () => {
-    assert.deepEqual(modelPickerBadges(MODELS[1], {
+    const kimiFast = MODELS.find((model) => model.slug === "kimi-fast-latest");
+    assert.deepEqual(modelPickerBadges(kimiFast, {
       currentModel: "kimi-fast-latest",
       recommendedModel: "kimi-fast-latest",
     }), ["Current", "Recommended", "Fast", "262K", "Vision"]);
-    assert.deepEqual(modelPickerBadges(MODELS[0], {
+    assert.deepEqual(modelPickerBadges(MODELS.find((model) => model.slug === "glm-latest"), {
       currentModel: "",
       recommendedModel: "",
     }), ["Standard", "1M", "Text-only"]);
     assert.equal(formatContextWindow(1_000_000), "1M");
     assert.equal(formatContextWindow(131_072), "131K");
+  });
+
+  it("includes auto on standard keys but not Fire Pass", async () => {
+    const fireworks = await loadClaudeModelPickerCatalog({
+      apiKey: "fw_test_key",
+      keyType: "fireworks",
+      includeFirerouter: false,
+      loadCatalog: async () => ({ catalog: [] }),
+    });
+    assert.ok(fireworks.some((model) => model.slug === "auto"));
+    assert.ok(fireworks.some((model) => model.slug === "auto-instant"));
+    assert.ok(fireworks.every((model) => model.slug !== "firerouter"));
+
+    const firepass = await loadClaudeModelPickerCatalog({
+      apiKey: "fpk_test_firepass_key",
+      keyType: "firepass",
+      includeFirerouter: true,
+    });
+    assert.ok(firepass.every((model) => model.slug !== "auto"));
   });
 
   it("uses only the Fire Pass-compatible catalog for fpk keys", async () => {
@@ -77,7 +176,7 @@ describe("Claude slot-aware model picker", () => {
     assert.ok(catalog.every((model) => model.tools));
   });
 
-  it("injects non-fast fallbacks when the live catalog is empty", async () => {
+  it("injects offline fallbacks when the live catalog is empty", async () => {
     const catalog = await loadClaudeModelPickerCatalog({
       apiKey: "fw_empty_catalog",
       keyType: "fireworks",
@@ -89,7 +188,7 @@ describe("Claude slot-aware model picker", () => {
       catalog.map((model) => model.slug).sort(),
       // fw_ keys always get the native "Claude default" choice alongside the
       // Fireworks fallbacks.
-      ["claude-default", "deepseek-v4-pro", "glm-latest", "kimi-latest"],
+      ["auto", "auto-instant", "claude-default", "deepseek-v4-pro", "glm-latest", "kimi-latest"],
     );
     assert.ok(catalog.every((model) => !model.fast));
   });

--- a/packages/setup-cli/test/harnesses/claude/claude-model-profile.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-model-profile.test.mjs
@@ -6,14 +6,17 @@ import {
   resolveClaudeActivationPlan,
 } from "../../../lib/harnesses/claude/activation.mjs";
 import {
+  CLAUDE_FIREWORKS_PINNED_DEFAULTS,
   CLAUDE_MODEL_SLOTS,
   defaultClaudeModelMapping,
+  FIRST_CONNECT_AUTOMATIC_SONNET_MODEL,
   inferClaudeActiveKeyType,
   migrateLegacyClaudeModelMapping,
   normalizeClaudeProfiles,
   savedClaudeModelMapping,
   withSavedClaudeModelMapping,
 } from "../../../lib/harnesses/claude/model-profile.mjs";
+import { CLAUDE_NATIVE_MODEL_ID } from "../../../lib/fireworks/model-id.mjs";
 
 const EMPTY_OVERRIDES = {
   main: "",
@@ -131,6 +134,96 @@ describe("Claude model profiles", () => {
       snapshot: { profiles, intent: { mapping: ambiguous } },
     });
     assert.deepEqual(plan.mapping, firepass);
+  });
+
+  it("keeps a live Sonnet pin when Opus is already FireRouter", () => {
+    const persisted = {
+      ...defaultClaudeModelMapping("fireworks"),
+      opus: "firerouter",
+      sonnet: "deepseek-pro-latest",
+    };
+    const profiles = withSavedClaudeModelMapping({}, "fireworks", persisted);
+    const plan = resolveClaudeActivationPlan({
+      ctx: EMPTY_OVERRIDES,
+      keyType: "fireworks",
+      activeKeyType: "fireworks",
+      snapshot: { profiles, intent: { mapping: persisted } },
+    });
+    assert.equal(plan.mapping.sonnet, "deepseek-pro-latest");
+  });
+
+  it("honors explicit --sonnet overrides and live custom Sonnet pins", () => {
+    const live = {
+      ...defaultClaudeModelMapping("fireworks"),
+      opus: "firerouter",
+      sonnet: "kimi-latest",
+    };
+    const plan = resolveClaudeActivationPlan({
+      ctx: EMPTY_OVERRIDES,
+      keyType: "fireworks",
+      activeKeyType: "fireworks",
+      snapshot: { profiles: {}, intent: { mapping: live } },
+    });
+    assert.equal(plan.mapping.sonnet, "kimi-latest");
+
+    const explicit = resolveClaudeActivationPlan({
+      ctx: { ...EMPTY_OVERRIDES, sonnet: "deepseek-pro-latest" },
+      keyType: "fireworks",
+      activeKeyType: "fireworks",
+      snapshot: {
+        profiles: {},
+        intent: {
+          mapping: {
+            ...defaultClaudeModelMapping("fireworks"),
+            opus: "firerouter",
+          },
+        },
+      },
+    });
+    assert.equal(explicit.mapping.sonnet, "deepseek-pro-latest");
+  });
+
+  it("does not rewrite an unpinned native Sonnet slot under FireRouter Opus", () => {
+    const live = {
+      ...defaultClaudeModelMapping("fireworks"),
+      opus: "firerouter",
+      sonnet: CLAUDE_NATIVE_MODEL_ID,
+    };
+    const plan = resolveClaudeActivationPlan({
+      ctx: EMPTY_OVERRIDES,
+      keyType: "fireworks",
+      activeKeyType: "fireworks",
+      snapshot: { profiles: {}, intent: { mapping: live } },
+    });
+    assert.equal(plan.mapping.sonnet, CLAUDE_NATIVE_MODEL_ID);
+  });
+
+  it("moves Sonnet to GLM when Opus switches to FireRouter without a Sonnet override", () => {
+    const live = {
+      ...defaultClaudeModelMapping("fireworks"),
+      opus: "glm-latest",
+      sonnet: "deepseek-pro-latest",
+    };
+    const plan = resolveClaudeActivationPlan({
+      ctx: { ...EMPTY_OVERRIDES, opus: "firerouter" },
+      keyType: "fireworks",
+      activeKeyType: "fireworks",
+      snapshot: { profiles: {}, intent: { mapping: live } },
+    });
+    assert.equal(plan.mapping.opus, "firerouter");
+    assert.equal(plan.mapping.sonnet, FIRST_CONNECT_AUTOMATIC_SONNET_MODEL);
+  });
+
+  it("auto-pins Opus to firerouter on first connect when FireRouter auth is available", () => {
+    const plan = resolveClaudeActivationPlan({
+      ctx: EMPTY_OVERRIDES,
+      keyType: "fireworks",
+      activeKeyType: "",
+      automaticFirerouter: true,
+      snapshot: { profiles: {}, intent: null },
+    });
+    assert.equal(plan.mapping.opus, "firerouter");
+    assert.equal(plan.mapping.sonnet, FIRST_CONNECT_AUTOMATIC_SONNET_MODEL);
   });
 
   it("defers routing validation only when the wizard can add FireRouter", () => {

--- a/packages/setup-cli/test/harnesses/claude/claude-onboarding.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-onboarding.test.mjs
@@ -5,34 +5,25 @@ import {
   printClaudeModelMapping,
   runClaudeMappingEditor,
   runClaudeModelOnboarding,
-  standardClaudeModelMapping,
 } from "../../../lib/harnesses/claude/onboarding.mjs";
 import {
   defaultClaudeModelMapping,
   mergeClaudeModelMappings,
 } from "../../../lib/harnesses/claude/model-profile.mjs";
 
-// Mirrors defaultClaudeModelMapping(): main is never pinned and Sonnet stays
-// native, so neither is written by `claude on`.
-const FAST = {
-  main: "claude-default",
-  opus: "deepseek-pro-latest",
-  sonnet: "claude-default",
-  haiku: "deepseek-flash-latest",
-  fable: "kimi-fast-latest",
-  subagent: "deepseek-flash-latest",
-};
+// Baseline mapping from defaultClaudeModelMapping() for wizard tests.
+const DEFAULTS = defaultClaudeModelMapping();
 
 function catalogModel(slug, overrides = {}) {
   return {
     id: `accounts/fireworks/routers/${slug}`,
     slug,
     label: slug,
-    fast: slug.includes("fast") || slug.includes("flash"),
+    fast: slug.includes("fast") || slug.includes("turbo"),
     contextWindow: 1_000_000,
     vision: slug.includes("kimi"),
     tools: true,
-    pricing: { display: "$1 in / $2 out" },
+    pricing: { display: "$1 in / $2 out", tier: slug.includes("fast") ? "fast" : "standard" },
     router: true,
     firerouter: slug === "firerouter",
     ...overrides,
@@ -42,9 +33,11 @@ function catalogModel(slug, overrides = {}) {
 const CATALOG = [
   catalogModel("kimi-fast-latest"),
   catalogModel("glm-fast-latest"),
+  catalogModel("glm-flash-latest", { fast: false, vision: true }),
   catalogModel("glm-latest", { fast: false }),
   catalogModel("deepseek-v4-flash"),
   catalogModel("deepseek-v4-pro", { fast: false }),
+  catalogModel("deepseek-pro-latest", { fast: false }),
   catalogModel("gpt-oss-120b", { fast: false }),
   catalogModel("qwen-plus-latest", { fast: false, vision: true }),
   catalogModel("minimax-latest", { fast: false, vision: true }),
@@ -66,13 +59,13 @@ describe("Claude model onboarding", () => {
   it("merges defaults, stored, live, and flags from lowest to highest", () => {
     assert.deepEqual(
       mergeClaudeModelMappings(
-        FAST,
+        DEFAULTS,
         { opus: "stored-opus", sonnet: "stored-sonnet" },
         { sonnet: "live-sonnet", haiku: "live-haiku" },
         { opus: "flag-opus", subagent: "" },
       ),
       {
-        ...FAST,
+        ...DEFAULTS,
         opus: "flag-opus",
         sonnet: "live-sonnet",
         haiku: "live-haiku",
@@ -83,8 +76,7 @@ describe("Claude model onboarding", () => {
   it("keeps the recommended mapping on the one-step default path", async () => {
     const output = outputBuffer();
     const mapping = await runClaudeModelOnboarding({
-      recommended: FAST,
-      fastDefaults: FAST,
+      shownMapping: DEFAULTS,
       output,
       select: async ({ message, choices, initialIndex }) => {
         assert.match(message, /Claude model mapping/);
@@ -92,23 +84,23 @@ describe("Claude model onboarding", () => {
         assert.equal(initialIndex, 5);
         assert.ok(choices[0].name.includes("Fable"));
         assert.ok(!choices.some((choice) => choice.value.slot === "main"));
-        for (const model of Object.values(FAST)) {
-          // Native slots are rendered as the "Claude default" label, not the slug.
-          const label = model === "claude-default" ? "Claude default" : model;
-          assert.ok(choices.some((choice) => choice.name.includes(label)));
+        assert.ok(!choices.some((choice) => choice.value.action === "non-fast"));
+        assert.ok(!choices.some((choice) => choice.value.action === "fast"));
+        for (const model of Object.values(DEFAULTS)) {
+          if (model === "claude-default") continue;
+          assert.ok(choices.some((choice) => choice.name.includes(model)));
         }
         return choices.find((choice) => choice.value.action === "save").value;
       },
     });
 
-    assert.deepEqual(mapping, FAST);
+    assert.deepEqual(mapping, DEFAULTS);
     assert.match(output.text(), /Set Claude Code model defaults/);
   });
 
   it("returns an explicit cancellation instead of the baseline mapping", async () => {
     const mapping = await runClaudeModelOnboarding({
-      recommended: FAST,
-      fastDefaults: FAST,
+      shownMapping: DEFAULTS,
       output: outputBuffer(),
       select: async () => null,
     });
@@ -117,105 +109,58 @@ describe("Claude model onboarding", () => {
 
   it("prints one Fable-first final mapping without an unpinned Main", () => {
     const output = outputBuffer();
-    printClaudeModelMapping(FAST, output);
+    printClaudeModelMapping(DEFAULTS, output);
     const text = output.text();
     assert.equal((text.match(/Model mapping/g) ?? []).length, 1);
     assert.ok(text.indexOf("Fable") < text.indexOf("Opus"));
     // Main is unpinned here, so it has nothing to report.
     assert.ok(!text.includes("Main"));
-    for (const [slot, model] of Object.entries(FAST)) {
-      if (slot === "main") continue;
-      // Native slots are rendered as the "Claude default" label, not the slug.
-      assert.ok(text.includes(model === "claude-default" ? "Claude default" : model));
+    for (const [slot, model] of Object.entries(DEFAULTS)) {
+      if (slot === "main" || model === "claude-default") continue;
+      assert.ok(text.includes(model));
     }
   });
 
   it("prints a pinned Main row when one is set", () => {
     const output = outputBuffer();
-    printClaudeModelMapping({ ...FAST, main: "glm-latest" }, output);
+    printClaudeModelMapping({ ...DEFAULTS, main: "glm-latest" }, output);
     const text = output.text();
     assert.ok(text.includes("Main"));
     assert.ok(text.indexOf("Main") < text.indexOf("Fable"));
   });
 
-  it("shows a pinned Main row in the editor and preserves it across mode toggles", async () => {
-    const pinned = { ...FAST, main: "glm-latest" };
-    let visits = 0;
+  it("shows a pinned Main row in the editor", async () => {
+    const pinned = { ...DEFAULTS, main: "glm-latest" };
     const mapping = await runClaudeModelOnboarding({
-      recommended: pinned,
-      fastDefaults: FAST,
+      shownMapping: pinned,
+      badgeMapping: DEFAULTS,
       mappingLabel: "Current",
       output: outputBuffer(),
-      select: async ({ message, choices, initialIndex }) => {
-        visits += 1;
-        if (visits === 1) {
-          assert.equal(initialIndex, 6);
-          assert.ok(choices.some((choice) => choice.value.slot === "main"));
-          assert.ok(choices[0].name.includes("Main"));
-          return choices.find((choice) => choice.value.action === "non-fast").value;
-        }
-        if (visits === 2) {
-          assert.match(message, /Non-fast mode/);
-          assert.ok(choices.some((choice) => choice.name.includes("Main")));
-          assert.ok(choices.some((choice) => choice.name.includes("glm-latest")));
-          return choices.find((choice) => choice.value.action === "save").value;
-        }
-        throw new Error("unexpected select");
+      select: async ({ choices, initialIndex }) => {
+        assert.equal(initialIndex, 6);
+        assert.ok(choices.some((choice) => choice.value.slot === "main"));
+        assert.ok(choices[0].name.includes("Main"));
+        assert.ok(choices.some((choice) => choice.name.includes("glm-latest")));
+        return choices.find((choice) => choice.value.action === "save").value;
       },
     });
 
-    assert.deepEqual(mapping, {
-      ...standardClaudeModelMapping(),
-      main: "glm-latest",
-    });
-    assert.equal(visits, 2);
+    assert.deepEqual(mapping, pinned);
   });
 
-  it("lets the mode toggle update Main on Fire Pass, where it is a normal slot", async () => {
-    // Fire Pass has no Anthropic fallback, so both mode mappings pin main and it
-    // is an editable row. The toggle must move it like every other slot instead
-    // of treating the previous value as a deliberate --model pin.
-    const fastFirepass = defaultClaudeModelMapping("firepass");
-    const nonFastFirepass = standardClaudeModelMapping("firepass");
-    assert.notEqual(fastFirepass.main, nonFastFirepass.main);
-    let visits = 0;
+  it("includes Main as an editable row on Fire Pass", async () => {
+    const firepass = defaultClaudeModelMapping("firepass");
     const mapping = await runClaudeModelOnboarding({
-      recommended: fastFirepass,
-      fastDefaults: fastFirepass,
+      shownMapping: firepass,
       keyType: "firepass",
       output: outputBuffer(),
       select: async ({ choices }) => {
-        visits += 1;
-        if (visits === 1) {
-          assert.ok(choices.some((choice) => choice.value.slot === "main"));
-          return choices.find((choice) => choice.value.action === "non-fast").value;
-        }
+        assert.ok(choices.some((choice) => choice.value.slot === "main"));
         return choices.find((choice) => choice.value.action === "save").value;
       },
     });
 
-    assert.deepEqual(mapping, nonFastFirepass);
-    assert.equal(mapping.main, nonFastFirepass.main);
-  });
-
-  it("reports non-fast mode when a preserved Main pin is the only difference", async () => {
-    // The toggle keeps a pinned main, so a saved mapping that is otherwise the
-    // non-fast set is already in non-fast mode — the header must say so instead
-    // of offering a switch that would change nothing visible.
-    const nonFast = standardClaudeModelMapping();
-    const saved = { ...nonFast, main: "kimi-latest" };
-    let seen = null;
-    await runClaudeModelOnboarding({
-      recommended: saved,
-      fastDefaults: FAST,
-      mappingLabel: "Current",
-      output: outputBuffer(),
-      select: async ({ message, choices }) => {
-        seen ??= message;
-        return choices.find((choice) => choice.value.action === "save").value;
-      },
-    });
-    assert.match(seen, /Non-fast mode/);
+    assert.deepEqual(mapping, firepass);
   });
 
   it("uses the shared brand styles for the mapping and profile choices", async () => {
@@ -224,12 +169,11 @@ describe("Claude model onboarding", () => {
     try {
       const output = outputBuffer();
       await runClaudeModelOnboarding({
-        recommended: FAST,
-        fastDefaults: FAST,
+        shownMapping: DEFAULTS,
         output,
         select: async ({ choices }) => {
           assert.match(choices[0].name, /\x1b\[1mFable/);
-          assert.match(choices[0].name, /\x1b\[36mkimi-fast-latest/);
+          assert.match(choices[0].name, /\x1b\[36mglm-flash-latest/);
           const save = choices.find((choice) => choice.value.action === "save");
           assert.match(save.name, /\x1b\[1mSave mapping/);
           assert.match(save.name, /\x1b\[90m· Recommended/);
@@ -245,110 +189,33 @@ describe("Claude model onboarding", () => {
     }
   });
 
-  it("maps every class to non-fast aliases with the standard profile", async () => {
-    let visits = 0;
-    const mapping = await runClaudeModelOnboarding({
-      recommended: FAST,
-      fastDefaults: FAST,
-      output: outputBuffer(),
-      loadCatalog: async () => CATALOG,
-      select: async ({ message, choices }) => {
-        if (message.startsWith("Opus ·")) {
-          const models = choices
-            .map((choice) => choice.value.model)
-            .filter(Boolean);
-          assert.ok(models.length > 0);
-          assert.ok(models.every((model) => !model.fast && !model.firerouter));
-          assert.ok(models.every((model) => !/(?:fast|flash|turbo)/i.test(model.slug)));
-          return choices.find((choice) => choice.value.action === "search").value;
-        }
-        visits += 1;
-        if (visits === 1) {
-          return choices.find((choice) => choice.value.action === "non-fast").value;
-        }
-        if (visits === 2) {
-          assert.match(message, /Non-fast mode/);
-          assert.ok(choices.some((choice) => (
-            choice.value.action === "fast"
-            && choice.name.includes("Use fast models")
-          )));
-          return choices.find((choice) => choice.value.slot === "opus").value;
-        }
-        return choices.find((choice) => choice.value.action === "save").value;
-      },
-      search: async ({ items }) => {
-        assert.ok(items.length > 5);
-        assert.ok(items.every((model) => !model.fast && !model.firerouter));
-        return items.find((model) => model.slug === "glm-latest");
-      },
-    });
-
-    assert.deepEqual(mapping, standardClaudeModelMapping());
-    assert.equal(visits, 3);
-  });
-
-  it("switches a saved non-fast mapping back to fast defaults", async () => {
-    const nonFast = standardClaudeModelMapping();
-    let visits = 0;
-    const mapping = await runClaudeModelOnboarding({
-      recommended: nonFast,
-      fastDefaults: FAST,
-      mappingLabel: "Current",
-      output: outputBuffer(),
-      select: async ({ message, choices }) => {
-        visits += 1;
-        if (visits === 1) {
-          assert.match(message, /Non-fast mode/);
-          const toggle = choices.find((choice) => choice.value.action === "fast");
-          assert.ok(toggle.name.includes("Use fast models"));
-          return toggle.value;
-        }
-        assert.doesNotMatch(message, /Non-fast mode/);
-        for (const model of Object.values(FAST)) {
-          // Native slots are rendered as the "Claude default" label, not the slug.
-          const label = model === "claude-default" ? "Claude default" : model;
-          assert.ok(choices.some((choice) => choice.name.includes(label)));
-        }
-        return choices.find((choice) => choice.value.action === "save").value;
-      },
-    });
-
-    assert.equal(visits, 2);
-    assert.deepEqual(mapping, FAST);
-  });
-
   it("returns to the mapping editor when no compatible models are available", async () => {
     let overviewVisits = 0;
     const mapping = await runClaudeMappingEditor({
-      initialMapping: FAST,
-      recommended: FAST,
-      nonFastMapping: standardClaudeModelMapping(),
+      initialMapping: DEFAULTS,
+      recommended: DEFAULTS,
       catalog: [],
       output: outputBuffer(),
       select: async ({ message, choices }) => {
         assert.match(message, /Claude model mapping/);
         overviewVisits += 1;
         if (overviewVisits === 1) {
-          return choices.find((choice) => choice.value.action === "non-fast").value;
-        }
-        if (overviewVisits === 2) {
           return choices.find((choice) => choice.value.slot === "opus").value;
         }
         return choices.find((choice) => choice.value.action === "save").value;
       },
     });
 
-    assert.equal(overviewVisits, 3);
-    assert.deepEqual(mapping, standardClaudeModelMapping());
+    assert.equal(overviewVisits, 2);
+    assert.deepEqual(mapping, DEFAULTS);
   });
 
   it("reset restores the exact mapping shown before customization", async () => {
-    const shown = { ...FAST, opus: "firerouter" };
+    const shown = { ...DEFAULTS, opus: "firerouter" };
     let overviewVisits = 0;
     const mapping = await runClaudeMappingEditor({
       initialMapping: shown,
-      recommended: FAST,
-      nonFastMapping: standardClaudeModelMapping(),
+      recommended: DEFAULTS,
       catalog: CATALOG,
       output: outputBuffer(),
       select: async ({ message, choices }) => {
@@ -372,8 +239,7 @@ describe("Claude model onboarding", () => {
   it("labels reconfiguration as current rather than recommended", async () => {
     const output = outputBuffer();
     await runClaudeModelOnboarding({
-      recommended: FAST,
-      fastDefaults: FAST,
+      shownMapping: DEFAULTS,
       mappingLabel: "Current",
       output,
       select: async ({ choices }) => {
@@ -389,8 +255,7 @@ describe("Claude model onboarding", () => {
     let overviewVisits = 0;
     let catalogLoads = 0;
     const mapping = await runClaudeModelOnboarding({
-      recommended: FAST,
-      fastDefaults: FAST,
+      shownMapping: DEFAULTS,
       output: outputBuffer(),
       loadCatalog: async () => {
         catalogLoads += 1;
@@ -430,11 +295,36 @@ describe("Claude model onboarding", () => {
     });
 
     assert.deepEqual(mapping, {
-      ...FAST,
+      ...DEFAULTS,
       opus: "glm-latest",
       haiku: "deepseek-v4-pro",
     });
     assert.equal(overviewVisits, 3);
     assert.equal(catalogLoads, 1);
+  });
+
+  it("shows flash models in the picker alongside standard-tier models", async () => {
+    let visits = 0;
+    await runClaudeModelOnboarding({
+      shownMapping: DEFAULTS,
+      output: outputBuffer(),
+      loadCatalog: async () => CATALOG,
+      select: async ({ message, choices }) => {
+        if (message.startsWith("Fable ·")) {
+          const models = choices
+            .map((choice) => choice.value.model)
+            .filter(Boolean);
+          assert.ok(models.some((model) => model.slug === "glm-flash-latest"));
+          assert.ok(models.some((model) => model.slug === "kimi-latest"));
+          return choices.find((choice) => choice.value.action === "search").value;
+        }
+        visits += 1;
+        if (visits === 1) {
+          return choices.find((choice) => choice.value.slot === "fable").value;
+        }
+        return choices.find((choice) => choice.value.action === "save").value;
+      },
+      search: async ({ items }) => items.find((model) => model.slug === "kimi-latest"),
+    });
   });
 });

--- a/packages/setup-cli/test/harnesses/claude/claude-statusline.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-statusline.test.mjs
@@ -1,0 +1,615 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { userSettingsPath } from "../../../lib/harnesses/claude/core.mjs";
+import {
+  claudeStatusLineCommand,
+  claudeStatusLineModelLabel,
+  claudeStatusLineSettings,
+  claudeStatusLineUsage,
+  isFireconnectStatusLine,
+  renderClaudeStatusLine,
+  stripClaudeStatusLine,
+  withClaudeStatusLine,
+} from "../../../lib/harnesses/claude/statusline.mjs";
+import { runFireconnect, withTempHome } from "../../helpers.mjs";
+
+const USER_STATUS_LINE = { type: "command", command: "~/my-own-statusline.sh" };
+
+/** Strip ANSI color sequences so assertions compare visible text. */
+const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+/** One assistant call, in the shape Claude Code writes to a transcript. */
+function assistantLine({ id, model, input = 0, output = 0, cacheRead = 0 }) {
+  return JSON.stringify({
+    type: "assistant",
+    message: {
+      id,
+      model,
+      usage: {
+        input_tokens: input,
+        output_tokens: output,
+        cache_read_input_tokens: cacheRead,
+      },
+    },
+  });
+}
+
+describe("claude status line", () => {
+  it("resolves Fireworks model ids to their catalog label, ignoring the [1m] tag", () => {
+    assert.equal(claudeStatusLineModelLabel("firerouter[1m]"), "FireRouter");
+    assert.equal(claudeStatusLineModelLabel("firerouter"), "FireRouter");
+    assert.equal(claudeStatusLineModelLabel("kimi-fast-latest[1m]"), "Kimi K3 Fast (Latest)");
+    // No metadata for the id: the bare slug, never a crash.
+    assert.equal(claudeStatusLineModelLabel("not-a-real-model"), "not-a-real-model");
+    assert.equal(claudeStatusLineModelLabel(""), "unknown model");
+  });
+
+  it("invokes the helper with an absolute node and script path", () => {
+    const command = claudeStatusLineCommand();
+    // Claude Code spawns through a shell whose PATH need not contain our Node.
+    assert.match(command, /bin\/claude-statusline\.mjs/);
+    assert.ok(
+      path.isAbsolute(command.split(" ").at(-1).replace(/^'|'$/g, "")),
+      command,
+    );
+    assert.deepEqual(Object.keys(claudeStatusLineSettings()).sort(), ["command", "type"]);
+  });
+
+  it("claims only its own status line", () => {
+    assert.equal(isFireconnectStatusLine(claudeStatusLineSettings()), true);
+    assert.equal(isFireconnectStatusLine(USER_STATUS_LINE), false);
+    assert.equal(isFireconnectStatusLine(undefined), false);
+    assert.equal(isFireconnectStatusLine("statusline.sh"), false);
+  });
+
+  it("never overwrites or strips a status line the user owns", () => {
+    const withUser = withClaudeStatusLine({ statusLine: USER_STATUS_LINE });
+    assert.deepEqual(withUser.statusLine, USER_STATUS_LINE);
+
+    const stripped = stripClaudeStatusLine({ statusLine: USER_STATUS_LINE });
+    assert.equal(stripped.changed, false);
+    assert.deepEqual(stripped.settings.statusLine, USER_STATUS_LINE);
+  });
+
+  it("replaces its own status line idempotently and strips it back off", () => {
+    const once = withClaudeStatusLine({});
+    const twice = withClaudeStatusLine(once);
+    assert.deepEqual(twice.statusLine, once.statusLine);
+
+    const stripped = stripClaudeStatusLine(twice);
+    assert.equal(stripped.changed, true);
+    assert.equal(Object.hasOwn(stripped.settings, "statusLine"), false);
+  });
+
+  it("prices a transcript at Fireworks rates, not Anthropic's", async () => {
+    await withTempHome("statusline-cost", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // deepseek-v4-flash: $0.22 in / $0.66 out per Mtok (static spec).
+      // 1M input + 1M output = $0.88.
+      await writeFile(transcript, [
+        assistantLine({
+          id: "msg_1",
+          model: "accounts/fireworks/models/deepseek-v4-flash",
+          input: 1_000_000,
+          output: 1_000_000,
+        }),
+      ].join("\n"));
+
+      const line = await renderClaudeStatusLine({
+        model: { id: "deepseek-flash-latest[1m]" },
+        transcript_path: transcript,
+        context_window: { used_percentage: 12 },
+      }, { home });
+
+      const plain = stripAnsi(line);
+      assert.match(plain, /\$0\.88/, plain);
+      // Claude Code's own estimate for the same tokens would be far higher; the
+      // point of the line is that it reports the Fireworks number.
+      assert.doesNotMatch(plain, /\$4\.20|\$12\.00/, plain);
+      // Context usage is Claude Code's own number, shown in its own UI — the
+      // payload carries it, and this line deliberately does not repeat it.
+      assert.doesNotMatch(plain, /ctx/, plain);
+      assert.doesNotMatch(plain, /12%/, plain);
+    });
+  });
+
+  it("says the cost is unavailable rather than quoting a rate it does not have", async () => {
+    await withTempHome("statusline-unpriced", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        assistantLine({
+          id: "msg_1",
+          model: "accounts/fireworks/models/some-unlisted-model",
+          input: 1_000_000,
+          output: 1_000_000,
+        }),
+      ].join("\n"));
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "some-unlisted-model" },
+        transcript_path: transcript,
+      }, { home }));
+
+      assert.match(plain, /cost n\/a/, plain);
+      // Neither a reference figure nor a free-looking $0.00.
+      assert.doesNotMatch(plain, /\$/, plain);
+    });
+  });
+
+  it("leaves the session total unavailable when only some calls are priced", async () => {
+    await withTempHome("statusline-partly-unpriced", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        assistantLine({ id: "msg_1", model: "accounts/fireworks/models/deepseek-v4-flash", output: 1_000_000 }),
+        assistantLine({ id: "msg_2", model: "accounts/fireworks/models/some-unlisted-model", output: 1_000_000 }),
+      ].join("\n"));
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter" },
+        transcript_path: transcript,
+      }, { home }));
+
+      // $0.66 of known spend plus an unknown is not a $0.66 session, so the
+      // total withholds the figure — while the legend still reports the per-model
+      // cost it does know, and n/a for the one it doesn't.
+      const [total, legend] = plain.split("\n");
+      assert.match(total, /cost n\/a/, plain);
+      assert.doesNotMatch(total, /\$/, plain);
+      assert.match(legend, /DeepSeek V4 Flash \$0\.66/, plain);
+      assert.match(legend, /some-unlisted-model n\/a/, plain);
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      assert.equal(usage.models.length, 2);
+      assert.equal(
+        usage.models.reduce((sum, model) => sum + model.costShare, 0),
+        1,
+        "mixed priced/unpriced bar shares must use one denominator",
+      );
+      assert.deepEqual(
+        usage.models.map((model) => model.costShare),
+        [0.5, 0.5],
+        "when spend share is unknowable, every segment uses call share",
+      );
+    });
+  });
+
+  it("blends per-call rates when a session spans Fireworks and Anthropic models", async () => {
+    await withTempHome("statusline-mixed", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        // $0.66 for 1M output at deepseek-v4-flash…
+        assistantLine({ id: "msg_1", model: "accounts/fireworks/models/deepseek-v4-flash", output: 1_000_000 }),
+        // …plus $25.00 for 1M output at Claude Opus 5 list price.
+        assistantLine({ id: "msg_2", model: "claude-opus-5", output: 1_000_000 }),
+      ].join("\n"));
+
+      const line = await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home });
+
+      const plain = stripAnsi(line);
+      assert.match(plain, /\$25\.66/, plain);
+      // The legend attributes spend per model, which is the whole point: an
+      // even split of calls here is a wildly uneven split of the bill.
+      assert.match(plain, /DeepSeek V4 Flash \$0\.66/, plain);
+      assert.match(plain, /Claude Opus 5 \$25\.00/, plain);
+    });
+  });
+
+  it("draws a textless share bar so the only percentages are labeled ones", async () => {
+    await withTempHome("statusline-bar-mixed", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // 3 calls to GLM, 1 to Opus -> 75% / 25%.
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p2", input: 1, output: 1 }),
+        assistantLine({ id: "m2", model: "accounts/fireworks/models/glm-5p2", input: 1, output: 1 }),
+        assistantLine({ id: "m3", model: "accounts/fireworks/models/glm-5p2", input: 1, output: 1 }),
+        assistantLine({ id: "m4", model: "claude-opus-5", input: 1, output: 1 }),
+      ].join("\n"));
+
+      const line = await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home });
+
+      const plain = stripAnsi(line);
+      const [bar, legend] = plain.split("\n");
+      // The bar is width-only: no digits inside it, so its share cannot be
+      // confused with the labeled cache percentages in the legend.
+      assert.match(bar, /^[━ ]+ ·/, bar);
+      const barSegments = bar.split(" · ")[0];
+      assert.doesNotMatch(barSegments, /\d/, barSegments);
+      // Share is therefore never printed as a number at all.
+      assert.doesNotMatch(legend, /75%/, legend);
+      assert.doesNotMatch(legend, /25%/, legend);
+      // EVERY percentage that is printed carries its unit.
+      const unlabeled = [...legend.matchAll(/\d+%(?! cache)/g)].map((m) => m[0]);
+      assert.deepEqual(unlabeled, [], `unlabeled percentages: ${legend}`);
+      assert.match(legend, /GLM 5\.2 \$/, legend);
+      assert.match(legend, /Claude Opus 5 \$/, legend);
+      // The slot alias is not shown when there's a transcript to break down.
+      assert.doesNotMatch(plain, /FireRouter/, plain);
+    });
+  });
+
+  it("attributes spend per model so a cheap majority reads apart from the bill", async () => {
+    await withTempHome("statusline-cost-split", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // 3 cheap calls vs 1 expensive one: 75% of calls, but a sliver of cost.
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/deepseek-v4-flash", output: 1_000_000 }),
+        assistantLine({ id: "m2", model: "accounts/fireworks/models/deepseek-v4-flash", output: 1_000_000 }),
+        assistantLine({ id: "m3", model: "accounts/fireworks/models/deepseek-v4-flash", output: 1_000_000 }),
+        assistantLine({ id: "m4", model: "claude-opus-5", output: 1_000_000 }),
+      ].join("\n"));
+
+      const line = await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home });
+
+      const plain = stripAnsi(line);
+      // 3 of 4 calls went to the cheap model, yet it accounts for $1.98 against
+      // Opus 5's $25.00.
+      assert.match(plain, /DeepSeek V4 Flash \$1\.98/, plain);
+      assert.match(plain, /Claude Opus 5 \$25\.00/, plain);
+      assert.match(plain, /\$26\.98/, plain);
+
+      const [bar, legend] = plain.split("\n");
+      assert.match(bar, /^[━ ]+/, bar);
+      // The bar draws SPEND, not calls: Opus 5 ran a quarter of the calls and
+      // leads anyway, because it is 97% of the bill. Ordering follows suit, so
+      // bar and legend agree.
+      assert.ok(
+        legend.indexOf("Claude Opus 5") < legend.indexOf("DeepSeek V4 Flash"),
+        `legend must lead with the costliest model: ${legend}`,
+      );
+      const segments = bar.split(" · ")[0].split(" ");
+      assert.ok(
+        segments[0].length > segments[1].length,
+        `costliest model needs the widest segment: ${JSON.stringify(segments)}`,
+      );
+    });
+  });
+
+  it("sizes bar segments by spend, not by how many calls each model took", async () => {
+    await withTempHome("statusline-bar-is-cost", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // 9 cheap calls vs 1 expensive: 90% of the calls, ~3% of the money.
+      const rows = [];
+      for (let i = 0; i < 9; i += 1) {
+        rows.push(assistantLine({
+          id: `m${i}`,
+          model: "accounts/fireworks/models/deepseek-v4-flash",
+          output: 1_000_000,
+        }));
+      }
+      rows.push(assistantLine({ id: "opus", model: "claude-opus-5", output: 3_000_000 }));
+      await writeFile(transcript, rows.join("\n"));
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      const opus = usage.models.find((m) => m.label === "Claude Opus 5");
+      const flash = usage.models.find((m) => m.label === "DeepSeek V4 Flash");
+      // Calls say the flash model dominates; spend says the opposite.
+      assert.ok(flash.share > opus.share, "flash should own most calls");
+      assert.ok(opus.costShare > flash.costShare, "opus should own most spend");
+      assert.ok(opus.costShare > 0.9, `opus cost share was ${opus.costShare}`);
+
+      // The bar follows spend, so opus gets the wider segment.
+      const bar = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home })).split("\n")[0];
+      const [first, second] = bar.split(" · ")[0].split(" ");
+      assert.ok(
+        first.length > second.length,
+        `spend-weighted bar expected, got ${JSON.stringify([first, second])}`,
+      );
+    });
+  });
+
+  it("draws a solid bar with no percentage for a single-model session", async () => {
+    await withTempHome("statusline-bar-single", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p2", input: 1, output: 1 }),
+        assistantLine({ id: "m2", model: "accounts/fireworks/models/glm-5p2", input: 1, output: 1 }),
+      ].join("\n"));
+
+      const line = await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home });
+
+      const plain = stripAnsi(line);
+      // One backend -> a solid bar with no embedded percentage: there is no
+      // share to compare against.
+      assert.match(plain, /^[━ ]+ ·/, plain);
+      assert.doesNotMatch(plain, /\d%━/, plain);
+      // The legend keeps the model's cache figure but drops the per-model cost,
+      // which would only repeat the total already shown beside the bar.
+      assert.match(plain, /GLM 5\.2 \d+%/, plain);
+      assert.doesNotMatch(plain, /GLM 5\.2 <?\$/, plain);
+    });
+  });
+
+  it("reports each model's cache-hit share the way the live meter does", async () => {
+    await withTempHome("statusline-cache", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // deepseek: 900 cache-read + 100 fresh -> 90%. opus: 500/500 -> 50%.
+      // Per-model, not session-wide: pooled they would read 70%, which would
+      // describe neither model.
+      await writeFile(transcript, [
+        assistantLine({
+          id: "msg_1",
+          model: "accounts/fireworks/models/deepseek-v4-flash",
+          input: 100,
+          cacheRead: 900,
+          output: 50,
+        }),
+        assistantLine({
+          id: "msg_2",
+          model: "claude-opus-5",
+          input: 500,
+          cacheRead: 500,
+          output: 50,
+        }),
+      ].join("\n"));
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      const byLabel = new Map(usage.models.map((m) => [m.label, m.cachePct]));
+      assert.equal(byLabel.get("DeepSeek V4 Flash"), "90%");
+      assert.equal(byLabel.get("Claude Opus 5"), "50%");
+
+      // Identical to the live meter's `cache%` column, from the same helpers.
+      const { cachePct } = await import("../../../lib/harnesses/claude/usage/meter-layout.mjs");
+      assert.equal(cachePct({ input: 100, cacheRead: 900, cacheWrite: 0 }), "90%");
+      assert.equal(cachePct({ input: 500, cacheRead: 500, cacheWrite: 0 }), "50%");
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home }));
+      // `e-` allowed: a cost below $0.0001 is quoted as an exponent.
+      assert.match(plain, /DeepSeek V4 Flash \$[\d.e-]+ 90%/, plain);
+      assert.match(plain, /Claude Opus 5 \$[\d.e-]+ 50%/, plain);
+    });
+  });
+
+  it("does not price a transcript that exists but has no API calls yet", async () => {
+    await withTempHome("statusline-fresh-transcript", async (home) => {
+      // Claude Code opens the transcript with user/metadata lines before the
+      // first call, so "the file exists" is not "there is something to bill".
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        JSON.stringify({ type: "user", message: { role: "user", content: "hi" } }),
+        JSON.stringify({ type: "summary", summary: "new session" }),
+      ].join("\n"));
+
+      assert.equal(await claudeStatusLineUsage(transcript, { home }), null);
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home }));
+      // A session that has not been billed must not read as a free one.
+      assert.equal(plain, "FireRouter");
+      assert.doesNotMatch(plain, /\$/, plain);
+    });
+  });
+
+  it("expresses de-emphasis as a modifier so it survives a light theme", async () => {
+    await withTempHome("statusline-theme-safe", async (home) => {
+      // The suite runs under NO_COLOR, which would make every assertion here
+      // vacuously true — so drive the real helper with color switched on.
+      const helper = path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../../../bin/claude-statusline.mjs",
+      );
+      const line = execFileSync(process.execPath, [helper], {
+        input: JSON.stringify({
+          model: { id: "firerouter[1m]" },
+          transcript_path: path.join(home, "missing.jsonl"),
+        }),
+        env: { ...process.env, NO_COLOR: "", FORCE_COLOR: "1", HOME: home },
+        encoding: "utf8",
+      });
+
+      assert.match(line, /FireRouter/, line);
+      // Secondary text must not pin an absolute color: the status line cannot
+      // know the surface it lands on, and a fixed light grey validated for a
+      // dark theme washes out on a light one. Faint + default foreground
+      // de-emphasizes relative to whatever the user's theme provides.
+      const seriesStripped = line.replace(/\x1b\[38;2;\d+;\d+;\d+m[━ ]*\x1b\[0m/g, "");
+      assert.doesNotMatch(seriesStripped, /\x1b\[38;2;/, `text pinned a truecolor: ${JSON.stringify(line)}`);
+      assert.doesNotMatch(seriesStripped, /\x1b\[38;5;/, `text pinned a 256-color: ${JSON.stringify(line)}`);
+      assert.match(line, /\x1b\[2m/, `expected faint for de-emphasis: ${JSON.stringify(line)}`);
+    });
+  });
+
+  it("renders the slot alias alone when there is no transcript to break down", async () => {
+    await withTempHome("statusline-no-transcript", async (home) => {
+      const line = await renderClaudeStatusLine({
+        model: { id: "glm-fast-latest[1m]" },
+        // A brand-new session: Claude Code names a transcript before writing it.
+        transcript_path: path.join(home, "does-not-exist.jsonl"),
+      }, { home });
+
+      const plain = stripAnsi(line);
+      assert.equal(plain, "GLM 5.2 Fast (Latest)");
+      // No transcript must not read as a free session.
+      assert.doesNotMatch(plain, /\$/, plain);
+    });
+  });
+
+  it("names the Claude default slot rather than a Fireworks label", async () => {
+    await withTempHome("statusline-native", async (home) => {
+      const line = await renderClaudeStatusLine({
+        model: { id: "claude-default", display_name: "Sonnet 5" },
+      }, { home });
+      assert.equal(stripAnsi(line), "Sonnet 5");
+    });
+  });
+
+  it("labels a real Anthropic model id from the list-price table", async () => {
+    await withTempHome("statusline-anthropic-id", async (home) => {
+      const line = await renderClaudeStatusLine({
+        model: { id: "claude-sonnet-5" },
+      }, { home });
+      assert.equal(stripAnsi(line), "Claude Sonnet 5");
+    });
+  });
+
+  it("survives a malformed payload without throwing", async () => {
+    assert.equal(typeof await renderClaudeStatusLine({}), "string");
+    assert.equal(typeof await renderClaudeStatusLine({ model: {} }), "string");
+    assert.equal(
+      typeof await renderClaudeStatusLine({ transcript_path: "/nope/nothing.jsonl" }),
+      "string",
+    );
+  });
+
+  it("attributes subagent spend so the per-model costs sum to the total", async () => {
+    await withTempHome("statusline-subagent-reconcile", async (home) => {
+      // Claude Code lays subagent logs out as <dir>/<sessionId>/subagents/agent-*.jsonl
+      const sessionId = "11111111-2222-3333-4444-555555555555";
+      const transcript = path.join(home, `${sessionId}.jsonl`);
+      await writeFile(transcript, [
+        assistantLine({ id: "p1", model: "accounts/fireworks/models/glm-5p2", output: 1_000_000 }),
+      ].join("\n"));
+      const subagentDir = path.join(home, sessionId, "subagents");
+      await mkdir(subagentDir, { recursive: true });
+      await writeFile(path.join(subagentDir, "agent-abc.jsonl"), [
+        assistantLine({ id: "s1", model: "accounts/fireworks/models/deepseek-v4-flash", output: 1_000_000 }),
+      ].join("\n"));
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      // The headline total counts subagents, so the breakdown must too —
+      // otherwise the legend silently orphans their spend.
+      const summed = usage.models.reduce((total, m) => total + m.cost, 0);
+      assert.ok(
+        Math.abs(summed - usage.cost) < 1e-9,
+        `per-model costs ${summed} must reconcile with total ${usage.cost}`,
+      );
+      // Both the parent's model and the subagent's model appear.
+      const labels = usage.models.map((m) => m.label);
+      assert.ok(labels.includes("GLM 5.2"), labels.join(", "));
+      assert.ok(labels.includes("DeepSeek V4 Flash"), labels.join(", "));
+      // "What is serving me now" stays the main thread's model.
+      assert.match(usage.lastModel, /glm-5p2/);
+    });
+  });
+
+  it("terminates every ANSI sequence so no parameters leak as text", async () => {
+    await withTempHome("statusline-ansi-wellformed", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p2", input: 1, output: 1 }),
+        assistantLine({ id: "m2", model: "claude-opus-5", input: 1, output: 1 }),
+      ].join("\n"));
+
+      const line = await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+        context_window: { used_percentage: 40 },
+      }, { home });
+
+      // An unterminated SGR (`\x1b[38;5;141` with no `m`) makes the terminal
+      // treat the NEXT character as the CSI terminator: "GLM" loses its "G" to
+      // a cursor-move, and a following "█" leaks the params as literal text.
+      // Every escape here must therefore end in `m`.
+      for (const esc of line.matchAll(/\x1b\[[0-9;]*./g)) {
+        assert.ok(esc[0].endsWith("m"), `unterminated escape: ${JSON.stringify(esc[0])}`);
+      }
+      // And no bare SGR parameters may survive into the visible text.
+      assert.doesNotMatch(stripAnsi(line), /\d+;\d+;\d+/, stripAnsi(line));
+      // Model names keep their first character.
+      assert.match(stripAnsi(line), /GLM 5\.2/, stripAnsi(line));
+      assert.match(stripAnsi(line), /Claude Opus 5/, stripAnsi(line));
+    });
+  });
+
+  it("never emits more than two lines", async () => {
+    await withTempHome("statusline-two-lines", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // Four distinct backends — the bar/legend still fits in two lines.
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p2", input: 1, output: 1 }),
+        assistantLine({ id: "m2", model: "accounts/fireworks/models/deepseek-v4-flash", input: 1, output: 1 }),
+        assistantLine({ id: "m3", model: "claude-opus-5", input: 1, output: 1 }),
+        assistantLine({ id: "m4", model: "accounts/fireworks/models/kimi-k3", input: 1, output: 1 }),
+      ].join("\n"));
+
+      const line = await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+        context_window: { used_percentage: 80 },
+      }, { home });
+
+      assert.equal(line.trimEnd().split("\n").length, 2, line);
+    });
+  });
+
+  it("on installs the status line and off removes it", async () => {
+    await withTempHome("statusline-roundtrip", async (home) => {
+      const settingsPath = userSettingsPath(home);
+      await mkdir(path.dirname(settingsPath), { recursive: true });
+      await writeFile(settingsPath, JSON.stringify({
+        env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+        theme: "dark",
+      }));
+
+      const on = await runFireconnect(
+        ["claude", "on", "--api-key", "fw_test_key_12345", "--non-interactive"],
+        { HOME: home, FIREWORKS_API_KEY: "", ANTHROPIC_API_KEY: "", ANTHROPIC_AUTH_TOKEN: "" },
+      );
+      assert.equal(on.code, 0, on.stderr);
+
+      const enabled = JSON.parse(await readFile(settingsPath, "utf8"));
+      assert.equal(isFireconnectStatusLine(enabled.statusLine), true);
+      assert.equal(enabled.theme, "dark", "unrelated settings must survive");
+
+      const off = await runFireconnect(["claude", "off"], { HOME: home });
+      assert.equal(off.code, 0, off.stderr);
+
+      const restored = JSON.parse(await readFile(settingsPath, "utf8"));
+      assert.equal(Object.hasOwn(restored, "statusLine"), false);
+      assert.equal(restored.theme, "dark");
+    });
+  });
+
+  it("leaves a user's own status line in place across on and off", async () => {
+    await withTempHome("statusline-user-owned", async (home) => {
+      const settingsPath = userSettingsPath(home);
+      await mkdir(path.dirname(settingsPath), { recursive: true });
+      await writeFile(settingsPath, JSON.stringify({
+        env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+        statusLine: USER_STATUS_LINE,
+      }));
+
+      const on = await runFireconnect(
+        ["claude", "on", "--api-key", "fw_test_key_12345", "--non-interactive"],
+        { HOME: home, FIREWORKS_API_KEY: "", ANTHROPIC_API_KEY: "", ANTHROPIC_AUTH_TOKEN: "" },
+      );
+      assert.equal(on.code, 0, on.stderr);
+      assert.deepEqual(
+        JSON.parse(await readFile(settingsPath, "utf8")).statusLine,
+        USER_STATUS_LINE,
+        "a custom status line is the user's, not ours to replace",
+      );
+
+      const off = await runFireconnect(["claude", "off"], { HOME: home });
+      assert.equal(off.code, 0, off.stderr);
+      assert.deepEqual(
+        JSON.parse(await readFile(settingsPath, "utf8")).statusLine,
+        USER_STATUS_LINE,
+      );
+    });
+  });
+});

--- a/packages/setup-cli/test/harnesses/claude/claude-upgrade-migrations.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-upgrade-migrations.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { writeGlobalConfig } from "../../../lib/config/global-config.mjs";
+import { FIREWORKS_BASE_URL } from "../../../lib/fireworks/model-id.mjs";
+import { userSettingsPath } from "../../../lib/harnesses/claude/core.mjs";
+import { migrateClaudeToolSearchOnUpgrade } from "../../../lib/harnesses/claude/upgrade-migrations.mjs";
+import { withTempHome } from "../../helpers.mjs";
+
+async function seedSettings(home, settings, { enabled = true } = {}) {
+  await writeGlobalConfig(home, {
+    harnesses: { claude: { enabled, provider: "fireworks" } },
+  });
+  const settingsPath = userSettingsPath(home);
+  await mkdir(path.dirname(settingsPath), { recursive: true });
+  const raw = `${JSON.stringify(settings, null, 2)}\n`;
+  await writeFile(settingsPath, raw, { mode: 0o600 });
+  return { settingsPath, raw };
+}
+
+describe("migrateClaudeToolSearchOnUpgrade", () => {
+  it("adds ENABLE_TOOL_SEARCH to managed settings, preserving everything else", async () => {
+    await withTempHome("claude-tool-search-", async (home) => {
+      const { settingsPath } = await seedSettings(home, {
+        env: {
+          ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL,
+          ANTHROPIC_CUSTOM_HEADERS: "X-Fireworks-Api-Key: fw_test_key_12345",
+          MY_CUSTOM_VAR: "keep-me",
+        },
+        permissions: { deny: ["WebSearch"] },
+      });
+
+      assert.equal(await migrateClaudeToolSearchOnUpgrade(home), true);
+
+      const settings = JSON.parse(await readFile(settingsPath, "utf8"));
+      assert.equal(settings.env.ENABLE_TOOL_SEARCH, "true");
+      assert.equal(settings.env.MY_CUSTOM_VAR, "keep-me");
+      assert.equal(settings.env.ANTHROPIC_CUSTOM_HEADERS, "X-Fireworks-Api-Key: fw_test_key_12345");
+      assert.deepEqual(settings.permissions.deny, ["WebSearch"]);
+      // The rewrite must not widen the mode: the file holds the Fireworks key.
+      assert.equal((await stat(settingsPath)).mode & 0o077, 0);
+    });
+  });
+
+  it("leaves a value the user already set alone", async () => {
+    await withTempHome("claude-tool-search-user-", async (home) => {
+      const { settingsPath, raw } = await seedSettings(home, {
+        env: {
+          ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL,
+          ENABLE_TOOL_SEARCH: "false",
+        },
+      });
+
+      assert.equal(await migrateClaudeToolSearchOnUpgrade(home), false);
+      assert.equal(await readFile(settingsPath, "utf8"), raw);
+    });
+  });
+
+  it("no-ops on settings FireConnect does not route to Fireworks", async () => {
+    await withTempHome("claude-tool-search-native-", async (home) => {
+      const { settingsPath, raw } = await seedSettings(home, {
+        env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+      });
+
+      assert.equal(await migrateClaudeToolSearchOnUpgrade(home), false);
+      assert.equal(await readFile(settingsPath, "utf8"), raw);
+    });
+  });
+
+  it("no-ops when there is no settings file", async () => {
+    await withTempHome("claude-tool-search-missing-", async (home) => {
+      await writeGlobalConfig(home, {
+        harnesses: { claude: { enabled: true, provider: "fireworks" } },
+      });
+      assert.equal(await migrateClaudeToolSearchOnUpgrade(home), false);
+    });
+  });
+
+  it("leaves settings alone when the harness is off", async () => {
+    await withTempHome("claude-tool-search-off-", async (home) => {
+      const { raw } = await seedSettings(home, {
+        env: { ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL },
+      }, { enabled: false });
+
+      assert.equal(await migrateClaudeToolSearchOnUpgrade(home), false);
+      assert.equal(await readFile(userSettingsPath(home), "utf8"), raw);
+    });
+  });
+});

--- a/packages/setup-cli/test/harnesses/claude/usage/agent-picker.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/agent-picker.test.mjs
@@ -22,8 +22,8 @@ import { runClaudeUsageLive } from "../../../../lib/harnesses/claude/usage/live.
 import { Dashboard, ModelIndex } from "../../../../lib/harnesses/claude/usage/meter.mjs";
 import { METER } from "../../../../lib/ui/palette.mjs";
 import {
-  formatLiveCost,
-  formatLiveCostTotal,
+  formatUsageCost,
+  usageCostDigits,
 } from "../../../../lib/harnesses/claude/usage/format.mjs";
 
 const temps = [];
@@ -110,11 +110,38 @@ describe("formatUsageCachePct / agent choice labels", () => {
         totals: { cost: 0.0563, input: 1000, cacheRead: 9000, cacheWrite5m: 0, cacheWrite1h: 0 },
       },
     });
-    assert.match(label, /\$0\.06/);
+    assert.match(label, /\$0\.0563/);
     assert.match(label, /90% cache/);
     assert.match(label, /4 calls/);
     assert.match(label, /Main/);
     assert.match(label, /FireRouter demo/);
+  });
+
+  it("reserves enough room for four-decimal totals over $100", () => {
+    const label = formatClaudeUsageAgentChoice({
+      kind: "main",
+      id: "main",
+      label: "Main",
+      report: {
+        requests: 1,
+        totals: { cost: 116.9562 },
+      },
+    });
+    assert.match(label, /^\s\$116\.9562 ·/);
+  });
+
+  it("shows n/a for an agent whose total includes an unpriced call", () => {
+    const label = formatClaudeUsageAgentChoice({
+      kind: "subagent",
+      id: "unknown-cost",
+      label: "Explore",
+      report: {
+        requests: 2,
+        totals: { cost: null, input: 1000, cacheRead: 0 },
+      },
+    });
+    assert.match(label, /^\s*n\/a ·/);
+    assert.doesNotMatch(label, /\$0\.00/);
   });
 
   it("strips escapes from session names on Main", () => {
@@ -165,9 +192,12 @@ describe("formatUsageCachePct / agent choice labels", () => {
       }, { stream: { isTTY: true }, color: true, active: true });
       assert.ok(label.includes(METER.gold), `expected gold in ${JSON.stringify(label)}`);
       assert.ok(label.includes(METER.ghost), `expected ghost in ${JSON.stringify(label)}`);
-      // Per-call keeps 4 decimals; the picker row is a total, so 2.
-      assert.equal(formatLiveCost(0.0563), "$0.0563");
-      assert.equal(formatLiveCostTotal(0.0563), "$0.06");
+      // A total reads exactly like the call it sums — 4 decimals, one rule.
+      assert.equal(formatUsageCost(0.0563), "$0.0563");
+      // Free is `$0`; a real cost too small for 4 decimals is not.
+      assert.equal(formatUsageCost(0), "$0");
+      assert.equal(usageCostDigits(0), "0");
+      assert.equal(formatUsageCost(0.00004), "$4.0e-5");
     } finally {
       if (prevForce === undefined) delete process.env.FORCE_COLOR;
       else process.env.FORCE_COLOR = prevForce;

--- a/packages/setup-cli/test/harnesses/claude/usage/cost.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/cost.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  addUsage,
+  sumCosts,
+  sumUsage,
+} from "../../../../lib/harnesses/claude/usage/cost.mjs";
+
+describe("usage totals", () => {
+  it("adds every usage field in one canonical operation", () => {
+    assert.deepEqual(
+      addUsage(
+        { input: 1, cacheRead: 2, output: 3, cost: 0.1 },
+        { input: 4, cacheWrite5m: 5, cacheWrite1h: 6, webSearches: 7, cost: 0.2 },
+      ),
+      {
+        input: 5,
+        cacheWrite5m: 5,
+        cacheWrite1h: 6,
+        cacheRead: 2,
+        output: 3,
+        webSearches: 7,
+        cost: 0.30000000000000004,
+      },
+    );
+  });
+
+  it("keeps a total unknown when any item is unpriced", () => {
+    const totals = sumUsage([
+      { input: 10, output: 1, cost: 0.01 },
+      { input: 20, output: 2, cost: null },
+    ]);
+    assert.equal(totals.input, 30);
+    assert.equal(totals.output, 3);
+    assert.equal(totals.cost, null);
+    assert.equal(sumCosts([0.01, null, 0.02]), null);
+  });
+
+  it("treats an omitted cost as absent, not unpriced", () => {
+    assert.equal(sumUsage([{ input: 10 }]).cost, 0);
+    assert.equal(sumCosts([]), 0);
+  });
+});

--- a/packages/setup-cli/test/harnesses/claude/usage/display.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/display.test.mjs
@@ -9,6 +9,7 @@ import {
   renderSegmentedBar,
   runClaudeUsageInteractiveDisplay,
 } from "../../../../lib/harnesses/claude/usage/display.mjs";
+import { formatUsageCost } from "../../../../lib/harnesses/claude/usage/format.mjs";
 
 function lastInteractiveFrame(text) {
   const plain = String(text).replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
@@ -83,6 +84,37 @@ describe("claude usage display", () => {
     assert.match(text, /\*\*\*All pricing shown below are estimates based on token usage/);
     assert.match(text, /Use -v \/ --verbose for request and sub-agent details/);
     assert.doesNotMatch(text, /Parent\/Sub-agent ID/);
+  });
+
+  it("keeps a sub-cent total at the precision the status line quotes", () => {
+    // One real GLM 5.3 call: 2,086 uncached + 15,222 cached in, 3 out.
+    const cost = 0.006891;
+    const row = {
+      model: "accounts/fireworks/models/glm-5p3",
+      displayModel: "glm-5p3",
+      input: 2_086,
+      output: 3,
+      cacheRead: 15_222,
+      cost,
+    };
+    const totals = { input: 2_086, output: 3, cacheRead: 15_222, cost };
+    const text = formatClaudeUsageSummaryDisplay({
+      path: "/tmp/12345678-1234-4234-9234-123456789abc.jsonl",
+      requests: 1,
+      rows: [row],
+      totals,
+      grandTotals: totals,
+      grandRequests: 1,
+      subagents: [],
+      estimated: false,
+    }, { stream: { isTTY: false } });
+
+    // The cent is not the floor: rounding this up to `$0.01` would overstate a
+    // known figure by 45%.
+    assert.match(text, /\$0\.0069/);
+    assert.doesNotMatch(text, /\$0\.01(\D|$)/);
+    // And the status line quotes that same figure, digit for digit.
+    assert.equal(formatUsageCost(cost), "$0.0069");
   });
 
   it("shows fallback pricing disclaimer in static and interactive estimated summaries", () => {
@@ -312,6 +344,52 @@ describe("claude usage display", () => {
     assert.match(requests, /REQ\s+SOURCE\s+MODEL\s+INPUT\s+5M WRITE\s+1H WRITE\s+CACHE RD\s+OUTPUT\s+COST/);
     assert.match(requests, /#1\s+sub-agent alpha\s+claude-opus-4-8\s+5\s+11\s+13\s+17\s+7\s+0\.20/);
     assert.match(requests, /TOTAL sub-agent alpha\s+5\s+11\s+13\s+17\s+7\s+0\.20/);
+  });
+
+  it("keeps unpriced costs unknown in source rows and interactive notes", () => {
+    const sessionId = "44444444-4444-4444-9444-444444444444";
+    const report = {
+      path: `/tmp/${sessionId}.jsonl`,
+      rows: [
+        {
+          model: "accounts/fireworks/models/glm-5p3",
+          displayModel: "glm-5p3",
+          input: 10,
+          cacheWrite5m: 0,
+          cacheWrite1h: 0,
+          output: 1,
+          cacheRead: 0,
+          cost: 0.01,
+        },
+        {
+          model: "accounts/fireworks/models/glm-5p3",
+          displayModel: "glm-5p3",
+          input: 20,
+          cacheWrite5m: 0,
+          cacheWrite1h: 0,
+          output: 2,
+          cacheRead: 0,
+          cost: null,
+          priced: false,
+        },
+      ],
+      totals: { input: 30, cacheWrite5m: 0, cacheWrite1h: 0, output: 3, cacheRead: 0, cost: null },
+      grandTotals: { input: 30, cacheWrite5m: 0, cacheWrite1h: 0, output: 3, cacheRead: 0, cost: null },
+      grandRequests: 2,
+      subagents: [],
+      estimated: false,
+      unpriced: 1,
+    };
+
+    const text = formatClaudeUsageInteractiveFrame(report, {
+      expandedSessionId: sessionId,
+      detailSessionId: sessionId,
+    }, { stream: { isTTY: false, columns: 140 } });
+
+    assert.match(text, /parent\s+glm-5p3\s+2\s+30\s+0\s+0\s+0\s+3\s+n\/a/);
+    assert.match(text, /TOTAL\s+2\s+30\s+0\s+0\s+0\s+3\s+n\/a/);
+    assert.match(text, /Some calls have no rate available; their cost reads n\/a/);
+    assert.doesNotMatch(text, /parent\s+glm-5p3[\s\S]*\$0\.00/);
   });
 
   it("drills into interactive usage with right arrow and exits with q", async () => {

--- a/packages/setup-cli/test/harnesses/claude/usage/live.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/live.test.mjs
@@ -9,6 +9,7 @@ import {
   liveMeterKeyHint,
   runClaudeUsageLive,
   shouldRunClaudeUsageLive,
+  summarizePeerAgents,
 } from "../../../../lib/harnesses/claude/usage/live.mjs";
 import { METER } from "../../../../lib/ui/palette.mjs";
 import { runFireconnect } from "../../../helpers.mjs";
@@ -47,6 +48,33 @@ function collectStream() {
     },
   };
 }
+
+describe("summarizePeerAgents", () => {
+  it("propagates an unpriced peer cost instead of coercing it to zero", () => {
+    const summary = summarizePeerAgents([
+      {
+        kind: "subagent",
+        label: "Priced",
+        report: { requests: 2, totals: { cost: 0.25 } },
+      },
+      {
+        kind: "subagent",
+        label: "Unpriced",
+        report: { requests: 1, totals: { cost: null } },
+      },
+      {
+        kind: "main",
+        label: "Main",
+        report: { requests: 3, totals: { cost: null } },
+      },
+    ]);
+
+    assert.equal(summary.count, 2);
+    assert.equal(summary.calls, 3);
+    assert.equal(summary.cost, null);
+    assert.equal(summary.main.cost, null);
+  });
+});
 
 describe("shouldRunClaudeUsageLive", () => {
   it("watches on a TTY", () => {

--- a/packages/setup-cli/test/harnesses/claude/usage/meter-accuracy.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/meter-accuracy.test.mjs
@@ -21,6 +21,10 @@ import {
   formatUsageCachePct,
   roundCachePct,
 } from "../../../../lib/harnesses/claude/usage/format.mjs";
+import {
+  COST_COL,
+  money,
+} from "../../../../lib/harnesses/claude/usage/meter-layout.mjs";
 
 /** Render `entries` (raw JSONL records) through the meter and return the frame. */
 async function render(entries, { columns = 130, readPeers, agentLabel = "Main" } = {}) {
@@ -99,6 +103,11 @@ const assistant = (id, usage, model = "accounts/fireworks/models/glm-5p2") => ({
 const money0Width = "$0.0018".length;
 
 describe("live meter billing accuracy", () => {
+  it("keeps four-decimal totals through $9999 inside the cost column", () => {
+    assert.equal(COST_COL, "$1234.5678".length);
+    assert.equal(money(1234.5678), "$1234.5678");
+  });
+
   it("prices a call from its richest payload, not the first all-zero block", async () => {
     // Claude Code repeats a message.id across content blocks and attaches usage
     // to the last one. Counting the first billed real work at $0.00.
@@ -330,6 +339,43 @@ describe("live meter billing accuracy", () => {
       Math.abs(sessionCost - (ownCost + 0.5)) <= 0.01,
       `${sessionCost} != ${ownCost} + 0.5`,
     );
+  });
+
+  it("shows n/a when the tracked agent or a peer has an unpriced call", async () => {
+    const unpricedTracked = await render([
+      { type: "user", message: { content: "go" } },
+      assistant("msg_1", { input_tokens: 1_000, output_tokens: 100 }, "accounts/fireworks/models/unknown"),
+    ]);
+    assert.match(unpricedTracked, /TOTAL COST\s+n\/a/);
+
+    const unpricedPeer = await render(
+      [
+        { type: "user", message: { content: "go" } },
+        assistant("msg_1", { input_tokens: 1_000, output_tokens: 100 }),
+      ],
+      { readPeers: async () => ({ count: 1, calls: 1, cost: null }) },
+    );
+    assert.match(unpricedPeer, /1 subagent · 1 call\s+n\/a/);
+    assert.match(unpricedPeer, /SESSION COST\s+n\/a/);
+    assert.doesNotMatch(unpricedPeer, /SESSION COST\s+\$0\.00/);
+
+    const unpricedMain = await render(
+      [
+        { type: "user", message: { content: "go" } },
+        assistant("msg_1", { input_tokens: 1_000, output_tokens: 100 }),
+      ],
+      {
+        agentLabel: "Explore",
+        readPeers: async () => ({
+          count: 1,
+          calls: 1,
+          cost: 0.25,
+          main: { label: "Main", calls: 1, cost: null },
+        }),
+      },
+    );
+    assert.match(unpricedMain, /Main · 1 call\s+n\/a/);
+    assert.match(unpricedMain, /SESSION COST\s+n\/a/);
   });
 
   it("reports Main on its own row rather than as a subagent", async () => {

--- a/packages/setup-cli/test/harnesses/claude/usage/modules.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/modules.test.mjs
@@ -36,6 +36,7 @@ describe("usage folder layout", () => {
     assert.deepEqual(MODULES, [
       "agent-picker",
       "agents",
+      "cost",
       "display",
       "format",
       "live",
@@ -44,6 +45,7 @@ describe("usage folder layout", () => {
       "meter-render",
       "meter-style",
       "meter",
+      "pricing",
       "report",
       "session-picker",
     ].sort());
@@ -71,10 +73,12 @@ describe("cost meter module layering", () => {
   // Lower may not import higher. Written out rather than derived, so an import
   // that inverts the chain fails here instead of quietly working.
   const ALLOWED = {
+    cost: [],
+    pricing: [],
     "meter-style": [],
-    "meter-layout": ["format"],
-    "meter-model": ["report"],
-    "meter-render": ["meter-style", "meter-layout", "meter-model", "format"],
+    "meter-layout": ["cost", "format"],
+    "meter-model": ["pricing"],
+    "meter-render": ["cost", "meter-style", "meter-layout", "meter-model", "format"],
     meter: ["meter-style", "meter-layout", "meter-model", "meter-render", "report"],
   };
 
@@ -123,13 +127,14 @@ describe("cost meter module layering", () => {
   });
 
   it("prices in exactly one place", () => {
-    // Live figures and the one-shot snapshot must not be able to drift, so
-    // `computeClaudeUsageCost` has a single caller.
+    // The definition is isolated in pricing; live and snapshot consumers call
+    // it rather than implementing their own rate math. The demo imports the same
+    // module from outside this folder.
     const callers = MODULES.filter((m) => /computeClaudeUsageCost/.test(read(m)));
     assert.deepEqual(
       callers.sort(),
-      ["meter-model", "report"],
-      "only meter-model (live) and report (its definition) may price calls",
+      ["meter-model", "pricing", "report"],
+      "only the canonical module and its live/snapshot consumers may price calls",
     );
   });
 
@@ -161,6 +166,8 @@ describe("cost meter module layering", () => {
       "meter-model": 300,
       "meter-render": 350,
       meter: 700,
+      cost: 80,
+      pricing: 220,
       format: 150,
       live: 400,
       agents: 350,

--- a/packages/setup-cli/test/harnesses/claude/usage/report.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/report.test.mjs
@@ -15,6 +15,7 @@ import {
   readClaudeUsage,
   readClaudeUsages,
   snapshotLiveSessionLogs,
+  usageReportFromText,
   waitForLiveSessionLog,
   waitForNewSessionLog,
 } from "../../../../lib/harnesses/claude/usage/report.mjs";
@@ -199,8 +200,87 @@ describe("claude usage", () => {
     });
     assert.equal(row.displayModel, "deepseek-v4-flash");
     assert.equal(row.fireworks, true);
-    assert.equal(row.cost, 0.14);
+    assert.equal(row.cost, 0.22);
     assert.equal(row.estimated, false);
+  });
+
+  it("reports no cost at all for a model it has no rate for", () => {
+    // providerListPricing answers for any id — an unknown one gets an estimated
+    // Sonnet reference — so the Anthropic table must only be consulted for ids
+    // that actually name an Anthropic model. With no rate anywhere the call is
+    // unpriced: null, never a reference figure and never a free-looking 0.
+    const row = computeClaudeUsageCost("accounts/fireworks/models/some-unlisted-model", {
+      input_tokens: 1_000_000,
+      cache_creation_input_tokens: 1_000_000,
+    });
+    assert.equal(row.cost, null);
+    assert.equal(row.priced, false);
+    assert.equal(row.rates, null);
+    assert.equal(row.estimated, false);
+    // The tokens are still real and still reported.
+    assert.equal(row.input, 1_000_000);
+  });
+
+  it("leaves a total unknown when any call in it is unpriced", () => {
+    // Summing an unknown as 0 would hand back a number that reads complete while
+    // silently omitting part of the session.
+    const text = jsonl([
+      { type: "assistant", message: { id: "m1", model: "accounts/fireworks/models/deepseek-v4-flash", usage: { input_tokens: 1_000_000 } } },
+      { type: "assistant", message: { id: "m2", model: "accounts/fireworks/models/some-unlisted-model", usage: { input_tokens: 1_000_000 } } },
+    ]);
+    const report = usageReportFromText("/tmp/session.jsonl", text);
+    assert.equal(report.rows.length, 2);
+    assert.equal(report.unpriced, 1);
+    assert.equal(report.totals.cost, null);
+  });
+
+  it("names the unpriced models in the report instead of printing a cost", () => {
+    const text = jsonl([
+      { type: "assistant", message: { id: "m1", model: "accounts/fireworks/models/some-unlisted-model", usage: { input_tokens: 1_000 } } },
+    ]);
+    const report = {
+      ...usageReportFromText("/tmp/session.jsonl", text),
+      subagents: [],
+      grandRequests: 1,
+    };
+    report.grandTotals = report.totals;
+    const verbose = formatClaudeUsageReport(report, { verbose: true });
+    assert.match(verbose, /Grand total cost: n\/a/, verbose);
+    assert.match(verbose, /no rate available/, verbose);
+    assert.match(verbose, /some-unlisted-model/, verbose);
+    assert.doesNotMatch(verbose, /Grand total cost: \$/, verbose);
+  });
+
+  it("still prices Anthropic models from the Anthropic list", () => {
+    const row = computeClaudeUsageCost("claude-sonnet-5", { input_tokens: 1_000_000 });
+    assert.equal(row.fireworks, false);
+    assert.equal(row.estimated, false);
+    assert.equal(row.cost, 2);
+  });
+
+  it("uses exact published cache rates for Anthropic fast mode", () => {
+    const row = computeClaudeUsageCost("claude-opus-5", {
+      speed: "fast",
+      input_tokens: 100,
+      cache_creation: {
+        ephemeral_5m_input_tokens: 200,
+        ephemeral_1h_input_tokens: 300,
+      },
+      cache_read_input_tokens: 400,
+      output_tokens: 500,
+    });
+    const expected = (100 * 10 + 200 * 12.5 + 300 * 20 + 400 * 1 + 500 * 50) / 1_000_000;
+    assert.equal(row.cost, expected);
+    assert.deepEqual(
+      {
+        input: row.rates.inputPerMillion,
+        write5m: row.rates.cacheWrite5mPerMillion,
+        write1h: row.rates.cacheWrite1hPerMillion,
+        read: row.rates.cacheReadPerMillion,
+        output: row.rates.outputPerMillion,
+      },
+      { input: 10, write5m: 12.5, write1h: 20, read: 1, output: 50 },
+    );
   });
 
   it("computes Anthropic cache write, cache read, geo, batch, and web-search costs", () => {

--- a/packages/setup-cli/test/harnesses/claude/usage/session-picker.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/session-picker.test.mjs
@@ -105,11 +105,38 @@ describe("formatSessionAge / choice labels", () => {
         grandTotals: { cost: 0.0751 },
       },
     });
-    assert.match(label, /\$0\.08/);
+    assert.match(label, /\$0\.0751/);
     assert.match(label, /4 calls/);
     assert.match(label, /aaaaaaaa…/);
     assert.match(label, /FireRouter demo/);
     assert.match(label, /2m ago/);
+  });
+
+  it("reserves enough room for four-decimal totals over $100", () => {
+    const label = formatClaudeUsageSessionChoice({
+      filePath: "/tmp/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa.jsonl",
+      mtimeMs: Date.now(),
+      report: {
+        grandRequests: 1,
+        grandTotals: { cost: 116.9562 },
+      },
+    });
+    assert.match(label, /^\s\$116\.9562 ·/);
+  });
+
+  it("shows n/a rather than zero for an unpriced session", () => {
+    const label = formatClaudeUsageSessionChoice({
+      filePath: "/tmp/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa.jsonl",
+      mtimeMs: Date.now(),
+      report: {
+        requests: 1,
+        grandRequests: 1,
+        totals: { cost: null },
+        grandTotals: { cost: null },
+      },
+    });
+    assert.match(label, /^\s*n\/a ·/);
+    assert.doesNotMatch(label, /\$0\.00/);
   });
 
   it("strips CSI/OSC escapes from session names", () => {

--- a/packages/setup-cli/test/harnesses/codex/codex-azure.test.mjs
+++ b/packages/setup-cli/test/harnesses/codex/codex-azure.test.mjs
@@ -8,7 +8,7 @@ import assert from "node:assert/strict";
 
 import { codexConfigPath } from "../../../lib/harnesses/codex/core.mjs";
 import { SHELL_HOOK_BEGIN } from "../../../lib/io/shell-env-hook.mjs";
-import { seedKeychainConfig } from "../../helpers.mjs";
+import { codexOnOffArgs, seedKeychainConfig } from "../../helpers.mjs";
 
 const CLI = path.join(import.meta.dirname, "..", "..", "..", "bin", "fireconnect.mjs");
 const AZURE_ENDPOINT = "https://msft-fw-foundry-resource.services.ai.azure.com";
@@ -17,7 +17,7 @@ const AZURE_KEY = "azure-test-key-1234567890";
 
 function runFireconnect(args, env = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [CLI, ...args], {
+    const child = spawn(process.execPath, [CLI, ...codexOnOffArgs(args)], {
       env: { ...process.env, FIREWORKS_API_KEY: "", AZURE_API_KEY: "", FIRECONNECT_SECRET_STORE: "memory", FIRECONNECT_TEST: "1", ...env },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/packages/setup-cli/test/harnesses/codex/codex-catalog.test.mjs
+++ b/packages/setup-cli/test/harnesses/codex/codex-catalog.test.mjs
@@ -10,7 +10,7 @@ import {
   codexCatalogContainsModel,
   codexModelExclusionReason,
   DEPRECATED_MODELS,
-  ensureCodexFirerouterPatternEntry,
+  ensureCodexOffCatalogEntry,
   filterPickerCatalogForCodex,
   MODEL_OVERRIDES,
   MODEL_REASONING,
@@ -70,8 +70,8 @@ describe("codex-catalog buildCodexCatalogEntry", () => {
   });
 
   for (const [modelName, defaultLevel, efforts, summaryFormat] of [
-    ["accounts/fireworks/models/glm-5p2", "max", ["high", "max"], "experimental"],
-    ["accounts/fireworks/models/minimax-m2p7", "medium", ["low", "medium", "high"], "experimental"],
+    ["accounts/fireworks/models/glm-5p2", "high", ["low", "medium", "high", "max"], "experimental"],
+    ["accounts/fireworks/models/minimax-m2p7", "high", ["low", "medium", "high"], "experimental"],
   ]) {
     it(`uses correct reasoning config for ${modelName.split("/").pop()}`, () => {
       const entry = buildCodexCatalogEntry(mockModel({ name: modelName }));
@@ -91,8 +91,35 @@ describe("codex-catalog buildCodexCatalogEntry", () => {
   it("uses default reasoning config for an unknown model", () => {
     const entry = buildCodexCatalogEntry(mockModel({ name: "accounts/fireworks/models/unknown-model" }));
     assert.equal(entry.default_reasoning_level, "high");
-    assert.deepEqual(entry.supported_reasoning_levels.map((level) => level.effort), ["high"]);
-    assert.equal(entry.reasoning_summary_format, "none");
+    assert.deepEqual(entry.supported_reasoning_levels.map((level) => level.effort), ["low", "medium", "high"]);
+    assert.equal(entry.reasoning_summary_format, "experimental");
+  });
+
+  it("falls back from a versioned slug to the unversioned base reasoning config", () => {
+    // Live catalog returns versioned slugs (e.g. deepseek-v4-flash-0731); the
+    // reasoning table is keyed by the unversioned base (deepseek-v4-flash).
+    const flash = buildCodexCatalogEntry(mockModel({ name: "accounts/fireworks/models/deepseek-v4-flash-0731" }));
+    assert.equal(flash.default_reasoning_level, "high");
+    assert.deepEqual(flash.supported_reasoning_levels.map((level) => level.effort), ["low", "medium", "high", "max"]);
+    const pro = buildCodexCatalogEntry(mockModel({ name: "accounts/fireworks/models/deepseek-v4-pro-0813" }));
+    assert.equal(pro.default_reasoning_level, "high");
+    assert.deepEqual(pro.supported_reasoning_levels.map((level) => level.effort), ["low", "medium", "high", "max"]);
+  });
+
+  it("uses the kimi-k3 reasoning config for the current Kimi generation", () => {
+    const entry = buildCodexCatalogEntry(mockModel({ name: "accounts/fireworks/models/kimi-k3" }));
+    assert.equal(entry.default_reasoning_level, "high");
+    assert.deepEqual(entry.supported_reasoning_levels.map((level) => level.effort), ["low", "medium", "high"]);
+  });
+
+  it("offers a multi-tier effort ladder for every catalog model", () => {
+    // The app only renders a selectable Effort row when a model advertises more
+    // than one tier — a single-tier model looks frozen at its default.
+    for (const [name, config] of Object.entries(MODEL_REASONING)) {
+      assert.ok(config.levels.length > 1, `${name} must expose more than one effort tier`);
+      const efforts = config.levels.map((level) => level.effort);
+      assert.ok(efforts.includes(config.default), `${name} default ${config.default} must be in its ladder`);
+    }
   });
 });
 
@@ -120,7 +147,7 @@ describe("codex-catalog buildCodexCatalog", () => {
     assert.equal(catalog.models[0].slug, "firerouter");
     assert.equal(
       catalog.models[0].description,
-      "Picks a model for each request based on the task.",
+      "Routes each request between Claude and open models.",
     );
     assert.equal(catalog.models[0].context_window, 1_048_575);
     assert.equal(catalog.models[0].supports_parallel_tool_calls, true);
@@ -130,7 +157,7 @@ describe("codex-catalog buildCodexCatalog", () => {
 
   it("dynamically adds firerouter* entries with shared FireRouter metadata", () => {
     const base = buildCodexCatalogFromSnapshot(buildServerlessCatalogSnapshot([]), []);
-    const catalog = ensureCodexFirerouterPatternEntry(base, "firerouter/x");
+    const catalog = ensureCodexOffCatalogEntry(base, "firerouter/x");
     const entry = catalog.models.find((model) => model.slug === "firerouter/x");
     assert.ok(entry);
     assert.equal(entry.context_window, 1_048_575);
@@ -138,14 +165,47 @@ describe("codex-catalog buildCodexCatalog", () => {
     assert.equal(entry.supports_parallel_tool_calls, true);
     assert.equal(
       entry.description,
-      "Picks a model for each request based on the task.",
+      "Routes each request between Claude and open models.",
     );
     assert.equal(codexCatalogContainsModel(catalog, "firerouter/x"), true);
     assert.equal(
-      ensureCodexFirerouterPatternEntry(catalog, "firerouter/x"),
+      ensureCodexOffCatalogEntry(catalog, "firerouter/x"),
       catalog,
       "idempotent when already present",
     );
+  });
+
+  it("dynamically adds an auto entry so Codex can resolve its context", () => {
+    const base = buildCodexCatalogFromSnapshot(buildServerlessCatalogSnapshot([]), []);
+    const catalog = ensureCodexOffCatalogEntry(base, "auto");
+    const entry = catalog.models.find((model) => model.slug === "auto");
+    assert.ok(entry);
+    assert.equal(entry.display_name, "Auto");
+    assert.equal(entry.context_window, 1_048_575);
+    assert.deepEqual(entry.input_modalities, ["text", "image"]);
+    assert.equal(entry.supports_parallel_tool_calls, true);
+    assert.equal(codexCatalogContainsModel(catalog, "auto"), true);
+    assert.equal(
+      ensureCodexOffCatalogEntry(catalog, "auto"),
+      catalog,
+      "idempotent when already present",
+    );
+  });
+
+  it("dynamically adds an auto-* entry so Codex can resolve its context", () => {
+    const base = buildCodexCatalogFromSnapshot(buildServerlessCatalogSnapshot([]), []);
+    const catalog = ensureCodexOffCatalogEntry(base, "auto-instant");
+    const entry = catalog.models.find((model) => model.slug === "auto-instant");
+    assert.ok(entry);
+    assert.equal(entry.display_name, "Auto Instant");
+    assert.equal(entry.context_window, 1_048_575);
+    assert.deepEqual(entry.input_modalities, ["text", "image"]);
+    assert.equal(codexCatalogContainsModel(catalog, "auto-instant"), true);
+  });
+
+  it("leaves the catalog alone for an ordinary off-catalog model", () => {
+    const base = buildCodexCatalogFromSnapshot(buildServerlessCatalogSnapshot([]), []);
+    assert.equal(ensureCodexOffCatalogEntry(base, "not-a-real-model"), base);
   });
 
   it("filters out deprecated models", () => {
@@ -363,6 +423,7 @@ describe("codex-catalog metadata tables", () => {
       "accounts/fireworks/models/gpt-oss-120b",
       "accounts/fireworks/models/nemotron-3-ultra-nvfp4",
       "accounts/fireworks/models/qwen3p7-plus",
+      "accounts/fireworks/models/kimi-k3",
     ];
     for (const id of expected) {
       assert.ok(MODEL_REASONING[id], `missing reasoning config for ${id}`);

--- a/packages/setup-cli/test/harnesses/codex/codex-ide-running.test.mjs
+++ b/packages/setup-cli/test/harnesses/codex/codex-ide-running.test.mjs
@@ -1,0 +1,84 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+import { ensureIdeStopped } from "../../../lib/io/ide-running.mjs";
+import {
+  CHATGPT_PROCESS_SPEC,
+  CHATGPT_RUNNING_MESSAGE,
+  ensureChatGptStopped,
+  isChatGptRunning,
+} from "../../../lib/harnesses/codex/ide-running.mjs";
+
+const SPEC = CHATGPT_PROCESS_SPEC;
+const MSG = CHATGPT_RUNNING_MESSAGE;
+
+/** POSIX ERE check (same dialect as `pgrep -f`). Node RegExp lacks `[[:space:]]`. */
+function linuxCmdlineMatchesPattern(pattern, cmdline) {
+  const r = spawnSync("grep", ["-E", pattern], { input: cmdline, encoding: "utf8" });
+  return r.status === 0;
+}
+
+describe("ChatGPT app pgrep pattern", () => {
+  it("matches the real ChatGPT.app binary path on macOS", () => {
+    // Real cmdline observed on macOS: /Applications/ChatGPT.app/Contents/MacOS/ChatGPT
+    const { darwinPattern } = SPEC;
+    const r = spawnSync("grep", ["-E", darwinPattern], { input: "/Applications/ChatGPT.app/Contents/MacOS/ChatGPT", encoding: "utf8" });
+    assert.equal(r.status, 0);
+  });
+
+  it("does not match unrelated paths that merely contain 'chatgpt'", () => {
+    const { darwinPattern } = SPEC;
+    for (const cmdline of [
+      "/Users/x/scripts/chatgpt-helper.mjs",
+      "/opt/chatgptify/bin/chatgptify",
+    ]) {
+      const r = spawnSync("grep", ["-E", darwinPattern], { input: cmdline, encoding: "utf8" });
+      assert.notEqual(r.status, 0, `should not match: ${cmdline}`);
+    }
+  });
+
+  it("matches a Linux chatgpt binary at common paths (either casing)", () => {
+    assert.ok(linuxCmdlineMatchesPattern(SPEC.linuxPattern, "/usr/bin/chatgpt --no-sandbox"));
+    assert.ok(linuxCmdlineMatchesPattern(SPEC.linuxPattern, "/opt/ChatGPT/ChatGPT"));
+    assert.ok(linuxCmdlineMatchesPattern(SPEC.linuxPattern, "/opt/chatgpt/chatgpt"));
+  });
+
+  it("does not match unrelated Linux paths that merely contain 'chatgpt'", () => {
+    assert.ok(!linuxCmdlineMatchesPattern(SPEC.linuxPattern, "/home/x/bin/chatgptify --foo"));
+    assert.ok(!linuxCmdlineMatchesPattern(SPEC.linuxPattern, "/usr/bin/mychatgpt-tool"));
+  });
+
+  it("treats Electron helper processes as not running once the main process exits", () => {
+    const { linuxCmdlineMatches } = SPEC;
+    assert.equal(linuxCmdlineMatches("/opt/ChatGPT/ChatGPT --type=utility --utility-sub-type=network.mojom.NetworkService"), false);
+    assert.equal(linuxCmdlineMatches("/opt/ChatGPT/ChatGPT --type=renderer --enable-crashpad"), false);
+    assert.equal(linuxCmdlineMatches("/opt/ChatGPT/ChatGPT --no-sandbox"), true);
+  });
+});
+
+describe("ensureChatGptStopped", () => {
+  it("returns immediately when the app is not running", async () => {
+    // Inject isRunning=false to avoid depending on a real app state.
+    await ensureIdeStopped(SPEC, MSG, { isRunning: () => false });
+  });
+
+  it("throws the ChatGPT running message in non-TTY mode when running", async () => {
+    await assert.rejects(
+      ensureIdeStopped(SPEC, MSG, {
+        isRunning: () => true,
+        stdin: { isTTY: false },
+      }),
+      /ChatGPT app is running/,
+    );
+  });
+
+  it("warns instead of waiting when force is set and the app is running", async () => {
+    // Should not throw or hang.
+    await ensureIdeStopped(SPEC, MSG, { force: true, isRunning: () => true });
+  });
+
+  it("isChatGptRunning returns a boolean without throwing", () => {
+    assert.equal(typeof isChatGptRunning(), "boolean");
+  });
+});

--- a/packages/setup-cli/test/harnesses/cursor/cursor-harness.test.mjs
+++ b/packages/setup-cli/test/harnesses/cursor/cursor-harness.test.mjs
@@ -907,17 +907,19 @@ describe("cursor harness integration", () => {
     });
   });
 
-  itIfSqlite("firerouter without a key reports the missing-key error", async () => {
+  itIfSqlite("firerouter without a key reports the Anthropic-required error", async () => {
     await withTempHome("cursor-firerouter-no-key-", async (home) => {
       const dbPath = path.join(home, "state.vscdb");
       writeCursorDb(dbPath, baseBlob());
+      // Bare firerouter routes to an Anthropic primary, so even with no key the
+      // dedicated refusal fires (Cursor can't forward a local Anthropic key) —
+      // more informative than the generic missing-key error.
       const result = await runCli(
         ["cursor", "on", "--model", "firerouter", "--db-path", dbPath, "--force"],
         { home, env: { FIREWORKS_API_KEY: "" } },
       );
       assert.notEqual(result.code, 0);
-      assert.match(result.stderr, /No Fireworks API key found/);
-      assert.doesNotMatch(result.stderr, /needs workspace BYOK/);
+      assert.match(result.stderr, /Anthropic API key Cursor can't forward/);
     });
   });
 
@@ -962,22 +964,54 @@ describe("cursor harness integration", () => {
     });
   });
 
-  itIfSqlite("firerouter is rejected by Cursor on", async () => {
+  itIfSqlite("firerouter is rejected by Cursor on without workspace BYOK", async () => {
     await withTempHome("cursor-reject-firerouter-", async (home) => {
       const dbPath = path.join(home, "state.vscdb");
       writeCursorDb(dbPath, baseBlob());
+      // A pure-Fireworks selection needs no Anthropic key, so without workspace
+      // BYOK it gets the general "enable FireRouter for your account" refusal.
       const unsupported =
         /Ask the Fireworks team to enable FireRouter for your account/;
 
       const selectOn = await runCli(
         [
           "cursor", "on", "--api-key", "fw_test_key_12345",
-          "--model", "firerouter", "--db-path", dbPath, "--force",
+          "--model", "firerouter/kimi-k3", "--db-path", dbPath, "--force",
         ],
         { home, env: { FIREWORKS_API_KEY: "" } },
       );
       assert.notEqual(selectOn.code, 0);
       assert.match(selectOn.stderr, unsupported);
+      await assert.rejects(access(path.join(home, ".fireconnect", ".secret-memory")));
+    });
+  });
+
+  itIfSqlite("firerouter selection with an Anthropic primary is refused in Cursor", async () => {
+    await withTempHome("cursor-refuse-anthropic-firerouter-", async (home) => {
+      const dbPath = path.join(home, "state.vscdb");
+      writeCursorDb(dbPath, baseBlob());
+      const refused =
+        /Anthropic API key Cursor can't forward/;
+
+      // Bare firerouter's primary is Claude Opus 5 → needs an Anthropic key.
+      const bare = await runCli(
+        ["cursor", "on", "--api-key", "fw_test_key_12345",
+          "--model", "firerouter", "--db-path", dbPath, "--force"],
+        { home, env: { FIREWORKS_API_KEY: "" } },
+      );
+      assert.notEqual(bare.code, 0);
+      assert.match(bare.stderr, refused);
+
+      // A multi-model slug naming Claude Opus 5 is the same category — this is
+      // the regression for the crash reported with firerouter/claude-opus-5/kimi-k3-fast.
+      const compound = await runCli(
+        ["cursor", "on", "--api-key", "fw_test_key_12345",
+          "--model", "firerouter/claude-opus-5/kimi-k3-fast", "--db-path", dbPath, "--force"],
+        { home, env: { FIREWORKS_API_KEY: "" } },
+      );
+      assert.notEqual(compound.code, 0);
+      assert.match(compound.stderr, refused);
+      // Nothing was written.
       await assert.rejects(access(path.join(home, ".fireconnect", ".secret-memory")));
     });
   });
@@ -1032,7 +1066,7 @@ describe("cursor harness integration", () => {
           cursorCurrentModelId(readBlob(dbPath), CURSOR_DEFAULT_MODE),
           "firerouter",
         );
-        assert.match(result.stdout, /FireRouter is on\. Picks a model for each request/);
+        assert.match(result.stdout, /FireRouter is on\. Routes each request between Claude and open models/);
       });
     } finally {
       gateway.server.close();

--- a/packages/setup-cli/test/harnesses/opencode/opencode-catalog-models.test.mjs
+++ b/packages/setup-cli/test/harnesses/opencode/opencode-catalog-models.test.mjs
@@ -138,6 +138,29 @@ describe("opencode catalog model handling", () => {
     assert.equal(models["firerouter/x"].limit.context, 1_048_575);
   });
 
+  it("writes an explicit auto override so OpenCode doesn't fall back to 128K", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "fc-opencode-auto-"));
+    const configPath = path.join(home, "opencode.json");
+    const dataDir = path.join(home, "data");
+    await mkdir(dataDir, { recursive: true });
+
+    await enableOpencodeFireworks({
+      configPath,
+      dataDir,
+      apiKey: "fw_test_key_12345",
+      effectiveApiKey: "fw_test_key_12345",
+      modelId: "auto",
+      catalogModelIds: ["accounts/fireworks/routers/glm-latest"],
+    });
+
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    assert.equal(config.model, "fireworks-ai/auto");
+    const entry = config.provider?.["fireworks-ai"]?.models?.auto;
+    assert.ok(entry, "auto is absent from models.dev, so it needs an explicit override");
+    assert.equal(entry.limit.context, 1_048_575);
+    assert.equal(entry.limit.output, 131_072);
+  });
+
   it("re-on with catalog rebuilds idempotently and drops duplicate legacy keys", async () => {
     const home = await mkdtemp(path.join(os.tmpdir(), "fc-opencode-reon-idempotent-"));
     const configPath = path.join(home, "opencode.json");

--- a/packages/setup-cli/test/harnesses/opencode/opencode-models.test.mjs
+++ b/packages/setup-cli/test/harnesses/opencode/opencode-models.test.mjs
@@ -105,6 +105,27 @@ describe("opencode model entries", () => {
     assert.equal(opencodeNeedsProviderModelOverride("firerouter/x"), true);
   });
 
+  it("requires a provider override for auto and keeps its bare slug", () => {
+    // `auto` is absent from models.dev, so OpenCode can only resolve it from a
+    // provider entry keyed by the same slug the infer command passes
+    // (fireworks-ai/auto).
+    assert.equal(opencodeNeedsProviderModelOverride("auto"), true);
+    assert.equal(opencodeConfigModelRef("auto"), "auto");
+    const entry = buildOpencodeModelEntry("auto");
+    assert.equal(entry.name, "Auto");
+    assert.deepEqual(entry.modalities, { input: ["text", "image"] });
+    assert.equal(entry.limit.context, 1_048_575);
+  });
+
+  it("requires a provider override for auto-* and keeps the variant slug", () => {
+    assert.equal(opencodeNeedsProviderModelOverride("auto-instant"), true);
+    assert.equal(opencodeConfigModelRef("auto-instant"), "auto-instant");
+    const entry = buildOpencodeModelEntry("auto-instant");
+    assert.equal(entry.name, "Auto Instant");
+    assert.deepEqual(entry.modalities, { input: ["text", "image"] });
+    assert.equal(entry.limit.context, 1_048_575);
+  });
+
   it("adds image modalities for vision serverless models", () => {
     const entry = buildOpencodeModelEntry("accounts/fireworks/models/kimi-k2p7-code");
     assert.deepEqual(entry.modalities, { input: ["text", "image"] });

--- a/packages/setup-cli/test/harnesses/pi/pi-fireworks-models.test.mjs
+++ b/packages/setup-cli/test/harnesses/pi/pi-fireworks-models.test.mjs
@@ -6,6 +6,7 @@ import {
   managedPiFireworksModelIds,
   mergePiFireworksRouterModels,
   ONE_MILLION_CONTEXT,
+  piEnabledModels,
   resolvePiEffectiveFireworksModel,
 } from "../../../lib/harnesses/pi/fireworks-models.mjs";
 import {
@@ -99,7 +100,7 @@ describe("mergePiFireworksRouterModels", () => {
     );
     assert.ok(entry, "glm-latest re-registered");
     assert.equal(entry.cost, undefined, "firepass row carries no metered cost");
-    assert.equal(entry.contextWindow, 1_048_575, "limits still resolved");
+    assert.equal(entry.contextWindow, 1_048_576, "limits still resolved");
   });
 
   it("uses live catalog labels for -latest router picker names", () => {
@@ -152,7 +153,7 @@ describe("mergePiFireworksRouterModels", () => {
     const entry = merged.providers.fireworks.models.find((model) => model.id === GLM_LATEST);
 
     assert.ok(entry);
-    assert.equal(entry.contextWindow, 1_048_575);
+    assert.equal(entry.contextWindow, 1_048_576);
     assert.equal(entry.cost.input, 1.4);
     assert.equal(entry.cost.output, 4.4);
     assert.equal(merged.providers.fireworks.modelOverrides?.[GLM_LATEST], undefined);
@@ -238,7 +239,7 @@ describe("resolvePiEffectiveFireworksModel", () => {
   it("buildPiCustomFireworksModelEntry uses shared limits, not vscode field names", () => {
     const entry = buildPiCustomFireworksModelEntry(GLM_LATEST, "GLM Latest");
     assert.equal(entry.id, GLM_LATEST);
-    assert.equal(entry.contextWindow, 1_048_575);
+    assert.equal(entry.contextWindow, 1_048_576);
     assert.equal(entry.maxTokens, 131_072);
     assert.deepEqual(entry.input, ["text"]);
     assert.equal(entry.cost.output, 4.4);
@@ -260,6 +261,37 @@ describe("resolvePiEffectiveFireworksModel", () => {
     assert.deepEqual(entry.input, ["text", "image"]);
     assert.equal(entry.contextWindow, 1_048_575);
     assert.equal(entry.maxTokens, 131_072);
+  });
+
+  it("registers a selected auto model with its spec limits", () => {
+    const entry = buildPiCustomFireworksModelEntry("auto", "Auto");
+    assert.equal(entry.id, "auto");
+    assert.deepEqual(entry.input, ["text", "image"]);
+    assert.equal(entry.contextWindow, 1_048_575);
+    assert.equal(entry.maxTokens, 131_072);
+
+    const merged = mergePiFireworksRouterModels({}, "auto", {}, [
+      "accounts/fireworks/routers/glm-latest",
+    ]);
+    const ids = merged.providers.fireworks.models.map((model) => model.id);
+    assert.ok(ids.includes("auto"), "active auto model registered");
+    assert.ok(
+      piEnabledModels("auto").includes("fireworks/auto"),
+      "and enabled, so Pi doesn't swap in its own default",
+    );
+  });
+
+  it("registers a selected auto-* model with shared spec limits and keeps the slug", () => {
+    const entry = buildPiCustomFireworksModelEntry("auto-instant", "Auto Instant");
+    assert.equal(entry.id, "auto-instant");
+    assert.deepEqual(entry.input, ["text", "image"]);
+    assert.equal(entry.contextWindow, 1_048_575);
+
+    const merged = mergePiFireworksRouterModels({}, "auto-instant", {}, [
+      "accounts/fireworks/routers/glm-latest",
+    ]);
+    const ids = merged.providers.fireworks.models.map((model) => model.id);
+    assert.ok(ids.includes("auto-instant"), "active auto-instant model registered");
   });
 
   it("registers the router catalog alongside a selected firerouter* model", () => {
@@ -319,6 +351,21 @@ describe("fullFireworksResourceId router classification", () => {
     );
   });
 
+  it("expands documented US-only slugs to routers/", () => {
+    assert.equal(
+      fullFireworksResourceId("kimi-k3-us"),
+      "accounts/fireworks/routers/kimi-k3-us",
+    );
+    assert.equal(
+      fullFireworksResourceId("glm-5p2-fast-us"),
+      "accounts/fireworks/routers/glm-5p2-fast-us",
+    );
+    assert.equal(
+      fullFireworksResourceId("glm-5p3-flash-us"),
+      "accounts/fireworks/routers/glm-5p3-flash-us",
+    );
+  });
+
   it("classifies firerouter* variants as routers, not just the bare firerouter slug", () => {
     assert.equal(
       fullFireworksResourceId("firerouter"),
@@ -333,8 +380,15 @@ describe("fullFireworksResourceId router classification", () => {
       "accounts/fireworks/routers/firerouter-fast-latest",
     );
     // A slash-bearing firerouter gateway pattern passes through unchanged and is
-    // handled by isFirerouterGatewayPattern at the spec layer.
+    // handled by isFirerouterModelPattern at the spec layer.
     assert.equal(fullFireworksResourceId("firerouter/x"), "firerouter/x");
+  });
+
+  it("leaves the auto model id unexpanded (no accounts/fireworks path exists)", () => {
+    assert.equal(fullFireworksResourceId("auto"), "auto");
+    assert.equal(fullFireworksResourceId("Auto"), "auto");
+    assert.equal(fullFireworksResourceId("auto[1m]"), "auto");
+    assert.equal(fullFireworksResourceId("auto-instant"), "auto-instant");
   });
 
   it("registers a router-slug active model as a single canonical row (no duplicate)", () => {
@@ -388,6 +442,31 @@ describe("fullFireworksResourceId router classification", () => {
     } finally {
       setServerlessCatalogSnapshot(null);
     }
+  });
+
+  it("piEnabledModels scopes the picker and still enables an off-scope active model", () => {
+    // Pi substitutes its own (long-dead) built-in default for any defaultModel
+    // outside enabledModels, so the active model must join the scope.
+    assert.deepEqual(
+      piEnabledModels("accounts/fireworks/routers/glm-latest"),
+      ["fireworks/accounts/fireworks/routers/*"],
+    );
+    assert.deepEqual(
+      piEnabledModels("auto"),
+      ["fireworks/accounts/fireworks/routers/*", "fireworks/auto"],
+    );
+    assert.deepEqual(
+      piEnabledModels("glm-5p2"),
+      [
+        "fireworks/accounts/fireworks/routers/*",
+        "fireworks/accounts/fireworks/models/glm-5p2",
+      ],
+    );
+    assert.deepEqual(
+      piEnabledModels("accounts/me/deployments/abc"),
+      ["fireworks/accounts/fireworks/routers/*", "fireworks/accounts/me/deployments/abc"],
+    );
+    assert.deepEqual(piEnabledModels(""), ["fireworks/accounts/fireworks/routers/*"]);
   });
 
   it("registers a concrete --model selection even though it's hidden from the picker", () => {

--- a/packages/setup-cli/test/harnesses/vscode/vscode-harness.test.mjs
+++ b/packages/setup-cli/test/harnesses/vscode/vscode-harness.test.mjs
@@ -17,7 +17,6 @@ import {
   fireworksProviderStatus,
   isFireconnectProvider,
   makeFireconnectSecretId,
-  migrateVscodeResponsesApiType,
   prettyModelName,
   removeFireconnectProvider,
   vscodeDataDir,
@@ -96,6 +95,24 @@ describe("vscode-core pure transforms", () => {
     assert.equal(m.maxOutputTokens, 131_072);
   });
 
+  it("buildModelEntry registers auto under its bare slug with vision", () => {
+    const m = buildModelEntry("auto");
+    assert.equal(m.id, "auto");
+    assert.equal(m.name, "Auto");
+    assert.equal(m.vision, true);
+    assert.equal(m.toolCalling, true);
+    assert.equal(m.maxInputTokens, 1_048_575);
+    assert.equal(m.maxOutputTokens, 131_072);
+  });
+
+  it("buildModelEntry registers auto-* under the variant slug with shared limits", () => {
+    const m = buildModelEntry("auto-instant");
+    assert.equal(m.id, "auto-instant");
+    assert.equal(m.name, "Auto Instant");
+    assert.equal(m.vision, true);
+    assert.equal(m.maxInputTokens, 1_048_575);
+  });
+
   it("buildAzureModelEntry sets maxInputTokens from the mapped Fireworks spec", () => {
     const m = buildAzureModelEntry("FW-GLM-5.2", "https://example.services.ai.azure.com/openai/v1");
     assert.equal(m.id, "FW-GLM-5.2");
@@ -157,68 +174,6 @@ describe("vscode-core pure transforms", () => {
     assert.equal(prettyModelName("accounts/fireworks/models/glm-5p2"), "GLM 5.2");
     assert.equal(prettyModelName("accounts/fireworks/models/deepseek-v4-flash"), "Deepseek V4 Flash");
     assert.equal(prettyModelName(""), "(unset)");
-  });
-});
-
-/* -------------------------------------------------------------------------- */
-/* migrateVscodeResponsesApiType — upgrade flip from the Responses wire to      */
-/* chat-completions. File-based but headless: `isRunning` is injected so the    */
-/* VS Code guard is deterministic.                                              */
-/* -------------------------------------------------------------------------- */
-
-describe("migrateVscodeResponsesApiType", () => {
-  const legacyProvider = (secretId) => ({
-    name: FIRECONNECT_PROVIDER_NAME,
-    vendor: "customendpoint",
-    apiType: "responses",
-    apiKey: `\${input:${secretId}}`,
-    models: [buildModelEntry("accounts/fireworks/routers/glm-latest")],
-  });
-
-  it("flips the fireconnect provider to chat-completions, leaving user providers alone", async () => {
-    await withTempHome("vscode-migrate-", async (home) => {
-      const vscodePath = path.join(home, "chatLanguageModels.json");
-      const secretId = makeFireconnectSecretId();
-      await writeFile(vscodePath, `${JSON.stringify([userProvider(), legacyProvider(secretId)])}\n`);
-
-      const migrated = await migrateVscodeResponsesApiType({ vscodePath, isRunning: () => false });
-      assert.equal(migrated, true);
-
-      const arr = await readJson(vscodePath);
-      assert.deepEqual(arr[0], userProvider()); // user provider fully untouched
-      assert.equal(arr[1].apiType, "chat-completions"); // flipped
-      assert.equal(arr[1].apiKey, `\${input:${secretId}}`); // secret reference preserved
-      assert.equal(arr[1].models[0].id, "glm-latest"); // models preserved
-    });
-  });
-
-  it("no-ops when the provider is already chat-completions or absent", async () => {
-    await withTempHome("vscode-migrate-noop-", async (home) => {
-      const vscodePath = path.join(home, "chatLanguageModels.json");
-      const secretId = makeFireconnectSecretId();
-      const original = `${JSON.stringify(
-        addFireworksProvider([], { secretId, models: [buildModelEntry("accounts/fireworks/routers/glm-latest")] }),
-      )}\n`;
-      await writeFile(vscodePath, original);
-
-      assert.equal(await migrateVscodeResponsesApiType({ vscodePath, isRunning: () => false }), false);
-      assert.equal(await readFile(vscodePath, "utf8"), original); // byte-for-byte untouched
-
-      // No fireconnect provider at all → nothing to migrate.
-      await writeFile(vscodePath, `${JSON.stringify([userProvider()])}\n`);
-      assert.equal(await migrateVscodeResponsesApiType({ vscodePath, isRunning: () => false }), false);
-    });
-  });
-
-  it("skips while VS Code is running", async () => {
-    await withTempHome("vscode-migrate-running-", async (home) => {
-      const vscodePath = path.join(home, "chatLanguageModels.json");
-      const original = `${JSON.stringify([legacyProvider(makeFireconnectSecretId())])}\n`;
-      await writeFile(vscodePath, original);
-
-      assert.equal(await migrateVscodeResponsesApiType({ vscodePath, isRunning: () => true }), false);
-      assert.equal(await readFile(vscodePath, "utf8"), original);
-    });
   });
 });
 
@@ -407,8 +362,11 @@ describe("vscode harness integration", () => {
       const vscodePath = path.join(home, "chatLanguageModels.json");
       await runCli(["vscode", "on", "--api-key", "fw_test_key_12345", "--vscode-path", vscodePath, "--force"], { home, env: secretEnv() });
       const legacy = await readJson(vscodePath);
-      legacy.find(isFireconnectProvider).models[0].id =
-        "accounts/fireworks/routers/glm-fast-latest";
+      const provider = legacy.find(isFireconnectProvider);
+      provider.models = [{
+        ...provider.models[0],
+        id: "accounts/fireworks/routers/glm-fast-latest",
+      }];
       await writeFile(vscodePath, `${JSON.stringify(legacy, null, "\t")}\n`);
       const r = await runCliJson(["vscode", "status", "--vscode-path", vscodePath, "--json"], { home, env: secretEnv() });
       assert.equal(r.code, 0, `stderr: ${r.stderr}`);

--- a/packages/setup-cli/test/harnesses/vscode/vscode-request-headers.test.mjs
+++ b/packages/setup-cli/test/harnesses/vscode/vscode-request-headers.test.mjs
@@ -25,4 +25,17 @@ describe("vscode request headers", () => {
     assert.equal(model.anthropic_api_key, undefined);
     assert.equal(model.requestHeaders?.["x-anthropic-api-key"], undefined);
   });
+
+  it("attaches routing-preference for a pure-Fireworks firerouter selection, without Anthropic BYOK", () => {
+    // A pure-Fireworks selection (firerouter/kimi-k3) needs no Anthropic key, so
+    // the BYOK header/body field must be dropped — but the routing-preference
+    // header still attaches because it applies to any FireRouter route.
+    const model = withFireconnectRequestHeaders(
+      { id: "firerouter/kimi-k3", name: "FireRouter · Kimi K3", url: "https://api.fireworks.ai/inference" },
+      { byokHeaders: { "x-routing-preference": "3", "x-anthropic-api-key": "sk-ant-byok" } },
+    );
+    assert.equal(model.requestHeaders["x-routing-preference"], "3");
+    assert.equal(model.requestHeaders?.["x-anthropic-api-key"], undefined);
+    assert.equal(model.anthropic_api_key, undefined);
+  });
 });

--- a/packages/setup-cli/test/harnesses/vscode/vscode-upgrade-migrations.test.mjs
+++ b/packages/setup-cli/test/harnesses/vscode/vscode-upgrade-migrations.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  addFireworksProvider,
+  buildModelEntry,
+  FIRECONNECT_PROVIDER_NAME,
+  makeFireconnectSecretId,
+} from "../../../lib/harnesses/vscode/core.mjs";
+import { migrateVscodeResponsesApiType } from "../../../lib/harnesses/vscode/upgrade-migrations.mjs";
+import { withTempHome } from "../../helpers.mjs";
+
+/** A non-fireconnect provider (user-managed) to prove ownership scoping. */
+function userProvider(name = "MyOther") {
+  return {
+    name,
+    vendor: "customendpoint",
+    apiType: "chat-completions",
+    apiKey: "${input:chat.lm.secret.user-managed-id}",
+    models: [{ id: "other-model", name: "Other", url: "https://other.example", toolCalling: false, vision: false, maxInputTokens: 8000, maxOutputTokens: 2000 }],
+  };
+}
+
+async function readJson(p) {
+  return JSON.parse(await readFile(p, "utf8"));
+}
+
+describe("migrateVscodeResponsesApiType", () => {
+  const legacyProvider = (secretId) => ({
+    name: FIRECONNECT_PROVIDER_NAME,
+    vendor: "customendpoint",
+    apiType: "responses",
+    apiKey: `\${input:${secretId}}`,
+    models: [buildModelEntry("accounts/fireworks/routers/glm-latest")],
+  });
+
+  it("flips the fireconnect provider to chat-completions, leaving user providers alone", async () => {
+    await withTempHome("vscode-migrate-", async (home) => {
+      const vscodePath = path.join(home, "chatLanguageModels.json");
+      const secretId = makeFireconnectSecretId();
+      await writeFile(vscodePath, `${JSON.stringify([userProvider(), legacyProvider(secretId)])}\n`);
+
+      const migrated = await migrateVscodeResponsesApiType(home, { vscodePath, isRunning: () => false });
+      assert.equal(migrated, true);
+
+      const arr = await readJson(vscodePath);
+      assert.deepEqual(arr[0], userProvider());
+      assert.equal(arr[1].apiType, "chat-completions");
+      assert.equal(arr[1].apiKey, `\${input:${secretId}}`);
+      assert.equal(arr[1].models[0].id, "glm-latest");
+    });
+  });
+
+  it("no-ops when the provider is already chat-completions or absent", async () => {
+    await withTempHome("vscode-migrate-noop-", async (home) => {
+      const vscodePath = path.join(home, "chatLanguageModels.json");
+      const secretId = makeFireconnectSecretId();
+      const original = `${JSON.stringify(
+        addFireworksProvider([], { secretId, models: [buildModelEntry("accounts/fireworks/routers/glm-latest")] }),
+      )}\n`;
+      await writeFile(vscodePath, original);
+
+      assert.equal(await migrateVscodeResponsesApiType(home, { vscodePath, isRunning: () => false }), false);
+      assert.equal(await readFile(vscodePath, "utf8"), original);
+
+      await writeFile(vscodePath, `${JSON.stringify([userProvider()])}\n`);
+      assert.equal(await migrateVscodeResponsesApiType(home, { vscodePath, isRunning: () => false }), false);
+    });
+  });
+
+  it("skips while VS Code is running", async () => {
+    await withTempHome("vscode-migrate-running-", async (home) => {
+      const vscodePath = path.join(home, "chatLanguageModels.json");
+      const original = `${JSON.stringify([legacyProvider(makeFireconnectSecretId())])}\n`;
+      await writeFile(vscodePath, original);
+
+      assert.equal(await migrateVscodeResponsesApiType(home, { vscodePath, isRunning: () => true }), false);
+      assert.equal(await readFile(vscodePath, "utf8"), original);
+    });
+  });
+});

--- a/packages/setup-cli/test/helpers.mjs
+++ b/packages/setup-cli/test/helpers.mjs
@@ -203,6 +203,33 @@ export async function withTempHome(prefix, fn) {
 }
 
 /**
+ * Run a test callback with Linux SSH env markers set (no-op on other platforms).
+ *
+ * @template T
+ * @param {(platformIsLinux: boolean) => T | Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+export async function withLinuxSshEnv(fn) {
+  if (process.platform !== "linux") {
+    return fn(false);
+  }
+  const prev = {
+    SSH_CONNECTION: process.env.SSH_CONNECTION,
+    FIRECONNECT_KEY_STORAGE: process.env.FIRECONNECT_KEY_STORAGE,
+  };
+  process.env.SSH_CONNECTION = "203.0.113.1 12345 198.51.100.2 22";
+  delete process.env.FIRECONNECT_KEY_STORAGE;
+  try {
+    return await fn(true);
+  } finally {
+    if (prev.SSH_CONNECTION === undefined) delete process.env.SSH_CONNECTION;
+    else process.env.SSH_CONNECTION = prev.SSH_CONNECTION;
+    if (prev.FIRECONNECT_KEY_STORAGE === undefined) delete process.env.FIRECONNECT_KEY_STORAGE;
+    else process.env.FIRECONNECT_KEY_STORAGE = prev.FIRECONNECT_KEY_STORAGE;
+  }
+}
+
+/**
  * Remove a temp dir, tolerating a transient ENOTEMPTY/EBUSY from a just-exited
  * subprocess still flushing files. Cleanup must never fail a test whose
  * assertions already passed — the OS reaps leftover temp dirs regardless.
@@ -222,12 +249,25 @@ async function removeTempDir(dir) {
   }
 }
 
+/**
+ * Codex `on`/`off` block while the ChatGPT app is running (mirrors
+ * Cursor/VS Code). Tests spawn non-TTY children, so the guard would throw
+ * "ChatGPT app is running" whenever the app is open on the dev machine.
+ * Append `--force` to bypass it, the way Cursor/VS Code tests pass `--force`
+ * per call. Shared so the bypass lives in one place.
+ */
+export function codexOnOffArgs(args) {
+  return args[0] === "codex" && (args[1] === "on" || args[1] === "off") && !args.includes("--force")
+    ? [...args, "--force"]
+    : args;
+}
+
 export function runFireconnect(args, env = {}) {
   return new Promise((resolve, reject) => {
     if (args.includes("on")) {
       seedOnCommandCatalog(env.HOME, args);
     }
-    const child = spawn(process.execPath, [CLI, ...args], {
+    const child = spawn(process.execPath, [CLI, ...codexOnOffArgs(args)], {
       env: {
         ...process.env,
         ...TEST_SECRET_STORE_ENV,
@@ -276,7 +316,7 @@ export async function runCli(args, { home, env = {} } = {}) {
     if (args.includes("on")) {
       seedOnCommandCatalog(home, args);
     }
-    const child = spawn(process.execPath, [CLI, ...args], {
+    const child = spawn(process.execPath, [CLI, ...codexOnOffArgs(args)], {
       env: {
         ...process.env,
         ...TEST_SECRET_STORE_ENV,

--- a/packages/setup-cli/test/keys/key-sync.test.mjs
+++ b/packages/setup-cli/test/keys/key-sync.test.mjs
@@ -53,13 +53,13 @@ async function readJson(filePath) {
 }
 
 describe("syncBakedKeysAfterStore", () => {
-  it("re-bakes Claude's custom header, migrating the legacy header name", async () => {
+  it("re-bakes Claude's custom header", async () => {
     await withTempHome("key-sync-", async (home) => {
       await enableHarnessesForSync(home, ["claude"]);
       await writeJsonFile(userSettingsPath(home), {
         env: {
           ANTHROPIC_BASE_URL: "https://api.fireworks.ai/inference",
-          ANTHROPIC_CUSTOM_HEADERS: "X-FireRouter-Fireworks-Key: fw_stale\nx-routing-preference: 3",
+          ANTHROPIC_CUSTOM_HEADERS: "X-Fireworks-Api-Key: fw_stale\nx-routing-preference: 3",
         },
       });
 

--- a/packages/setup-cli/test/keys/keyring-timeout.test.mjs
+++ b/packages/setup-cli/test/keys/keyring-timeout.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { KEYRING_OP_TIMEOUT_MS, KeyringTimeoutError, withKeyringTimeout } from "../../lib/keys/keyring-timeout.mjs";
+
+describe("withKeyringTimeout", () => {
+  it("returns when the operation finishes in time", async () => {
+    const value = await withKeyringTimeout(Promise.resolve("ok"), "test-op");
+    assert.equal(value, "ok");
+  });
+
+  it("rejects with KeyringTimeoutError when the operation exceeds the timeout", async () => {
+    const slow = new Promise(() => {});
+    await assert.rejects(
+      () => withKeyringTimeout(slow, "hanging-setPassword"),
+      (error) => {
+        assert.ok(error instanceof KeyringTimeoutError);
+        assert.equal(error.name, "KeyringTimeoutError");
+        assert.match(error.message, /timed out after \d+ms \(hanging-setPassword\)/);
+        assert.ok(error.message.includes(String(KEYRING_OP_TIMEOUT_MS)));
+        return true;
+      },
+    );
+  });
+});

--- a/packages/setup-cli/test/keys/missing-cross-keychain.test.mjs
+++ b/packages/setup-cli/test/keys/missing-cross-keychain.test.mjs
@@ -13,16 +13,42 @@ import {
   dependencyInstalled,
   ensureCliDependencies,
   resolveSetupCliDir,
+  runtimeDependencyNames,
   runtimeDepsInstalled,
 } from "../../lib/system/ensure-cli-deps.mjs";
-import { resetSecretStoreForTests } from "../../lib/keys/secret-store.mjs";
+import {
+  FIRECONNECT_KEY_STORAGE_ENV,
+  resetSecretStoreForTests,
+} from "../../lib/keys/secret-store.mjs";
 
 describe("ensure-cli-deps", () => {
   it("resolveSetupCliDir points at packages/setup-cli", () => {
     assert.equal(path.basename(resolveSetupCliDir()), "setup-cli");
     assert.ok(runtimeDepsInstalled());
   });
+
+  it("tracks every package.json production dependency, including yaml", () => {
+    const names = runtimeDependencyNames();
+    assert.ok(names.includes("yaml"));
+    assert.ok(names.includes("smol-toml"));
+    assert.ok(names.includes("ansis"));
+    assert.ok(names.includes("cross-keychain"));
+  });
 });
+
+function fileBackendEnv(home) {
+  const env = {
+    ...process.env,
+    HOME: home,
+    XDG_DATA_HOME: path.join(home, "data"),
+    XDG_CONFIG_HOME: path.join(home, "cfg"),
+    [FIRECONNECT_KEY_STORAGE_ENV]: "file",
+    KEYRING_FILE_MASTER_KEY: "a".repeat(64),
+  };
+  delete env.FIRECONNECT_SECRET_STORE;
+  delete env.FIREWORKS_API_KEY;
+  return env;
+}
 
 describe("dep-less checkout configure", () => {
   let home;
@@ -64,15 +90,17 @@ describe("dep-less checkout configure", () => {
     assert.equal(dependencyInstalled("ansis", setupDir), true);
   });
 
-  itIfNpm("harness on succeeds from a dep-less checkout (auto npm install)", () => {
-    const env = {
-      ...process.env,
-      HOME: home,
-      XDG_DATA_HOME: path.join(home, "data"),
-      XDG_CONFIG_HOME: path.join(home, "cfg"),
-    };
-    delete env.FIRECONNECT_SECRET_STORE;
-    delete env.FIREWORKS_API_KEY;
+  itIfNpm("ensureCliDependencies repairs a partial install missing yaml", async () => {
+    assert.equal(ensureCliDependencies(setupDir), true);
+    await rm(path.join(setupDir, "node_modules", "yaml"), { recursive: true, force: true });
+    assert.equal(dependencyInstalled("yaml", setupDir), false);
+    assert.equal(runtimeDepsInstalled(setupDir), false);
+    assert.equal(ensureCliDependencies(setupDir), true);
+    assert.equal(dependencyInstalled("yaml", setupDir), true);
+  });
+
+  itIfNpm("harness on succeeds from a dep-less checkout (auto npm install)", async () => {
+    const env = fileBackendEnv(home);
 
     const res = spawnSync(
       process.execPath,
@@ -85,6 +113,7 @@ describe("dep-less checkout configure", () => {
       { env, encoding: "utf8", timeout: 120000 },
     );
     assert.equal(res.status, 0, `${res.stderr}\n${res.stdout}`);
+    await assert.doesNotReject(access(path.join(home, "data/keyring/secrets.json")));
     assert.doesNotMatch(
       `${res.stdout}\n${res.stderr}`,
       /cross-keychain secret module could not be loaded/,
@@ -122,14 +151,7 @@ describe("dep-less checkout configure", () => {
       { force: true },
     );
 
-    const env = {
-      ...process.env,
-      HOME: home,
-      XDG_DATA_HOME: path.join(home, "data"),
-      XDG_CONFIG_HOME: path.join(home, "cfg"),
-    };
-    delete env.FIRECONNECT_SECRET_STORE;
-    delete env.FIREWORKS_API_KEY;
+    const env = fileBackendEnv(home);
 
     const res = spawnSync(
       process.execPath,

--- a/packages/setup-cli/test/keys/plaintext-fallback.test.mjs
+++ b/packages/setup-cli/test/keys/plaintext-fallback.test.mjs
@@ -56,8 +56,12 @@ describe("plaintext secret fallback", () => {
       XDG_DATA_HOME: process.env.XDG_DATA_HOME,
       XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
       [FIRECONNECT_KEY_STORAGE_ENV]: process.env[FIRECONNECT_KEY_STORAGE_ENV],
+      FIRECONNECT_SECRET_STORE: process.env.FIRECONNECT_SECRET_STORE,
+      FIRECONNECT_TEST: process.env.FIRECONNECT_TEST,
     };
     process.env.HOME = home;
+    delete process.env.FIRECONNECT_SECRET_STORE;
+    delete process.env.FIRECONNECT_TEST;
     await blockSecureKeyStorage(home);
   });
 

--- a/packages/setup-cli/test/keys/prefer-file-backend.test.mjs
+++ b/packages/setup-cli/test/keys/prefer-file-backend.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  remoteSecretStorageDetail,
+  shouldPreferFileBackendOnLinux,
+  shouldSkipEnvKeyAutoPersist,
+} from "../../lib/config/secret-storage-policy.mjs";
+import { withLinuxSshEnv } from "../helpers.mjs";
+
+describe("secret storage policy", () => {
+  it("returns false when not on Linux", () => {
+    if (process.platform === "linux") {
+      return;
+    }
+    assert.equal(shouldPreferFileBackendOnLinux(), false);
+  });
+
+  it("returns true on Linux when SSH env markers are set", async () => {
+    await withLinuxSshEnv((isLinux) => {
+      if (!isLinux) {
+        return;
+      }
+      assert.equal(shouldPreferFileBackendOnLinux(), true);
+      assert.match(remoteSecretStorageDetail() ?? "", /SSH\/remote/i);
+      assert.equal(shouldSkipEnvKeyAutoPersist(), true);
+    });
+  });
+
+  it("returns false when FIRECONNECT_KEY_STORAGE is explicitly set", async () => {
+    await withLinuxSshEnv((isLinux) => {
+      if (!isLinux) {
+        return;
+      }
+      const prev = process.env.FIRECONNECT_KEY_STORAGE;
+      process.env.FIRECONNECT_KEY_STORAGE = "keychain";
+      try {
+        assert.equal(shouldPreferFileBackendOnLinux(), false);
+      } finally {
+        if (prev === undefined) delete process.env.FIRECONNECT_KEY_STORAGE;
+        else process.env.FIRECONNECT_KEY_STORAGE = prev;
+      }
+    });
+  });
+});

--- a/packages/setup-cli/test/keys/secret-backend.test.mjs
+++ b/packages/setup-cli/test/keys/secret-backend.test.mjs
@@ -25,7 +25,7 @@ import { plaintextMode } from "../../lib/harnesses/vscode/safestorage.mjs";
 import { shellHookBlock } from "../../lib/io/shell-env-hook.mjs";
 import { verifyKeyExportWorks } from "../../lib/keys/selfcheck.mjs";
 import { resolveHarnessOnApiKey } from "../../lib/keys/harness-api-key.mjs";
-import { withoutEnvFireworksKey } from "../helpers.mjs";
+import { withoutEnvFireworksKey, withLinuxSshEnv } from "../helpers.mjs";
 
 const CLI = path.resolve("bin/fireconnect.mjs");
 const KEY = "fw_backend_test_key_000000000000";
@@ -100,6 +100,30 @@ describe("secret backend detection + file backend", () => {
     assert.match(backend.label, /Encrypted file/);
     assert.equal(backend.location, path.join(home, "data", "keyring", "secrets.json"));
     assert.equal(backend.forced, true);
+  });
+
+  it("detectSecretBackend reports file on Linux SSH even when libsecret is present", async () => {
+    await withLinuxSshEnv(async (isLinux) => {
+      if (!isLinux) {
+        return;
+      }
+      const prevStorage = process.env[FIRECONNECT_KEY_STORAGE_ENV];
+      delete process.env[FIRECONNECT_KEY_STORAGE_ENV];
+      resetSecretStoreForTests();
+      try {
+        const backend = await detectSecretBackend(home);
+        assert.equal(backend.backend, "file");
+        assert.match(backend.label, /Encrypted file/);
+      } finally {
+        if (prevStorage === undefined) {
+          delete process.env[FIRECONNECT_KEY_STORAGE_ENV];
+        } else {
+          process.env[FIRECONNECT_KEY_STORAGE_ENV] = prevStorage;
+        }
+        process.env[FIRECONNECT_KEY_STORAGE_ENV] = "file";
+        resetSecretStoreForTests();
+      }
+    });
   });
 
   it("round-trips a key through the encrypted file backend with no plaintext on disk", async () => {

--- a/packages/setup-cli/test/keys/secret-fallbacks.test.mjs
+++ b/packages/setup-cli/test/keys/secret-fallbacks.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createSecretFallbackHandlers } from "../../lib/keys/secret-fallbacks.mjs";
+
+function makeDeps(overrides = {}) {
+  return {
+    resolveHome: (home) => home ?? "/tmp/home",
+    withHomeScopedEnv: async (_home, fn) => fn(),
+    persistKeyStorageCache: async () => {},
+    clearKeyStorageCache: async () => {},
+    deleteSecretFromSecureBackend: async () => {},
+    primeSecureReadCache: () => {},
+    clearLastReadError: () => {},
+    secretService: "svc",
+    secretAccount: "acct",
+    ...overrides,
+  };
+}
+
+describe("createSecretFallbackHandlers", () => {
+  it("storeSecretWithFallbacks uses secure storage when it succeeds", async () => {
+    const calls = [];
+    const { storeSecretWithFallbacks } = createSecretFallbackHandlers(makeDeps());
+    const outcome = await storeSecretWithFallbacks("fw_key", "/tmp/home", async () => {
+      calls.push("secure");
+    });
+    assert.equal(outcome, "secure");
+    assert.deepEqual(calls, ["secure"]);
+  });
+});

--- a/packages/setup-cli/test/keys/secret-store.test.mjs
+++ b/packages/setup-cli/test/keys/secret-store.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import {
   deleteSecret,
+  detectSecretBackend,
   getSecret,
   hasSecret,
   resetSecretStoreForTests,
@@ -13,6 +14,37 @@ import {
 import { seedKeychainConfig, withTempHome } from "../helpers.mjs";
 
 describe("secret-store", () => {
+  it("never auto-selects the OS keychain in test context", async () => {
+    await withTempHome("secret-test-auto-", async (home) => {
+      const savedEnv = {
+        FIRECONNECT_SECRET_STORE: process.env.FIRECONNECT_SECRET_STORE,
+        FIRECONNECT_TEST: process.env.FIRECONNECT_TEST,
+        FIRECONNECT_KEY_STORAGE: process.env.FIRECONNECT_KEY_STORAGE,
+        XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+        XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+      };
+      process.env.FIRECONNECT_TEST = "1";
+      process.env.XDG_DATA_HOME = path.join(home, "data");
+      process.env.XDG_CONFIG_HOME = path.join(home, "config");
+      delete process.env.FIRECONNECT_SECRET_STORE;
+      delete process.env.FIRECONNECT_KEY_STORAGE;
+      resetSecretStoreForTests();
+      try {
+        const backend = await detectSecretBackend(home);
+        assert.equal(backend.backend, "file");
+      } finally {
+        for (const [key, value] of Object.entries(savedEnv)) {
+          if (value === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = value;
+          }
+        }
+        resetSecretStoreForTests();
+      }
+    });
+  });
+
   it("stores and retrieves secrets in memory mode", async () => {
     const home = await mkdtemp(path.join(os.tmpdir(), "fc-secret-mem-"));
     const prevHome = process.env.HOME;

--- a/packages/setup-cli/test/system/environment.test.mjs
+++ b/packages/setup-cli/test/system/environment.test.mjs
@@ -9,6 +9,7 @@ import {
   detectSecretStorage,
   isWsl,
 } from "../../lib/system/environment.mjs";
+import { withLinuxSshEnv } from "../helpers.mjs";
 
 describe("environment detection", () => {
   it("detects a structured, current-platform environment", () => {
@@ -69,5 +70,16 @@ describe("environment detection", () => {
     } finally {
       if (prev !== undefined) process.env.FIRECONNECT_KEY_STORAGE = prev;
     }
+  });
+
+  it("prefers encrypted file on Linux SSH sessions", async () => {
+    await withLinuxSshEnv((isLinux) => {
+      if (!isLinux) {
+        return;
+      }
+      const s = detectSecretStorage();
+      assert.equal(s.backend, "file");
+      assert.match(s.detail ?? "", /SSH\/remote/i);
+    });
   });
 });

--- a/packages/setup-cli/test/system/finalize-install.test.mjs
+++ b/packages/setup-cli/test/system/finalize-install.test.mjs
@@ -21,6 +21,10 @@ describe("finalizeInstallOrUpgrade", () => {
           calls.push(["reprobe", h]);
           return { migrated: true, backend: { backend: "keychain" } };
         },
+        migrate: async (h) => {
+          calls.push(["migrate", h]);
+          return ["Enabled MCP tool search for Claude Code (ENABLE_TOOL_SEARCH) — restart Claude Code to pick it up."];
+        },
         reconcile: async (h) => {
           calls.push(["reconcile", h]);
           return ["Updated Claude websearch MCP auth (baked Bearer token) — restart Claude Code to pick it up."];
@@ -29,13 +33,15 @@ describe("finalizeInstallOrUpgrade", () => {
 
       assert.equal(result.migrated, true);
       assert.deepEqual(result.notes, [
+        "Enabled MCP tool search for Claude Code (ENABLE_TOOL_SEARCH) — restart Claude Code to pick it up.",
         "Updated Claude websearch MCP auth (baked Bearer token) — restart Claude Code to pick it up.",
       ]);
       assert.deepEqual(
         calls.filter(([name]) => name !== "log").map(([name]) => name),
-        ["reprobe", "reconcile"],
+        ["reprobe", "migrate", "reconcile"],
       );
       assert.ok(calls.some(([name, msg]) => name === "log" && /Moved Fireworks API key/.test(String(msg))));
+      assert.ok(calls.some(([name, msg]) => name === "log" && /ENABLE_TOOL_SEARCH/.test(String(msg))));
       assert.ok(calls.some(([name, msg]) => name === "log" && /websearch MCP/.test(String(msg))));
     });
   });
@@ -49,6 +55,9 @@ describe("finalizeInstallOrUpgrade", () => {
         ensureDeps: () => true,
         reprobe: async () => {
           throw new Error("probe boom");
+        },
+        migrate: async () => {
+          throw new Error("migrate boom");
         },
         reconcile: async () => {
           throw new Error("reconcile boom");
@@ -73,6 +82,10 @@ describe("finalizeInstallOrUpgrade", () => {
       reprobe: async () => {
         calls.push("reprobe");
         return { migrated: false, backend: { backend: "plaintext" } };
+      },
+      migrate: async () => {
+        calls.push("migrate");
+        return ["should-not-run"];
       },
       reconcile: async () => {
         calls.push("reconcile");

--- a/packages/setup-cli/test/system/forward-migrations.test.mjs
+++ b/packages/setup-cli/test/system/forward-migrations.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { writeGlobalConfig } from "../../lib/config/global-config.mjs";
+import { FIREWORKS_BASE_URL } from "../../lib/fireworks/model-id.mjs";
+import { userSettingsPath } from "../../lib/harnesses/claude/core.mjs";
+import { runHarnessForwardMigrations } from "../../lib/system/forward-migrations.mjs";
+import { withTempHome } from "../helpers.mjs";
+
+describe("runHarnessForwardMigrations", () => {
+  it("backfills ENABLE_TOOL_SEARCH for an enabled Claude and reports a note", async () => {
+    await withTempHome("forward-migrate-claude-", async (home) => {
+      await writeGlobalConfig(home, {
+        harnesses: { claude: { enabled: true, provider: "fireworks" } },
+      });
+      const settingsPath = userSettingsPath(home);
+      await mkdir(path.dirname(settingsPath), { recursive: true });
+      await writeFile(
+        settingsPath,
+        `${JSON.stringify({
+          env: { ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL },
+        }, null, 2)}\n`,
+        { mode: 0o600 },
+      );
+
+      const notes = await runHarnessForwardMigrations(home);
+      assert.equal(notes.filter((n) => /ENABLE_TOOL_SEARCH/.test(n)).length, 1, notes.join("\n"));
+      assert.equal(JSON.parse(await readFile(settingsPath, "utf8")).env.ENABLE_TOOL_SEARCH, "true");
+    });
+  });
+
+  it("does not touch Claude settings when the harness is off", async () => {
+    await withTempHome("forward-migrate-claude-off-", async (home) => {
+      await writeGlobalConfig(home, {
+        harnesses: { claude: { enabled: false, provider: "fireworks" } },
+      });
+      const settingsPath = userSettingsPath(home);
+      await mkdir(path.dirname(settingsPath), { recursive: true });
+      const original = `${JSON.stringify({
+        env: { ANTHROPIC_BASE_URL: FIREWORKS_BASE_URL },
+      }, null, 2)}\n`;
+      await writeFile(settingsPath, original, { mode: 0o600 });
+
+      const notes = await runHarnessForwardMigrations(home);
+      assert.equal(notes.filter((n) => /ENABLE_TOOL_SEARCH/.test(n)).length, 0, notes.join("\n"));
+      assert.equal(await readFile(settingsPath, "utf8"), original);
+    });
+  });
+
+  it("reports a failed migration without skipping finalize", async () => {
+    await withTempHome("forward-migrate-failure-", async (home) => {
+      await writeGlobalConfig(home, {
+        harnesses: { claude: { enabled: true, provider: "fireworks" } },
+      });
+      const settingsPath = userSettingsPath(home);
+      await mkdir(path.dirname(settingsPath), { recursive: true });
+      await writeFile(settingsPath, "{invalid json");
+
+      const notes = await runHarnessForwardMigrations(home);
+      assert.ok(
+        notes.includes("Couldn't enable MCP tool search for Claude Code — re-run fireconnect claude on."),
+        notes.join("\n"),
+      );
+    });
+  });
+});

--- a/packages/setup-cli/test/system/postinstall-finalize.test.mjs
+++ b/packages/setup-cli/test/system/postinstall-finalize.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import process from "node:process";
+import { describe, it } from "node:test";
+
+import {
+  durableInstallContext,
+  runPostinstallFinalize,
+} from "../../lib/system/postinstall-finalize.mjs";
+
+describe("postinstall finalize bootstrap", () => {
+  it("derives HOME only from the durable curl-installer layout", () => {
+    assert.deepEqual(
+      durableInstallContext("/home/alice/.fireconnect/cli/packages/setup-cli"),
+      {
+        home: "/home/alice",
+        installDir: "/home/alice/.fireconnect/cli",
+      },
+    );
+    assert.equal(
+      durableInstallContext("/work/fireconnect-internal/packages/setup-cli"),
+      null,
+    );
+    assert.equal(
+      durableInstallContext("/usr/local/lib/node_modules/@fireconnect/cli"),
+      null,
+    );
+  });
+
+  it("runs the new finalizer in the durable install and passes its package root", async () => {
+    const calls = [];
+    const setupDir = path.resolve("/home/alice/.fireconnect/cli/packages/setup-cli");
+
+    assert.equal(await runPostinstallFinalize({
+      setupDir,
+      finalize: async (...args) => calls.push(args),
+    }), true);
+    assert.deepEqual(calls, [[
+      "/home/alice",
+      "/home/alice/.fireconnect/cli",
+    ]]);
+  });
+
+  it("does nothing outside the durable install", async () => {
+    let called = false;
+    assert.equal(await runPostinstallFinalize({
+      setupDir: "/work/fireconnect-internal/packages/setup-cli",
+      finalize: async () => {
+        called = true;
+      },
+    }), false);
+    assert.equal(called, false);
+  });
+
+  it("skips when the current installer will finalize explicitly", async () => {
+    const previous = process.env.FIRECONNECT_SKIP_POSTINSTALL_FINALIZE;
+    process.env.FIRECONNECT_SKIP_POSTINSTALL_FINALIZE = "1";
+    try {
+      let called = false;
+      assert.equal(await runPostinstallFinalize({
+        setupDir: "/home/alice/.fireconnect/cli/packages/setup-cli",
+        finalize: async () => {
+          called = true;
+        },
+      }), false);
+      assert.equal(called, false);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.FIRECONNECT_SKIP_POSTINSTALL_FINALIZE;
+      } else {
+        process.env.FIRECONNECT_SKIP_POSTINSTALL_FINALIZE = previous;
+      }
+    }
+  });
+
+  it("fails npm install when postflight cannot complete", async () => {
+    await assert.rejects(
+      runPostinstallFinalize({
+        setupDir: "/home/alice/.fireconnect/cli/packages/setup-cli",
+        finalize: async () => {
+          throw new Error("migration failed");
+        },
+      }),
+      /migration failed/,
+    );
+  });
+});

--- a/packages/setup-cli/test/system/upgrade.test.mjs
+++ b/packages/setup-cli/test/system/upgrade.test.mjs
@@ -1,11 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, it } from "node:test";
 
 import { runUpgradeCommand } from "../../lib/cli/commands/global.mjs";
 import { FIREWORKS_BASE_URL } from "../../lib/fireworks/model-id.mjs";
-import { userSettingsPath } from "../../lib/harnesses/claude/core.mjs";
 import {
   CLAUDE_OFF_UPGRADE_BEFORE_VERSION,
   CLAUDE_UPGRADE_PROMPT,
@@ -13,6 +11,7 @@ import {
   needsClaudeOffBeforeUpgrade,
   runClaudeUpgradePreflight,
 } from "../../lib/system/upgrade.mjs";
+import { runUpgradeFinalize } from "../../lib/system/upgrade-finalize.mjs";
 import { runCli, withTempHome } from "../helpers.mjs";
 
 function managedClaudeEvidence() {
@@ -58,6 +57,7 @@ function upgradeDependencies(overrides = {}) {
     infoFn: () => {},
     successFn: () => {},
     log: () => {},
+    runtimeDepsPresent: () => true,
     ...overrides,
   };
 }
@@ -237,41 +237,6 @@ describe("Claude upgrade preflight", () => {
   });
 });
 
-describe("Claude upgrade restoration fallback", () => {
-  it("strips backup-less legacy managed settings through the old adapter's off", async () => {
-    await withTempHome("upgrade-legacy-off", async (home) => {
-      const settingsPath = userSettingsPath(home);
-      await mkdir(path.dirname(settingsPath), { recursive: true });
-      await writeFile(settingsPath, `${JSON.stringify({
-        model: "accounts/fireworks/routers/firerouter[1m]",
-        env: {
-          ANTHROPIC_BASE_URL: "https://router.fireworks.ai",
-          ANTHROPIC_AUTH_TOKEN: "sk-ant-original",
-          ANTHROPIC_CUSTOM_HEADERS: [
-            "X-FireRouter-Fireworks-Key: fw_test_key",
-            "X-User-Header: keep-me",
-          ].join("\n"),
-          CLAUDE_CODE_ATTRIBUTION_HEADER: "0",
-          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1",
-          USER_ENV: "keep-me",
-        },
-        unrelated: { keep: true },
-      }, null, 2)}\n`);
-
-      const result = await runCli(["claude", "off"], { home });
-      assert.equal(result.code, 0, result.stderr);
-
-      const restored = JSON.parse(await readFile(settingsPath, "utf8"));
-      assert.equal(restored.model, undefined);
-      assert.deepEqual(restored.env, {
-        ANTHROPIC_CUSTOM_HEADERS: "X-User-Header: keep-me",
-        USER_ENV: "keep-me",
-      });
-      assert.deepEqual(restored.unrelated, { keep: true });
-    });
-  });
-});
-
 describe("upgrade fetch, compare, and reset ordering", () => {
   it("does not run the Claude preflight or reset when already current", async () => {
     const events = [];
@@ -364,5 +329,102 @@ describe("upgrade fetch, compare, and reset ordering", () => {
 
     assert.ok(events.includes("preflight"));
     assert.ok(events.includes("reset --hard new"));
+  });
+
+  it("runs npm install when already current but runtime packages are missing", async () => {
+    const events = [];
+    await runUpgradeCommand(upgradeDependencies({
+      execFile: (file, args) => {
+        if (file === "git") {
+          const command = args.slice(2);
+          events.push(command.join(" "));
+          if (command[0] === "rev-parse" && command[1] === "HEAD") {
+            return "same\n";
+          }
+          if (command[0] === "rev-parse" && command[1] === "FETCH_HEAD") {
+            return "same\n";
+          }
+          return "";
+        }
+        events.push([file, ...args].join(" "));
+        return "";
+      },
+      runtimeDepsPresent: () => false,
+    }));
+
+    assert.ok(
+      events.some((event) => /npm(\.cmd)? install --omit=dev/.test(event)),
+      `expected npm install, got: ${events.join(" | ")}`,
+    );
+  });
+
+  it("runs npm install when the lockfile is unchanged but packages are missing", async () => {
+    const events = [];
+    await runUpgradeCommand(upgradeDependencies({
+      execFile: (file, args) => {
+        if (file === "git") {
+          const command = args.slice(2);
+          events.push(command.join(" "));
+          if (command[0] === "rev-parse" && command[1] === "HEAD") {
+            return "old\n";
+          }
+          if (command[0] === "rev-parse" && command[1] === "FETCH_HEAD") {
+            return "new\n";
+          }
+          return "";
+        }
+        events.push([file, ...args].join(" "));
+        return "";
+      },
+      preflight: async () => ({ proceed: true, restored: false }),
+      runtimeDepsPresent: () => false,
+    }));
+
+    assert.ok(events.includes("reset --hard new"));
+    assert.ok(events.includes("diff --quiet old new -- packages/setup-cli/package-lock.json"));
+    assert.ok(
+      events.some((event) => /npm(\.cmd)? install --omit=dev/.test(event)),
+      `expected npm install, got: ${events.join(" | ")}`,
+    );
+  });
+});
+
+describe("upgrade finalize process", () => {
+  it("runs finalize-install from the updated checkout in a fresh Node process", async () => {
+    const calls = [];
+    const home = "/tmp/fireconnect-upgrade-home";
+    const installDir = `${home}/.fireconnect/cli`;
+
+    await runUpgradeFinalize(home, installDir, {
+      exists: () => true,
+      execFile: (file, args, options) => calls.push({ file, args, options }),
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].file, process.execPath);
+    assert.deepEqual(calls[0].args, [
+      `${installDir}/packages/setup-cli/bin/fireconnect.mjs`,
+      "finalize-install",
+    ]);
+    assert.equal(calls[0].options.env.HOME, home);
+    assert.equal(calls[0].options.stdio, "inherit");
+  });
+
+  it("falls back to in-process finalize when the installed CLI is missing", async () => {
+    const calls = [];
+    await runUpgradeFinalize("/tmp/home", "/tmp/home/.fireconnect/cli", {
+      exists: () => false,
+      execFile: () => {
+        throw new Error("must not spawn");
+      },
+      finalizeInProcess: async (opts) => {
+        calls.push(opts);
+      },
+    });
+
+    assert.deepEqual(calls, [{
+      home: "/tmp/home",
+      installDir: "/tmp/home/.fireconnect/cli",
+    }]);
   });
 });


### PR DESCRIPTION
## Summary

Public release of FireConnect **v0.9.5**.

### Highlights
- **Claude Code status line** — see which models served your session, what each cost at Fireworks rates, and cache savings, right in your prompt. Your own status line is never touched; `fireconnect claude off` restores everything.
- **ChatGPT desktop app support** — `fireconnect chatgpt` and `fireconnect codex` share one config, so you route both through Fireworks with a single command. Quit the app first so its model list refreshes.
- **Smart router mixes (preview)** — pin `auto` for the default mix or `auto-instant` for latency-first routing, e.g. `fireconnect claude --sonnet auto-instant`. Every `auto-*` slug works the same way.
- **Simpler Claude model setup** — the wizard lets you pick a model per slot instead of toggling fast profiles. New installs default to Sonnet on `deepseek-pro-latest`, Opus on `glm-latest`, and Fable on vision-capable `glm-flash-latest`. FireRouter still lands on Opus at first connect when your key supports it.
- **Faster `fireconnect model list`** — results cached for an hour, work offline, show last-updated time, and `--refresh` pulls the latest. Smart Routers lists `auto`, `auto-instant`, and FireRouter.

### Also improved
- MCP tool search works through the Fireworks gateway again — upgrade applies the fix automatically.
- `fireconnect claude demo` and the status line use the same pricing, so their numbers always match.
- `fireconnect upgrade` repairs missing dependencies; partial installs recover instead of crashing.
- Linux SSH/WSL: keys store in an encrypted file with timeouts on keyring and network calls — no more hangs.
- `fireconnect claude status` shows every slot, including defaults you never explicitly set.
- GLM 5.3 and GLM 5.3 Flash added. Stale pins no longer hide newer releases; US-only pricing corrected.
- Claude picker lists `auto` on every slot and `auto-instant` on Sonnet only.

## Reviewer Ask

Release sync to the public mirror: `packages/setup-cli` source, bins, and tests plus `README.md` / `install.sh` / `LICENSE`. Version is 0.9.5 and the `release-notes.json` entry ships with it. No review of logic is needed — this is the curated public snapshot of the release; a skim of the release notes wording in `packages/setup-cli/lib/system/release-notes.json` is the useful check. After merge, tag `v0.9.5` on this branch to publish.

## Perf Evidence

Not a perf-sensitive change (release sync of already-reviewed code; no new perf paths introduced here).

Made with [Cursor](https://cursor.com)