### PR TITLE
Release FireConnect v0.9.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ that first connect:
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-latest[1m]",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-flash-latest[1m]",
     "ANTHROPIC_DEFAULT_FABLE_MODEL": "glm-flash-latest[1m]",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-flash-latest",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-flash-latest[1m]",
     "ANTHROPIC_CUSTOM_HEADERS": "X-Fireworks-Api-Key: fw_..."
   }
 }
@@ -256,7 +256,11 @@ applied **per model ID** when the resolved serverless context window is at least
 1M tokens (live catalog cache when available, otherwise static specs), plus any
 `firerouter*` gateway pattern. Router aliases such as `deepseek-flash-latest`
 resolve to their base model before the limit check.
-`CLAUDE_CODE_SUBAGENT_MODEL` never gets `[1m]` — Claude Code forwards that value verbatim.
+Every slot is tagged the same way, `CLAUDE_CODE_SUBAGENT_MODEL` included: Claude Code
+reads the tag to size the context window and strips it before the request, so the
+gateway still sees a real model ID. Without the tag Claude Code sizes an unrecognized
+model at the 200K it assumes and auto-compacts the session down to fit, which is what
+starves subagents on a 1M model.
 The `[1m]` tag is Claude Code only; other harnesses (Cursor, etc.) should use the bare
 model ID without the suffix.
 

--- a/packages/setup-cli/lib/demo/claude-runner.mjs
+++ b/packages/setup-cli/lib/demo/claude-runner.mjs
@@ -494,7 +494,13 @@ export async function runClaude({
   //     whole document twice (opus output 11,995 -> 2,578 tokens).
   // Measured on the same tictactoe prompt: glm-fast 18s -> 10s, opus 135s -> 28s
   // (~4.8x) with cache-write down 120,689 -> 73,539.
+  //
+  // User MCPs (Google Drive, fireworks-websearch, etc.) live in ~/.claude.json
+  // and are NOT covered by `--tools ""`. `--strict-mcp-config` with no
+  // `--mcp-config` keeps the race MCP-free so models cannot invoke mcp__*
+  // tools mid-demo.
   args.push("--tools", tools);
+  args.push("--strict-mcp-config");
   const child = spawn("claude", args, {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],

--- a/packages/setup-cli/lib/demo/demo-models.mjs
+++ b/packages/setup-cli/lib/demo/demo-models.mjs
@@ -48,7 +48,7 @@ export const ANTHROPIC_SLOT_CONCRETE_IDS = Object.freeze({
   opus: "claude-opus-5",
   sonnet: "claude-sonnet-5",
   haiku: "claude-haiku-4-5",
-  fable: "claude-fable-5",
+  fable: "claude-fable-5-1",
 });
 
 // Labels include the version, matching the concrete id that actually runs
@@ -57,7 +57,7 @@ const ANTHROPIC_SLOT_LABELS = Object.freeze({
   opus: "Claude Opus 5",
   sonnet: "Claude Sonnet 5",
   haiku: "Claude Haiku 4.5",
-  fable: "Claude Fable 5",
+  fable: "Claude Fable 5.1",
 });
 
 const DEFAULT_LEFT_MODEL = "opus";

--- a/packages/setup-cli/lib/demo/list-pricing.mjs
+++ b/packages/setup-cli/lib/demo/list-pricing.mjs
@@ -42,7 +42,9 @@ const ANTHROPIC_LIST_RATES = {
   "claude-haiku-4-5": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku 4.5" },
   "claude-haiku-3-5": { input: 0.8, cacheWrite5m: 1, cacheWrite1h: 1.6, cacheRead: 0.08, output: 4, label: "Claude Haiku 3.5" },
   "claude-haiku": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku" },
-  // Fable 5 (next-gen long-running agents).
+  // Fable 5 / 5.1 (next-gen long-running agents). 5.1 keeps $10/$50 but drops
+  // cache-read to $0.25/Mtok (2026-09-01); legacy Fable 5 stays at $1.00/Mtok.
+  "claude-fable-5-1": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 0.25, output: 50, label: "Claude Fable 5.1" },
   "claude-fable-5": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable 5" },
   "claude-fable": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable" },
   // Bare `/model` aliases (settings.json `model` may be just "opus"/"sonnet"/"haiku").
@@ -52,7 +54,7 @@ const ANTHROPIC_LIST_RATES = {
   },
   "sonnet": { input: 2, cacheWrite5m: 2.5, cacheWrite1h: 4, cacheRead: 0.2, output: 10, label: "Claude Sonnet" },
   "haiku": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5, label: "Claude Haiku" },
-  "fable": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50, label: "Claude Fable" },
+  "fable": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 0.25, output: 50, label: "Claude Fable 5.1" },
 };
 
 /** USD per 1M tokens, list price. Embedded reference — verify at the source URL.

--- a/packages/setup-cli/lib/fireworks/model-list.mjs
+++ b/packages/setup-cli/lib/fireworks/model-list.mjs
@@ -18,8 +18,7 @@ function formatUsd(value) {
   if (!Number.isFinite(value)) {
     return "—";
   }
-  const text = value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
-  return `$${text}`;
+  return `$${value.toFixed(3)}`;
 }
 
 export function formatCatalogUpdatedAt(updatedAt, timeZone = undefined) {

--- a/packages/setup-cli/lib/fireworks/model-specs.mjs
+++ b/packages/setup-cli/lib/fireworks/model-specs.mjs
@@ -37,18 +37,12 @@ export const FIREWORKS_MODEL_SPECS = {
     pricing: { input: 1.40, cachedInput: 0.26, output: 4.40 },
     capabilities: { contextWindow: 1_048_576, maxOutputTokens: 131_072, vision: false, toolCalling: true },
   },
-  // GLM 5.3 Flash is a distinct cheaper model, not the fast tier of GLM 5.3 —
-  // `glm-flash-latest` names it, while `glm-fast-latest` is the GLM fast tier.
-  // It is also the first vision-capable GLM.
   "glm-5p3-flash": {
     label: "GLM 5.3 Flash",
     pricing: { input: 0.15, cachedInput: 0.03, output: 0.50 },
     capabilities: { contextWindow: 1_048_576, maxOutputTokens: 131_072, vision: true, toolCalling: true },
     api: { contextLength: 1_048_576, supportsImageInput: true },
   },
-  // US-only Serverless rates are per-model, not a uniform uplift: models
-  // launched from 2026-09-01 carry a 50% premium over the matching global row,
-  // while earlier US routers keep the rates they launched with.
   "glm-5p3-flash-us": {
     label: "GLM 5.3 Flash (US)",
     pricing: { input: 0.225, cachedInput: 0.045, output: 0.75 },
@@ -75,7 +69,6 @@ export const FIREWORKS_MODEL_SPECS = {
     pricing: { input: 2.10, cachedInput: 0.21, output: 6.60, tier: "fast" },
     capabilities: { contextWindow: 1_048_575, maxOutputTokens: 131_072, vision: false, toolCalling: true },
   },
-  // Priced at parity with the global GLM 5.2 Fast row, with no US premium.
   "glm-5p2-fast-us": {
     label: "GLM 5.2 Fast (US)",
     pricing: { input: 2.10, cachedInput: 0.21, output: 6.60, tier: "fast" },
@@ -86,7 +79,6 @@ export const FIREWORKS_MODEL_SPECS = {
     pricing: { input: 3.00, cachedInput: 0.30, output: 15.00 },
     capabilities: { contextWindow: 1_040_000, maxOutputTokens: 131_072, vision: true, toolCalling: true },
   },
-  // Launched before the 50% premium, at a 10% premium over the global row.
   "kimi-k3-us": {
     label: "Kimi K3 (US)",
     pricing: { input: 3.30, cachedInput: 0.33, output: 16.50 },
@@ -178,8 +170,6 @@ export const FIREWORKS_MODEL_SPECS = {
       toolCalling: true,
     },
   },
-  // Fireworks-managed mix of open models, served on the gateway but absent from
-  // the public serverless catalog.
   auto: {
     label: "Auto",
     capabilities: {
@@ -273,6 +263,7 @@ export const ROUTER_SPEC_ALIASES = {
 };
 
 const GLM_LATEST_BASE_CANDIDATES = ["glm-5p3", "glm-5p2"];
+const GLM_FAST_LATEST_BASE_CANDIDATES = ["glm-5p3-fast", "glm-5p2-fast"];
 const GLM_FLASH_LATEST_BASE_CANDIDATES = ["glm-5p3-flash"];
 const DEEPSEEK_FLASH_LATEST_BASE_CANDIDATES = ["deepseek-v4-flash-0731", "deepseek-v4-flash"];
 const DEEPSEEK_PRO_LATEST_BASE_CANDIDATES = ["deepseek-v4-pro-0813", "deepseek-v4-pro"];
@@ -289,11 +280,15 @@ function resolveFirstCatalogCandidate(catalogCheck, candidates) {
   return null;
 }
 
-function makeCatalogModelChecker(entryIds = null) {
+function makeCatalogModelChecker(entryIds = null, { includeRouters = false } = {}) {
   if (entryIds) {
-    return (slug) => entryIds.has(`accounts/fireworks/models/${slug}`);
+    return (slug) => entryIds.has(`accounts/fireworks/models/${slug}`)
+      || (includeRouters && entryIds.has(`accounts/fireworks/routers/${slug}`));
   }
-  return (slug) => Boolean(lookupCatalogEntryById(`accounts/fireworks/models/${slug}`));
+  return (slug) => Boolean(
+    lookupCatalogEntryById(`accounts/fireworks/models/${slug}`)
+    || (includeRouters && lookupCatalogEntryById(`accounts/fireworks/routers/${slug}`)),
+  );
 }
 
 function resolveKimiLatestBaseSlug(catalogCheck) {
@@ -313,7 +308,7 @@ export function resolveRouterSpecAliasTarget(alias, entryIds = null) {
     return resolveKimiLatestBaseSlug(catalogCheck) ?? ROUTER_SPEC_ALIASES[alias] ?? null;
   }
   if (alias === "kimi-fast-latest") {
-    if (catalogCheck("kimi-k3-fast")) {
+    if (makeCatalogModelChecker(entryIds, { includeRouters: true })("kimi-k3-fast")) {
       return "kimi-k3-fast";
     }
     const base = resolveKimiLatestBaseSlug(catalogCheck);
@@ -324,6 +319,14 @@ export function resolveRouterSpecAliasTarget(alias, entryIds = null) {
   }
   if (alias === "glm-latest") {
     return resolveFirstCatalogCandidate(catalogCheck, GLM_LATEST_BASE_CANDIDATES)
+      ?? ROUTER_SPEC_ALIASES[alias]
+      ?? null;
+  }
+  if (alias === "glm-fast-latest") {
+    return resolveFirstCatalogCandidate(
+      makeCatalogModelChecker(entryIds, { includeRouters: true }),
+      GLM_FAST_LATEST_BASE_CANDIDATES,
+    )
       ?? ROUTER_SPEC_ALIASES[alias]
       ?? null;
   }
@@ -463,10 +466,13 @@ export function resolveSpecSlug(modelRef) {
   if (FIREWORKS_MODEL_SPECS[shortId]) {
     return shortId;
   }
+  const folded = String(shortId).toLowerCase().replace(/(\d)\.(\d)/g, "$1p$2");
+  if (folded !== shortId && FIREWORKS_MODEL_SPECS[folded]) {
+    return folded;
+  }
   const baseModelId = resolveLiveRouterBaseModelId(modelRef);
   if (baseModelId) {
-    const baseSlug = specShortIdFromModelRef(baseModelId);
-    return fastSpecSlugForBase(baseSlug, shortId);
+    return fastSpecSlugForBase(specShortIdFromModelRef(baseModelId), shortId);
   }
   const aliasTarget = resolveRouterSpecAliasTarget(shortId);
   if (aliasTarget) {
@@ -540,11 +546,9 @@ export function resolveFireworksModelLabel(modelRef) {
 }
 
 export function lookupModelSpec(modelRef) {
-  // firerouter* IDs share the static firerouter catalog metadata (1M context, vision).
   if (isFirerouterModelPattern(modelRef)) {
     return FIREWORKS_MODEL_SPECS.firerouter;
   }
-  // auto / auto-* share the static auto mix metadata (1M context, vision).
   if (isAutoModelId(modelRef)) {
     return FIREWORKS_MODEL_SPECS.auto;
   }
@@ -555,8 +559,6 @@ export function lookupModelSpec(modelRef) {
   const direct = FIREWORKS_MODEL_SPECS[slug];
 
   if (direct) {
-    // Catalog-resolved slugs like kimi-k3-fast ship metadata before pricing lands.
-    // Borrow documented rates from the static -latest alias target when needed.
     if (direct.pricing || !aliasSpec?.pricing) {
       return direct;
     }
@@ -578,8 +580,6 @@ export function isRouterShortId(shortId) {
   if (typeof shortId !== "string") {
     return false;
   }
-  // `firerouter*` prefix (not just the bare slug) mirrors
-  // isFirerouterModelPattern, so firerouter variants classify as routers too.
   return shortId.startsWith("firerouter")
     || Boolean(ROUTER_SPEC_ALIASES[shortId])
     || shortId.endsWith("-latest")
@@ -619,7 +619,6 @@ export function pricingMatchesModelRefTier(modelRef, pricing) {
   if (!pricing) {
     return false;
   }
-  // Priority is opt-in at request time; never surface it in catalog or picker pricing.
   if (pricing.tier === "priority") {
     return false;
   }

--- a/packages/setup-cli/lib/harnesses/claude/code-context.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/code-context.mjs
@@ -15,7 +15,7 @@ const CLAUDE_CODE_1M_SUFFIX = "[1m]";
 
 /**
  * Concrete Anthropic model ids that support Claude Code's 1M context window.
- * Per platform.claude.com/docs: Opus 5 / Sonnet 5 / Fable 5 ship 1M context;
+ * Per platform.claude.com/docs: Opus 5 / Sonnet 5 / Fable 5 / 5.1 ship 1M context;
  * Haiku 4.5 is 200K, so it must NOT receive the `[1m]` suffix (the tag would
  * request a context window the model doesn't have). The bare aliases (opus/
  * sonnet/haiku/fable) resolve to these via ANTHROPIC_DEFAULT_*_MODEL, and a
@@ -30,6 +30,7 @@ const ANTHROPIC_1M_CONTEXT_IDS = new Set([
   "claude-opus-4-5",
   "claude-sonnet-5",
   "claude-fable-5",
+  "claude-fable-5-1",
 ]);
 
 export function stripClaudeCodeContextSuffix(modelId) {

--- a/packages/setup-cli/lib/harnesses/claude/core.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/core.mjs
@@ -647,14 +647,13 @@ export function modelEnvFromMapping(mapping) {
     }
     const envKey = SLOT_MODEL_ENV_KEY[slot];
     if (!envKey) continue;
-    const ref = shortFireworksModelRef(claudeCodeModelId(modelId));
-    merged[envKey] = slot === "subagent"
-      // Claude Code forwards the subagent model id verbatim to the provider API,
-      // unlike ANTHROPIC_MODEL/DEFAULT_* slots where it consumes the [1m] beta tag.
-      // Fireworks has no model literally named "glm-latest[1m]", so the suffix
-      // must be stripped here or subagent/agent-team spawns fail with "model may not exist".
-      ? stripClaudeCodeContextSuffix(ref)
-      : ref;
+    // Every slot — subagent included — carries the [1m] tag when its model has a
+    // 1M window. Claude Code consumes the tag client-side to size the context
+    // window and strips it before the provider call, so Fireworks still sees a
+    // real model id. Leaving it off a 1M model makes Claude Code fall back to the
+    // window it assumes for an unrecognized id (200K) and auto-compact enforces
+    // that assumption, which thrashes subagents that the server could have served.
+    merged[envKey] = shortFireworksModelRef(claudeCodeModelId(modelId));
   }
   return merged;
 }

--- a/packages/setup-cli/lib/harnesses/claude/statusline.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/statusline.mjs
@@ -20,12 +20,13 @@ import {
   appendLatestRouterSuffix,
   lookupModelSpec,
   resolveFireworksModelLabel,
+  resolveSpecSlug,
   specShortIdFromModelRef,
 } from "../../fireworks/model-specs.mjs";
 import { lookupFireworksPricing } from "../../fireworks/pricing.mjs";
 import { providerListPricing } from "../../demo/list-pricing.mjs";
 import { isAnthropicModelId, isAutoModelId, isClaudeNativeModel } from "../../fireworks/model-id.mjs";
-import { autoDisplayName } from "../../fireworks/models.mjs";
+import { autoDisplayName, prettyModelName, stripViaFireworksSuffix } from "../../fireworks/models.mjs";
 import { UNPRICED_TEXT, addUsage } from "./usage/cost.mjs";
 import {
   formatUsageCost,
@@ -103,29 +104,7 @@ export function stripClaudeStatusLine(settings) {
   return { settings: next, changed: true };
 }
 
-// ---------------------------------------------------------------------------
-// Rendering
-// ---------------------------------------------------------------------------
-
-// Raw escapes, not lib/ui/style.mjs: that module disables color when stdout is
-// not a TTY, and a status line's stdout is always a captured pipe. Claude Code
-// renders ANSI from status line output, so color is correct here — NO_COLOR
-// still wins for anyone who sets it. Codes match the live cost meter
-// (lib/ui/palette.mjs METER) so the line reads like `claude usage`.
-//
-// Every sequence MUST carry its `m` terminator. Without it the next character
-// terminates the CSI instead: `\x1b[38;5;141` + "GLM" parses as `\x1b[38;5;141G`
-// (CHA, cursor-move) and eats the "G", while `\x1b[38;5;141` + "█" is an invalid
-// sequence whose parameters leak to the screen as literal `38;5;141` text.
-// Text tokens. Values, labels and legends wear these — never a series color.
-//
-// Both are relative to the terminal's own foreground rather than fixed values:
-// `primary` is the default foreground (\x1b[39m) and `secondary` is that same
-// foreground faint (\x1b[2m). A status line has no say over the surface it
-// lands on — a hardcoded light grey is legible on a dark theme and washes out
-// on a light one — so de-emphasis has to be expressed as a modifier, not a
-// colour. (The series hues below are different: they are marks, not text, and
-// they are validated for contrast.)
+// Raw ANSI escapes (stdout is a pipe, not a TTY). Every SGR must end with `m`.
 const COLOR = process.env.NO_COLOR ? null : {
   bold: "\x1b[1m",
   primary: "\x1b[39m",
@@ -133,14 +112,7 @@ const COLOR = process.env.NO_COLOR ? null : {
   reset: "\x1b[0m",
 };
 
-// Categorical series hues, assigned in fixed order by share rank and never
-// cycled. These are the validated dark-mode steps: every check passes against
-// the dark surface (lightness band, chroma floor, CVD separation, normal-vision
-// floor, 3:1 contrast), with worst adjacent CVD ΔE 8.4 across all eight.
-//
-// Truecolor rather than 256-color so the rendered value is the validated one.
-// They carry identity ONLY — as bar segments and legend swatches. Text beside
-// them stays in the tokens above, which is what keeps the line calm.
+// Series hues for bar segments and swatches only; text uses COLOR tokens above.
 const SERIES_COLORS = Object.freeze([
   "\x1b[38;2;57;135;229m", // #3987e5 blue
   "\x1b[38;2;217;89;38m", // #d95926 orange
@@ -183,21 +155,7 @@ function joinParts(parts) {
 const BAR_MARK = "━";
 
 /**
- * One multi-color stacked bar showing each backend model's share of the
- * session's SPEND, encoded purely as segment width.
- *
- * Cost, not call count: the line exists to answer "where is the money going",
- * and those two answers diverge hard on a router — a model can take 47% of the
- * calls and 89% of the bill. Drawing calls put the less important dimension in
- * the most prominent position, and left the bar disagreeing with the legend
- * beneath it, which states cost.
- *
- * Deliberately textless. The legend already carries a percentage per model
- * (cache hit), and printing a share inside the segments put two unrelated kinds
- * of `%` side by side — the reader had to work out which was which. Width
- * answers "how much of the spend" at a glance, and the legend lists the models
- * in the same order with the exact dollars.
- *
+ * Stacked bar by spend share (not call count). Width only — no in-bar labels.
  * @param {Array<{ label: string, costShare: number }>} models largest first
  * @param {number} width total bar width in cells
  * @returns {string}
@@ -206,56 +164,25 @@ function renderModelBar(models, width) {
   if (models.length === 0) {
     return "";
   }
-  // One blank cell between segments — the terminal's version of the surface gap
-  // a stacked chart puts between fills. It separates neighbours without relying
-  // on hue alone, which matters for colorblind readers and for the two segments
-  // whose adjacent CVD separation is closest to the floor.
   const gaps = models.length - 1;
   const inkWidth = Math.max(models.length, width - gaps);
-  // Min one cell: a model that cost a rounding error still ran, and a segment
-  // that vanishes reads as "this model was not used".
   const widths = models.map((m) => Math.max(1, Math.round(m.costShare * inkWidth)));
-  // Rounding drift: hand the remainder to the largest segment so the bar always
-  // occupies exactly the width it was given.
   const drift = inkWidth - widths.reduce((sum, w) => sum + w, 0);
   if (drift !== 0) {
     widths[0] = Math.max(1, widths[0] + drift);
   }
   return models
-    // A thin rule, not a filled block: the bar is chrome, and a slab of
-    // saturated color out-shouts the numbers it exists to introduce.
     .map((model, index) => paintSeries(index, BAR_MARK.repeat(widths[index])))
     .join(" ");
 }
 
-function stripViaFireworks(label) {
-  return String(label).replace(/ via Fireworks$/i, "");
-}
-
-/**
- * Tighten a model label for the bar and legend.
- *
- * Catalog labels carry qualifiers that earn their place in a picker but not in a
- * status line: `DeepSeek V4 Flash (0731)` and `GLM 5.2 Fast (Latest)` cost ~9
- * columns apiece to say something the line does not turn on. With three models
- * plus the metrics, that overflow is what gets truncated away. The base name is
- * enough to tell the segments apart.
- *
- * @param {string} label
- * @returns {string}
- */
+/** Drop trailing parenthetical qualifiers when they fit the legend width. */
 function compactModelLabel(label) {
   return String(label).replace(/\s*\([^)]*\)\s*$/, "").trim() || String(label);
 }
 
 /**
- * Human label for the routed model.
- *
- * Mirrors `fireworksModelPickerName` (core.mjs) rather than importing it: the
- * status line runs on every assistant message, so it stays off core.mjs's
- * dependency graph. Live catalog label first, then static spec, then pricing
- * table, then the bare slug.
- *
+ * Human label for the routed model (mirrors picker naming without importing core.mjs).
  * @param {string} modelId
  * @returns {string}
  */
@@ -269,27 +196,30 @@ export function claudeStatusLineModelLabel(modelId) {
   }
   const live = resolveFireworksModelLabel(id);
   if (live) {
-    return stripViaFireworks(live);
+    return stripViaFireworksSuffix(live);
   }
   const spec = lookupModelSpec(id);
   if (spec?.label) {
-    return stripViaFireworks(appendLatestRouterSuffix(id, spec.label));
+    return stripViaFireworksSuffix(appendLatestRouterSuffix(id, spec.label));
   }
   const pricing = lookupFireworksPricing(id);
   if (pricing?.label) {
-    return stripViaFireworks(appendLatestRouterSuffix(id, pricing.label));
+    return stripViaFireworksSuffix(appendLatestRouterSuffix(id, pricing.label));
   }
-  // A native Anthropic model (a slot left on Claude's own default): label it
-  // from the list-price table rather than printing the bare slug.
   if (isAnthropicModelId(id)) {
     const anthropic = providerListPricing({ provider: "anthropic", modelId: id });
     if (anthropic?.label && !anthropic.estimated) {
       return anthropic.label;
     }
   }
-  // An id we have no metadata for — the bare slug, minus the Claude Code-only
-  // [1m] tag.
-  return specShortIdFromModelRef(id) || id;
+  const shortId = specShortIdFromModelRef(id) || id;
+  if (!/(?:^|-)[a-z]?\d+p\d+(?:-|$)/.test(shortId)) {
+    return shortId;
+  }
+  const withoutLatest = shortId.replace(/-latest$/, "");
+  const region = withoutLatest.endsWith("-us") ? " (US)" : "";
+  const base = withoutLatest.replace(/-us$/, "");
+  return appendLatestRouterSuffix(id, `${prettyModelName(base)}${region}`);
 }
 
 async function isFile(filePath) {
@@ -301,75 +231,30 @@ async function isFile(filePath) {
 }
 
 /**
- * Fireworks-accurate usage for the session, including its subagents.
- *
- * Returns null when there is nothing to report yet (no transcript on a fresh
- * session) so the caller can omit those fields instead of claiming $0.00.
- *
- * `lastModel` is the real backend model the gateway selected for the most
- * recent parent call — the transcript records it per assistant turn, so a
- * FireRouter session surfaces the model that actually served the last turn
- * (e.g. `accounts/fireworks/models/glm-5p2` or `claude-opus-5`), not the
- * `firerouter` alias the slot is pinned to.
- *
- * `models` is the per-backend breakdown of every billed call in the session,
- * subagents included — each entry `{ label, share, calls, cost }`, largest share
- * first — so the status line can draw one multi-color bar and attribute spend
- * per model instead of naming only the latest one. That split is the point: a
- * router sending 40% of calls to a frontier model can put 95% of the bill there,
- * which a single total hides. FireRouter routes per call and a `/model` switch
- * changes the slot mid-session, so a session can span several backends.
- *
- * In a fully priced session the per-model costs reconcile with `cost`. If any
- * call is unpriced the headline is `cost n/a`; known per-model costs remain in
- * the legend, and the bar switches from spend share to call share.
- *
+ * Fireworks-accurate usage for the session (parent + subagents).
  * @param {string} transcriptPath
  * @param {{ home?: string }} [opts]
  * @returns {Promise<{ cost: number, estimated: boolean, lastModel: string, models: Array<{ label: string, share: number, calls: number, cost: number }>, cachePct: string } | null>}
  */
 export async function claudeStatusLineUsage(transcriptPath, { home = process.env.HOME ?? "" } = {}) {
   const target = String(transcriptPath ?? "").trim();
-  // Guard before calling readClaudeUsage: given a path that does not exist it
-  // falls back to scanning every .jsonl under ~/.claude, which is far too much
-  // work for a status line (and would price the wrong session).
   if (!target || !path.isAbsolute(target) || !await isFile(target)) {
     return null;
   }
-  // Imported here, not at module scope: core.mjs pulls this module in on every
-  // `claude on` for the settings helpers alone, and the cost engine's dependency
-  // graph (pricing tables, catalog cache) is only needed when a status line is
-  // actually being rendered.
   const { readClaudeUsage } = await import("./usage/report.mjs");
   const report = await readClaudeUsage({ home, session: target });
-  // `lastModel` tracks the MAIN thread only: it answers "what is serving me
-  // right now", which a subagent's model does not.
   const lastModel = report.rows.at(-1)?.model ?? "";
-  // The breakdown, however, must cover every billed call — subagents included.
-  // `grandTotals.cost` (the headline) sums parent + subagents, so tallying only
-  // parent rows would leave the legend short of the total and silently orphan
-  // the subagents' spend.
   const allRows = [
     ...report.rows,
     ...(report.subagents ?? []).flatMap((subagent) => subagent.rows),
   ];
-  // Claude Code creates the transcript before the first API call — it opens with
-  // user and metadata lines. Existing-but-callless is still "nothing to price",
-  // so return null rather than a zero-cost report the caller would render as
-  // `$0.00` and pass off as a free session.
   if (allRows.length === 0) {
     return null;
   }
-  // Tally per backend, distinct by normalized short id so
-  // `accounts/fireworks/models/glm-5p2` and a bare `glm-5p2` are one model.
-  // The token buckets mirror the live meter's per-model Tally (meter-model.mjs):
-  // uncached input, cache reads, and both Anthropic cache-write TTLs summed —
-  // so the cache figure here is computed from the same inputs by the same
-  // helpers the meter's `cache%` column uses.
   /** @type {Map<string, { calls: number, cost: number | null, input: number, cacheRead: number, cacheWrite5m: number, cacheWrite1h: number }>} */
   const byModel = new Map();
   for (const row of allRows) {
-    const sid = specShortIdFromModelRef(row.model);
+    const sid = resolveSpecSlug(row.model);
     if (!sid) continue;
     const entry = byModel.get(sid)
       ?? {
@@ -391,9 +276,6 @@ export async function claudeStatusLineUsage(transcriptPath, { home = process.env
   const hasUnpriced = modelTallies.some((entry) => entry.cost == null);
   const totalCost = modelTallies.reduce((sum, entry) => sum + (entry.cost ?? 0), 0);
   const models = [...byModel.entries()]
-    // Spend share is undefined if even one model is unpriced. In that case every
-    // segment uses the same call-share denominator instead of combining priced
-    // spend share with unpriced call share (fractions that can sum above 100%).
     .sort((a, b) => (
       hasUnpriced
         ? b[1].calls - a[1].calls
@@ -401,16 +283,12 @@ export async function claudeStatusLineUsage(transcriptPath, { home = process.env
     ))
     .map(([sid, entry]) => ({
       label: claudeStatusLineModelLabel(sid),
-      // A fully-priced nonzero session draws spend share. A free or partly
-      // unpriced session draws call share for every segment.
       costShare: !hasUnpriced && totalCost > 0
         ? entry.cost / totalCost
         : entry.calls / totalCalls,
       share: entry.calls / totalCalls,
       calls: entry.calls,
       cost: entry.cost,
-      // Same function the session figure uses, and the same ratio+rounding the
-      // meter applies per row — a 99.85%-cached model must not read "100%".
       cachePct: formatUsageCachePct(entry),
     }));
   return {
@@ -418,32 +296,14 @@ export async function claudeStatusLineUsage(transcriptPath, { home = process.env
     estimated: report.estimated,
     lastModel,
     models,
-    // `formatUsageCachePct` returns "—" before the first prompt has any cached
-    // tokens; the caller drops the field in that case.
     cachePct: formatUsageCachePct(report.grandTotals),
   };
 }
 
-// Bar width in cells. Fixed rather than COLUMNS-adaptive so the line layout is
-// predictable and the cost always fits beside it on line 1. Kept modest so the
-// legend + metrics on line 2 stay within a typical status-line width.
 const MODEL_BAR_WIDTH = 16;
 
 /**
- * Build the status line text from Claude Code's stdin payload.
- *
- * Two lines:
- *   <textless spend-share bar> · <session total>
- *   <swatch> <model> <its cost> <its cache>% cache   (repeated per backend)
- *
- * Every number carries its unit: `$` for money, an explicit `% cache` for hit
- * rate. Spend share is the one figure left unlabeled, so it is shown only as bar
- * width — a bare percentage next to a bare percentage meaning something else is
- * what made an earlier version unreadable, and the exact dollars sit in the
- * legend directly beneath. Before the first call lands there is no transcript to
- * break down, so line 1 falls back to the slot alias and the bar is omitted.
- * Never more than two lines.
- *
+ * Build the two-line status line from Claude Code's stdin payload.
  * @param {{
  *   model?: { id?: string, display_name?: string },
  *   transcript_path?: string,
@@ -453,10 +313,6 @@ const MODEL_BAR_WIDTH = 16;
  */
 export async function renderClaudeStatusLine(input = {}, { home = process.env.HOME ?? "" } = {}) {
   const slotModelId = input.model?.id ?? "";
-  // The `claude-default` sentinel is FireConnect's own marker for an unpinned
-  // native slot; Claude Code never sends it as a model id, so prefer whatever
-  // display name it did send. Everything else — Fireworks routers, real
-  // Anthropic ids, unknown ids — resolves through the label helper.
   const slotLabel = isClaudeNativeModel(slotModelId)
     ? (input.model?.display_name || "Claude default")
     : claudeStatusLineModelLabel(slotModelId);
@@ -465,49 +321,32 @@ export async function renderClaudeStatusLine(input = {}, { home = process.env.HO
   try {
     usage = await claudeStatusLineUsage(input.transcript_path ?? "", { home });
   } catch {
-    // An unreadable or half-written transcript must not blank the status line.
     usage = null;
   }
 
   const multi = (usage?.models.length ?? 0) > 1;
 
-  // Line 1: the model bar (or the slot alias before any call lands) + cost.
   const bar = usage?.models.length
     ? renderModelBar(usage.models, MODEL_BAR_WIDTH)
     : "";
-  // No context-window figure here on purpose. Every other number on this line is
-  // one only FireConnect can give you — the real backend model, cost at
-  // Fireworks rates, per-model cache. Context usage is a value Claude Code
-  // hands us and already surfaces itself (`/context`, auto-compact warnings), so
-  // echoing it spent columns to repeat someone else's number and blurred what
-  // the line is for.
   const line1 = joinParts([
     bar || paint("secondary", slotLabel),
-    // The session total is the headline number: primary ink, bold. Colour is
-    // spent on identity (which model), never on emphasis.
-    //
-    // A null total means some call in the session has no rate we can look up, so
-    // there is no honest number to print: it reads `cost n/a` rather than a
-    // figure that would silently exclude those calls. The `~` estimate marker
-    // has nothing to qualify in that case.
     usage && (usage.cost == null
       ? paint("secondary", `cost ${UNPRICED_TEXT}`)
       : `${usage.estimated ? "~" : ""}${COLOR ? COLOR.bold : ""}${paint("primary", formatUsageCost(usage.cost))}`),
   ]);
 
-  // Line 2: one entry per backend — `<swatch> <model> <its cost> <its cache>`.
-  // Every figure is labeled, including a repeated `cache` on each entry: the
-  // repetition costs columns but leaves nothing to infer. Per-model spend is the
-  // fact a single total hides (47% of calls can be 89% of the bill).
-  //
-  // Only the swatch is coloured. Painting the whole entry in its series hue —
-  // name, cost AND cache — turned the line into three bands of saturated text
-  // competing with each other; identity belongs on a mark, and the numbers read
-  // far better in one consistent ink.
+  const rawLabels = usage?.models.map((m) => m.label) ?? [];
+  const compact = rawLabels.map(compactModelLabel);
+  const labelCounts = new Map();
+  for (const label of compact) {
+    labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+  }
+  const labels = compact.map((label, index) => (
+    labelCounts.get(label) > 1 ? String(rawLabels[index]) : label
+  ));
   const legend = usage?.models.map((m, index) => {
-    // A single-model session needs no per-model cost: it equals the total
-    // already shown on line 1.
-    const label = compactModelLabel(m.label);
+    const label = labels[index];
     const cache = m.cachePct && m.cachePct !== "—" ? ` ${m.cachePct} cache` : "";
     const text = multi
       ? `${label} ${formatUsageCost(m.cost)}${cache}`

--- a/packages/setup-cli/lib/harnesses/claude/usage/meter-layout.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/meter-layout.mjs
@@ -86,6 +86,13 @@ export const TOKEN_COLUMNS_WIDTH = TOKEN_COLUMNS.reduce((n, c) => n + c.width, 0
 /** Model badge column — 8 fits "GLM5.2" and "Opus5" but not two models joined. */
 export const MODEL_COL = 8;
 
+/**
+ * Footer model-name column — full priced labels ("GLM 5.3 Flash (US)"), not the
+ * compact turn-badge width. Footer rows start their numeric block further right
+ * than turn rows so names stay readable without colliding with "GLM 5.3".
+ */
+export const FOOTER_MODEL_COL = 18;
+
 /** Cost column — wide enough for "$1234.5678". */
 export const COST_COL = 10;
 
@@ -116,6 +123,9 @@ export const LABEL_BLOCK = TURN_NO_PREFIX.length + MODEL_COL;
 
 /** Gutter + coloured dot that opens a footer model row, before its label. */
 export const FOOTER_LABEL_INDENT = 4;
+
+/** Width of the footer label block (dot + model name) before numeric columns. */
+export const FOOTER_LABEL_BLOCK = FOOTER_LABEL_INDENT + FOOTER_MODEL_COL;
 
 /** Widest the elastic share bar is allowed to get. */
 export const BAR_MAX = 22;

--- a/packages/setup-cli/lib/harnesses/claude/usage/meter-render.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/meter-render.mjs
@@ -16,8 +16,8 @@ import { sumCosts } from "./cost.mjs";
 import {
   BAR_MAX,
   COST_COL,
-  FOOTER_LABEL_INDENT,
-  LABEL_BLOCK,
+  FOOTER_LABEL_BLOCK,
+  FOOTER_MODEL_COL,
   MODEL_COL,
   money,
   SHARE_COL,
@@ -202,7 +202,7 @@ export function renderFooter({ totals, unpriced, peers, agentLabel, colorOf, wid
   // the meter 40% of the window — 48-64 cols on a laptop — so this is the common
   // case, not an edge case. Its floor is everything on a model row except the bar
   // itself, derived so a column change cannot leave it stale.
-  const fixedRow = LABEL_BLOCK + TOKEN_COLUMNS_WIDTH + 1 + SHARE_COL + 1 + COST_COL;
+  const fixedRow = FOOTER_LABEL_BLOCK + TOKEN_COLUMNS_WIDTH + 1 + SHARE_COL + 1 + COST_COL;
   const barw = Math.max(0, Math.min(BAR_MAX, width - fixedRow - 2));
 
   const lines = [];
@@ -211,9 +211,9 @@ export function renderFooter({ totals, unpriced, peers, agentLabel, colorOf, wid
     const fill = grand ? Math.floor((t.cost / grand) * barw) : 0;
     const bar = barw ? `${c}${"█".repeat(fill)}${R}${D}${"░".repeat(barw - fill)}${R} ` : "";
     const share = `${grand ? ((t.cost / grand) * 100).toFixed(0) : "0"}%`.padStart(SHARE_COL);
-    // Label padded to LABEL_BLOCK minus its `  ● ` prefix, so the numbers land
-    // under the same headings as a turn row's.
-    const label = key.slice(0, MODEL_COL).padEnd(LABEL_BLOCK - FOOTER_LABEL_INDENT);
+    // Full priced label — turn badges stay compact; truncating here made
+    // "GLM 5.3 Flash" and "GLM 5.3" indistinguishable in the footer.
+    const label = clip(key, FOOTER_MODEL_COL).padEnd(FOOTER_MODEL_COL);
     lines.push(
       `  ${c}●${R} ${label}${D}${tokenCells(t)}${R} `
       + `${bar}${GHOST}${share}${R} ${GOLD}${money(t.cost)}${R}`,

--- a/packages/setup-cli/lib/harnesses/claude/usage/meter.mjs
+++ b/packages/setup-cli/lib/harnesses/claude/usage/meter.mjs
@@ -198,7 +198,14 @@ class Dashboard {
       // Ties keep the first record: repeated all-zero blocks shouldn't churn.
       if (weight <= prev.weight) return;
       prev.turn.tally.remove(prev.priced);
-      this.totals.get(prev.bucket)?.remove(prev.priced);
+      const orphan = this.totals.get(prev.bucket);
+      orphan?.remove(prev.priced);
+      if (orphan && !orphan.cost && !orphan.input && !orphan.cacheRead
+        && !orphan.write5m && !orphan.write1h && !orphan.output) {
+        this.totals.delete(prev.bucket);
+        const index = prev.turn.models.indexOf(prev.bucket);
+        if (index >= 0) prev.turn.models.splice(index, 1);
+      }
       prev.turn.tally.add(priced);
       const bucket = this.index.bucket(model, priced);
       if (!this.totals.has(bucket)) this.totals.set(bucket, new Tally());

--- a/packages/setup-cli/lib/harnesses/codex/core.mjs
+++ b/packages/setup-cli/lib/harnesses/codex/core.mjs
@@ -500,6 +500,8 @@ export async function enableCodexFireworks({
     catalogPath: effectiveCatalogPath,
     apiKey: resolvedEffective,
     literalAuth: true,
+    // codex 0.153+ injects a server-executed web_search tool; Fireworks Responses API rejects the mix (#320).
+    webSearch: "disabled",
     httpHeaders: mergeFireconnectTelemetryHeaders(
       priorHttpHeaders,
       telemetryHeaders,

--- a/packages/setup-cli/lib/harnesses/codex/toml-patch.mjs
+++ b/packages/setup-cli/lib/harnesses/codex/toml-patch.mjs
@@ -12,6 +12,8 @@ const ROOT_PROFILE_LINE = /^profile\s*=.+$/;
 const ROOT_MODEL_PROVIDER_LINE = /^model_provider\s*=.+$/;
 const ROOT_MODEL_LINE = /^model\s*=.+$/;
 const ROOT_MODEL_CATALOG_LINE = /^model_catalog_json\s*=.+$/;
+// fireconnect-owned root key: disables codex's default-on web_search tool (#320).
+const ROOT_WEB_SEARCH_LINE = /^web_search\s*=.+$/;
 const CODEX_BEARER_AUTH_LINE = /^experimental_bearer_token\s*=.+$/;
 const CODEX_ENV_AUTH_LINE = /^env_key\s*=.+$/;
 
@@ -116,7 +118,8 @@ export function stripFireconnectRoutingRaw(raw, { stripRootRouting = false } = {
       if (ROOT_PROFILE_LINE.test(trimmed)
         || ROOT_MODEL_PROVIDER_LINE.test(trimmed)
         || ROOT_MODEL_CATALOG_LINE.test(trimmed)
-        || ROOT_MODEL_LINE.test(trimmed)) {
+        || ROOT_MODEL_LINE.test(trimmed)
+        || ROOT_WEB_SEARCH_LINE.test(trimmed)) {
         continue;
       }
     }
@@ -152,6 +155,7 @@ export function stripFireconnectRoutingRaw(raw, { stripRootRouting = false } = {
  *   wireApi?: string,
  *   providerName?: string,
  *   authEnvKey?: string,
+ *   webSearch?: string,
  *   httpHeaders?: Record<string, string>,
  *   envHttpHeaders?: Record<string, string>,
  * }} routing
@@ -166,6 +170,7 @@ export function patchFireconnectRoutingRaw(raw, {
   wireApi = "responses",
   providerName = "Fireworks",
   authEnvKey = "FIREWORKS_API_KEY",
+  webSearch = "",
   httpHeaders = {},
   envHttpHeaders = {},
 }) {
@@ -174,6 +179,7 @@ export function patchFireconnectRoutingRaw(raw, {
     `model_provider = "${providerId}"`,
     ...(catalogPath ? [`model_catalog_json = "${catalogPath}"`] : []),
     `model = "${modelId}"`,
+    ...(webSearch ? [`web_search = "${webSearch}"`] : []),
   ].join("\n");
   const tablesBlock = [
     `[model_providers.${providerId}]`,

--- a/packages/setup-cli/lib/system/release-notes.json
+++ b/packages/setup-cli/lib/system/release-notes.json
@@ -1,6 +1,20 @@
 {
   "releases": [
     {
+      "version": "0.9.6",
+      "highlights": [
+        "Codex 0.153 works with Fireworks again. It turns on a `web_search` tool the Responses API can't accept; FireConnect now bakes `web_search = \"disabled\"` and repairs existing setups on `fireconnect codex on`.",
+        "Cleaner cost breakdown: the status line and meter dedupe and name model labels instead of listing the same one twice."
+      ],
+      "improvements": [
+        "Claude Fable 5.1 pricing added; estimates and `fireconnect model list` are accurate.",
+        "Subagent slot keeps its `[1m]` tag when routed.",
+        "`fireconnect model list` aligns price precision across models.",
+        "`fireconnect claude demo` disables your user MCPs so they can't skew the race."
+      ],
+      "footer": "Using Codex? Run `fireconnect upgrade` and 0.153 keeps working through Fireworks."
+    },
+    {
       "version": "0.9.5",
       "highlights": [
         "Session costs in your Claude prompt. A new status line shows which models ran, what they cost at Fireworks rates, and cache savings. Your own status line is left alone — `fireconnect claude off` restores everything.",

--- a/packages/setup-cli/package-lock.json
+++ b/packages/setup-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fireconnect/cli",
-  "version": "0.9.4",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fireconnect/cli",
-      "version": "0.9.4",
+      "version": "0.9.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/setup-cli/package.json
+++ b/packages/setup-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fireconnect/cli",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "FireConnect CLIs for using Fireworks models with Claude Code",
   "type": "module",
   "bin": {

--- a/packages/setup-cli/test/cli/cli-commands.test.mjs
+++ b/packages/setup-cli/test/cli/cli-commands.test.mjs
@@ -247,8 +247,8 @@ describe("fireconnect claude on", () => {
       assert.equal(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME, "DeepSeek V4 Flash (0731) (Latest)");
       assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL, CLAUDE_STORED_FABLE_MODEL);
       assert.equal(settings.env.ANTHROPIC_DEFAULT_FABLE_MODEL_NAME, "GLM 5.3 Flash (Latest)");
-      // Subagent takes the Haiku model, with the [1m] tag stripped.
-      assert.equal(settings.env.CLAUDE_CODE_SUBAGENT_MODEL, "deepseek-flash-latest");
+      // Subagent takes the Haiku model, [1m] tag and all.
+      assert.equal(settings.env.CLAUDE_CODE_SUBAGENT_MODEL, CLAUDE_STORED_DS_FLASH_MODEL);
       assert.equal(settings.env.ANTHROPIC_CUSTOM_MODEL_OPTION, undefined);
       assert.equal(settings.env.CLAUDE_CODE_ATTRIBUTION_HEADER, undefined);
       assert.equal(settings.env.DISABLE_TELEMETRY, "1");
@@ -278,9 +278,7 @@ describe("fireconnect claude on", () => {
       ]) {
         assert.equal(settings.env[key], CLAUDE_STORED_MAIN_MODEL);
       }
-      // Subagent model is forwarded verbatim to the provider, so the [1m] beta
-      // tag must be stripped (Fireworks has no "...kimi-fast-latest[1m]" model).
-      assert.equal(settings.env.CLAUDE_CODE_SUBAGENT_MODEL, KIMI_FAST_LATEST);
+      assert.equal(settings.env.CLAUDE_CODE_SUBAGENT_MODEL, CLAUDE_STORED_MAIN_MODEL);
       assert.equal(Object.hasOwn(settings.env, "CLAUDE_CODE_DISABLE_1M_CONTEXT"), false);
     });
   });

--- a/packages/setup-cli/test/demo/demo-integration.test.mjs
+++ b/packages/setup-cli/test/demo/demo-integration.test.mjs
@@ -666,6 +666,22 @@ test("providerListPricing: fast mode uses the published Opus 5/4.8 rate", () => 
   }
 });
 
+test("providerListPricing: Fable 5.1 uses reduced cache-read tier, not Fable 5", () => {
+  const f51 = providerListPricing({ provider: "anthropic", modelId: "claude-fable-5-1" });
+  assert.equal(f51.inputPerMillion, 10);
+  assert.equal(f51.outputPerMillion, 50);
+  assert.equal(f51.cacheReadPerMillion, 0.25);
+  assert.equal(f51.cacheWrite5mPerMillion, 12.5);
+  assert.equal(f51.cacheWrite1hPerMillion, 20);
+  assert.equal(f51.estimated, false);
+
+  const legacy = providerListPricing({ provider: "anthropic", modelId: "claude-fable-5" });
+  assert.equal(legacy.cacheReadPerMillion, 1);
+
+  const alias = providerListPricing({ provider: "anthropic", modelId: "fable" });
+  assert.equal(alias.cacheReadPerMillion, 0.25);
+});
+
 test("providerListPricing: gpt-4o-mini does not match the gpt-4o tier", () => {
   // Regression: substring matching by insertion order let `gpt-4o` shadow
   // `gpt-4o-mini`, inflating cost ~17x. The longest-key match must win.

--- a/packages/setup-cli/test/demo/demo-models.test.mjs
+++ b/packages/setup-cli/test/demo/demo-models.test.mjs
@@ -175,6 +175,6 @@ test("defaults and display labels", () => {
     opus: "claude-opus-5",
     sonnet: "claude-sonnet-5",
     haiku: "claude-haiku-4-5",
-    fable: "claude-fable-5",
+    fable: "claude-fable-5-1",
   });
 });

--- a/packages/setup-cli/test/demo/route-settings.test.mjs
+++ b/packages/setup-cli/test/demo/route-settings.test.mjs
@@ -33,7 +33,7 @@ test("demoCliModel: Anthropic slots resolve to concrete canonical ids (real Anth
   assert.equal(demoCliModel("opus"), "claude-opus-5[1m]");
   assert.equal(demoCliModel("sonnet"), "claude-sonnet-5[1m]");
   assert.equal(demoCliModel("haiku"), "claude-haiku-4-5");
-  assert.equal(demoCliModel("fable"), "claude-fable-5[1m]");
+  assert.equal(demoCliModel("fable"), "claude-fable-5-1[1m]");
 });
 
 test("demoCliModel: Fireworks models get Claude Code context suffix when needed", () => {

--- a/packages/setup-cli/test/fireworks/firepass-defaults.test.mjs
+++ b/packages/setup-cli/test/fireworks/firepass-defaults.test.mjs
@@ -212,6 +212,11 @@ describe("Fire Pass defaults", () => {
     assert.equal(Object.hasOwn(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT"), false);
   });
 
+  test("Fable 5.1 qualifies for Claude Code 1m context", () => {
+    assert.equal(claudeCodeModelId("claude-fable-5-1"), "claude-fable-5-1[1m]");
+    assert.equal(modelQualifiesForClaudeCode1mContext("claude-fable-5-1"), true);
+  });
+
   test("models below 1M context omit the Claude Code [1m] suffix", () => {
     assert.equal(claudeCodeModelId("accounts/fireworks/models/gpt-oss-120b"), "accounts/fireworks/models/gpt-oss-120b");
     assert.equal(claudeCodeModelId("accounts/fireworks/routers/minimax-latest"), "accounts/fireworks/routers/minimax-latest");

--- a/packages/setup-cli/test/fireworks/fireworks-model-specs.test.mjs
+++ b/packages/setup-cli/test/fireworks/fireworks-model-specs.test.mjs
@@ -509,6 +509,118 @@ describe("fireworks-model-specs", () => {
     }
   });
 
+  it("follows the catalog for the GLM fast tier rather than a static target", () => {
+    // glm-fast-latest is the default Sonnet slot. `resolveSpecSlug` reads the
+    // catalog's live router base, so the alias target has to consult the catalog
+    // too — otherwise the two disagree and a GLM 5.3 Fast call borrows GLM 5.2
+    // Fast's rates.
+    //
+    // Fast is a serving path, so a tier is published under `routers/`, NOT
+    // `models/`: `accounts/fireworks/routers/glm-5p2-fast` is the shipped one.
+    // A probe that only looked at `models/` would never see a fast tier.
+    const snapshot = (id) => ({
+      entries: [{ id, shortId: "glm-5p3-fast", displayName: "GLM 5.3 Fast", kind: "serverless" }],
+      pricingById: new Map(),
+      inputModalitiesById: new Map(),
+      routerBaseModelById: new Map(),
+      contextLengthById: new Map(),
+      supportsToolsById: new Map(),
+    });
+
+    for (const id of [
+      "accounts/fireworks/routers/glm-5p3-fast",
+      "accounts/fireworks/models/glm-5p3-fast",
+    ]) {
+      setServerlessCatalogSnapshot(snapshot(id));
+      try {
+        assert.equal(resolveRouterSpecAliasTarget("glm-fast-latest"), "glm-5p3-fast", id);
+        assert.equal(resolveSpecSlug("glm-fast-latest"), "glm-5p3-fast", id);
+      } finally {
+        setServerlessCatalogSnapshot(null);
+      }
+    }
+
+    // No GLM 5.3 fast tier is published today: the Fast lineup is GLM 5.2 Fast
+    // alone, so the alias must keep resolving there at the fast-tier rate.
+    assert.equal(resolveRouterSpecAliasTarget("glm-fast-latest"), "glm-5p2-fast");
+    assert.equal(resolveSpecSlug("glm-fast-latest"), "glm-5p2-fast");
+    assert.equal(lookupFireworksPricing("glm-fast-latest")?.input, 2.10);
+    assert.equal(lookupFireworksPricing("glm-fast-latest")?.output, 6.60);
+    // And GLM 5.3 itself has no fast tier to fall into.
+    assert.equal(FIREWORKS_MODEL_SPECS["glm-5p3-fast"], undefined);
+  });
+
+  it("folds dotted served-model ids onto the canonical p-form slug", () => {
+    // Claude Code records whatever the gateway stamped on the response, and a
+    // transcript can carry both `glm-5p3` and `GLM-5.3` for the same model. Left
+    // unfolded they price as two models — one of them unpriced — and every
+    // per-model breakdown reports the same release twice.
+    for (const ref of ["GLM-5.3", "glm-5.3", "accounts/fireworks/models/GLM-5.3"]) {
+      assert.equal(resolveSpecSlug(ref), "glm-5p3", ref);
+      assert.equal(lookupModelSpec(ref)?.label, "GLM 5.3", ref);
+      assert.equal(lookupFireworksPricing(ref)?.input, 1.40, ref);
+    }
+    assert.equal(resolveSpecSlug("Kimi-K2.6"), "kimi-k2p6");
+  });
+
+  it("does not invent a slug for a dotted id with no matching spec", () => {
+    // Folding is only safe because it must land on a model we know; an id that
+    // merely looks dotted must survive verbatim.
+    for (const ref of ["glm-9.9", "not-a-real-1.0", "FW-GLM-5.2"]) {
+      assert.equal(resolveSpecSlug(ref), ref, ref);
+      assert.equal(lookupFireworksPricing(ref), null, ref);
+    }
+  });
+
+  it("does not invent a rate by stripping -latest off an id", () => {
+    // `-latest` and pinned ids are mutually exclusive by design: `-latest`
+    // tracks current versions while a pinned id names one and does not. So
+    // `glm-5p2-latest` is a contradiction Fireworks does not publish, and
+    // stripping `-latest` to reach `glm-5p2` would be inventing a rate for an id
+    // nothing serves.
+    for (const ref of ["glm-5p2-latest", "glm-5p3-latest", "glm-5p2-fast-latest"]) {
+      assert.equal(resolveSpecSlug(ref), ref, ref);
+      assert.equal(lookupFireworksPricing(ref), null, ref);
+    }
+    // The real `-latest` aliases keep resolving through the catalog and
+    // ROUTER_SPEC_ALIASES paths that own them.
+    assert.equal(resolveSpecSlug("glm-latest"), "glm-5p3");
+    assert.equal(resolveSpecSlug("glm-fast-latest"), "glm-5p2-fast");
+    assert.equal(resolveSpecSlug("glm-flash-latest"), "glm-5p3-flash");
+    assert.equal(resolveSpecSlug("kimi-fast-latest"), "kimi-k3-fast");
+    assert.equal(resolveSpecSlug("not-real-latest"), "not-real-latest");
+  });
+
+  it("prefers the live catalog over the static alias table", () => {
+    // ROUTER_SPEC_ALIASES is a build-time snapshot of where a floating router
+    // pointed, so it goes stale the moment a release lands. Whenever the catalog
+    // can say, it wins — otherwise a status line would report a version, and
+    // charge a cached-input rate, that no longer matches what served the call.
+    assert.equal(resolveSpecSlug("glm-latest"), "glm-5p3");
+    setServerlessCatalogSnapshot({
+      entries: [
+        { id: "accounts/fireworks/models/glm-5p2", shortId: "glm-5p2", displayName: "GLM 5.2", kind: "serverless" },
+        { id: "accounts/fireworks/routers/glm-latest", shortId: "glm-latest", displayName: "GLM Latest", kind: "serverless" },
+      ],
+      pricingById: new Map(),
+      inputModalitiesById: new Map(),
+      routerBaseModelById: new Map([
+        ["accounts/fireworks/routers/glm-latest", "accounts/fireworks/models/glm-5p2"],
+      ]),
+      contextLengthById: new Map(),
+      supportsToolsById: new Map(),
+    });
+    try {
+      assert.equal(resolveSpecSlug("glm-latest"), "glm-5p2");
+      // And the rate follows the observed model, not the stale snapshot: GLM 5.2
+      // and 5.3 share input/output rates but differ on cached input.
+      assert.equal(lookupFireworksPricing("glm-latest")?.cachedInput, 0.14);
+    } finally {
+      setServerlessCatalogSnapshot(null);
+    }
+    assert.equal(lookupFireworksPricing("glm-latest")?.cachedInput, 0.26);
+  });
+
   it("resolves firerouter from the shared model spec like other routers", () => {
     const spec = lookupModelSpec("accounts/fireworks/routers/firerouter");
     assert.equal(spec?.label, "FireRouter");

--- a/packages/setup-cli/test/fireworks/fireworks-models.test.mjs
+++ b/packages/setup-cli/test/fireworks/fireworks-models.test.mjs
@@ -18,6 +18,7 @@ import {
 } from "../../lib/fireworks/models.mjs";
 import {
   catalogWithAutoEntry,
+  formatCatalogSections,
   formatCatalogUpdatedAt,
   organizeCatalogForDisplay,
 } from "../../lib/fireworks/model-list.mjs";
@@ -145,6 +146,37 @@ describe("fireworks-models serverless catalog", () => {  test("fetchServerlessCa
       "Aug 29, 2026, 1:28 PM PDT",
     );
     assert.equal(formatCatalogUpdatedAt(null), "bundled with FireConnect");
+  });
+
+  test("formatCatalogSections shows prices with consistent precision", () => {
+    const output = formatCatalogSections([{
+      title: "MODELS",
+      entries: [
+        {
+          id: "accounts/fireworks/models/model-a",
+          shortId: "model-a",
+          displayName: "Model A",
+          pricing: {
+            inputPerMillion: 0.2,
+            cachedInputPerMillion: 0.02,
+            outputPerMillion: 1,
+          },
+        },
+        {
+          id: "accounts/fireworks/models/model-b",
+          shortId: "model-b",
+          displayName: "Model B",
+          pricing: {
+            inputPerMillion: 4.5,
+            cachedInputPerMillion: 0.45,
+            outputPerMillion: 22.5,
+          },
+        },
+      ],
+    }]);
+
+    assert.match(output, /\$0\.200\s+\$0\.020\s+\$1\.000/);
+    assert.match(output, /\$4\.500\s+\$0\.450\s+\$22\.500/);
   });
 
   test("buildPickerCatalogFromApiModels derives routers from usage_identifier", () => {

--- a/packages/setup-cli/test/harnesses/claude/claude-firerouter.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-firerouter.test.mjs
@@ -55,7 +55,7 @@ describe("Claude slot-level FireRouter", () => {
     );
     assert.equal(
       settings.env.CLAUDE_CODE_SUBAGENT_MODEL,
-      "deepseek-flash-latest",
+      "deepseek-flash-latest[1m]",
     );
     assert.match(settings.env.ANTHROPIC_CUSTOM_HEADERS, /X-Fireworks-Api-Key: fw_test_key_12345/);
     assert.doesNotMatch(settings.env.ANTHROPIC_CUSTOM_HEADERS, /x-anthropic-api-key/i);

--- a/packages/setup-cli/test/harnesses/claude/claude-statusline.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-statusline.test.mjs
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import { userSettingsPath } from "../../../lib/harnesses/claude/core.mjs";
+import { lookupFireworksPricing } from "../../../lib/fireworks/pricing.mjs";
 import {
   claudeStatusLineCommand,
   claudeStatusLineModelLabel,
@@ -47,6 +48,66 @@ describe("claude status line", () => {
     // No metadata for the id: the bare slug, never a crash.
     assert.equal(claudeStatusLineModelLabel("not-a-real-model"), "not-a-real-model");
     assert.equal(claudeStatusLineModelLabel(""), "unknown model");
+  });
+
+  it("reads an id back without claiming to have recognised it", () => {
+    // `glm-5p2-latest` is not a router Fireworks publishes — `-latest` tracks
+    // versions and a pinned id names one, so the two never combine. The label is
+    // therefore only a tidier spelling of the id's own text, never a lookup: it
+    // must not imply we found a spec, and no rate may be attached.
+    assert.equal(claudeStatusLineModelLabel("glm-5p2-latest"), "GLM 5.2 (Latest)");
+    assert.equal(lookupFireworksPricing("glm-5p2-latest"), null);
+    // The dotted form a gateway may stamp on a response reads the same as the
+    // p-form slug, so one model never appears under two names.
+    assert.equal(claudeStatusLineModelLabel("GLM-5.3"), "GLM 5.3");
+    assert.equal(claudeStatusLineModelLabel("glm-5p3"), "GLM 5.3");
+  });
+
+  it("reads a Fireworks release newer than this build as a model, not a raw slug", () => {
+    // A GLM release whose spec has not shipped yet is still recognisably GLM.
+    assert.equal(claudeStatusLineModelLabel("glm-5p9"), "GLM 5.9");
+    assert.equal(claudeStatusLineModelLabel("glm-5p9-fast"), "GLM 5.9 Fast");
+    assert.equal(claudeStatusLineModelLabel("glm-5p9-latest"), "GLM 5.9 (Latest)");
+    assert.equal(claudeStatusLineModelLabel("kimi-k2p9"), "Kimi K2.9");
+    // An id carrying no Fireworks version segment is not ours to reformat.
+    assert.equal(claudeStatusLineModelLabel("some-unlisted-model"), "some-unlisted-model");
+  });
+
+  it("labels an unshipped region-bound router the way shipped ones read", () => {
+    // The three shipped US specs all label themselves "... (US)".
+    assert.equal(claudeStatusLineModelLabel("glm-5p2-fast-us"), "GLM 5.2 Fast (US)");
+    // A US variant with no spec yet must read in that same shape rather than as
+    // a bare slug, so it is recognisable as the regional twin of its base row.
+    assert.equal(claudeStatusLineModelLabel("glm-5p2-us"), "GLM 5.2 (US)");
+    assert.equal(claudeStatusLineModelLabel("glm-5p9-fast-us"), "GLM 5.9 Fast (US)");
+  });
+
+  it("never prices an unshipped US variant off its global row", async () => {
+    await withTempHome("statusline-us-unpriced", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // US premiums are per-model, not a uniform uplift: the shipped rows carry
+      // +0% (glm-5p2-fast-us), +10% (kimi-k3-us) and +50% (glm-5p3-flash-us)
+      // over their global twins. Nothing can be inferred from the base rate, so
+      // an unknown US id must withhold a figure rather than understate the bill.
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p2", output: 1_000_000 }),
+        assistantLine({ id: "m2", model: "accounts/fireworks/models/glm-5p2-us", output: 1_000_000 }),
+      ].join("\n"));
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      assert.equal(usage.models.length, 2, usage.models.map((m) => m.label).join(", "));
+      const byLabel = new Map(usage.models.map((m) => [m.label, m.cost]));
+      assert.equal(byLabel.get("GLM 5.2"), 4.40);
+      assert.equal(byLabel.get("GLM 5.2 (US)"), null);
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home }));
+      // The qualifier survives compaction: two rates must not share one name.
+      assert.match(plain, /GLM 5\.2 \(US\) n\/a/, plain);
+      assert.match(plain, /cost n\/a/, plain);
+    });
   });
 
   it("invokes the helper with an absolute node and script path", () => {
@@ -473,6 +534,134 @@ describe("claude status line", () => {
       typeof await renderClaudeStatusLine({ transcript_path: "/nope/nothing.jsonl" }),
       "string",
     );
+  });
+
+  it("merges alias and full-path model ids into one legend row", async () => {
+    await withTempHome("statusline-canonical-bucket", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p3", output: 1_000_000 }),
+        assistantLine({ id: "m2", model: "glm-5p3", output: 1_000_000 }),
+        assistantLine({ id: "m3", model: "glm-latest", output: 1_000_000 }),
+      ].join("\n"));
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      assert.equal(usage.models.length, 1, usage.models.map((m) => m.label).join(", "));
+      assert.equal(usage.models[0].label, "GLM 5.3");
+      assert.equal(usage.models[0].calls, 3);
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home }));
+      // One backend after merge: legend names the model without repeating the total.
+      assert.match(plain, /GLM 5\.3/, plain);
+      assert.doesNotMatch(plain, /glm-5p3|glm-latest/, plain);
+    });
+  });
+
+  it("merges a dotted served-model id with its p-form slug", async () => {
+    await withTempHome("statusline-dotted-merge", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // The duplicate-GLM report: one transcript, one model, two id spellings.
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p3", output: 1_000_000 }),
+        assistantLine({ id: "m2", model: "GLM-5.3", output: 1_000_000 }),
+      ].join("\n"));
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      assert.equal(usage.models.length, 1, usage.models.map((m) => m.label).join(", "));
+      assert.equal(usage.models[0].label, "GLM 5.3");
+      assert.equal(usage.models[0].calls, 2);
+      // Both spellings price, so the session total is a real figure rather than
+      // withheld over an id we could have recognised.
+      assert.equal(usage.cost, 8.80);
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home }));
+      assert.doesNotMatch(plain, /GLM-5\.3/, plain);
+      assert.doesNotMatch(plain, /cost n\/a/, plain);
+    });
+  });
+
+  it("merges the default Sonnet router with the model it resolves to", async () => {
+    await withTempHome("statusline-default-slot", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // `glm-fast-latest` is the default Sonnet slot, so this is the shape most
+      // sessions have: the slot alias and the resolved model both appear as
+      // served ids across one session's calls.
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "glm-fast-latest", output: 1_000_000 }),
+        assistantLine({ id: "m2", model: "accounts/fireworks/models/glm-5p2-fast", output: 1_000_000 }),
+        assistantLine({ id: "m3", model: "glm-5p2-fast", output: 1_000_000 }),
+      ].join("\n"));
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      assert.equal(usage.models.length, 1, usage.models.map((m) => m.label).join(", "));
+      assert.equal(usage.models[0].label, "GLM 5.2 Fast");
+      assert.equal(usage.models[0].calls, 3);
+      // 3M output at the fast tier's $6.60/Mtok.
+      assert.equal(Number(usage.cost.toFixed(4)), 19.80);
+    });
+  });
+
+  it("keeps the qualifier when dropping it would print one name twice", async () => {
+    await withTempHome("statusline-label-collision", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      // The global and US Flash routers are separate models on separate rates.
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p3-flash", output: 1_000_000 }),
+        assistantLine({ id: "m2", model: "accounts/fireworks/models/glm-5p3-flash-us", output: 1_000_000 }),
+      ].join("\n"));
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home }));
+
+      const legend = plain.split("\n")[1];
+      // Two rows billing $0.50 and $0.75 must not both read "GLM 5.3 Flash".
+      assert.match(legend, /GLM 5\.3 Flash \$0\.50/, legend);
+      assert.match(legend, /GLM 5\.3 Flash \(US\) \$0\.75/, legend);
+      const names = [...legend.matchAll(/GLM 5\.3 Flash(?: \(US\))?/g)].map((m) => m[0]);
+      assert.equal(new Set(names).size, names.length, `ambiguous legend: ${legend}`);
+    });
+  });
+
+  it("still drops the qualifier when nothing collides", async () => {
+    await withTempHome("statusline-label-compact", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p3-flash-us", output: 1_000_000 }),
+        assistantLine({ id: "m2", model: "claude-opus-5", output: 1_000_000 }),
+      ].join("\n"));
+
+      const plain = stripAnsi(await renderClaudeStatusLine({
+        model: { id: "firerouter[1m]" },
+        transcript_path: transcript,
+      }, { home }));
+
+      // Alone in the session, the US row needs no disambiguating suffix.
+      assert.match(plain, /GLM 5\.3 Flash \$/, plain);
+      assert.doesNotMatch(plain, /\(US\)/, plain);
+    });
+  });
+
+  it("keeps distinct GLM tiers as separate legend rows", async () => {
+    await withTempHome("statusline-glm-tiers", async (home) => {
+      const transcript = path.join(home, "session.jsonl");
+      await writeFile(transcript, [
+        assistantLine({ id: "m1", model: "accounts/fireworks/models/glm-5p3", output: 1_000_000 }),
+        assistantLine({ id: "m2", model: "accounts/fireworks/models/glm-5p3-flash", output: 1_000_000 }),
+      ].join("\n"));
+
+      const usage = await claudeStatusLineUsage(transcript, { home });
+      assert.equal(usage.models.length, 2);
+      const labels = usage.models.map((m) => m.label).sort();
+      assert.deepEqual(labels, ["GLM 5.3", "GLM 5.3 Flash"]);
+    });
   });
 
   it("attributes subagent spend so the per-model costs sum to the total", async () => {

--- a/packages/setup-cli/test/harnesses/claude/claude-subagent-context-tag.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/claude-subagent-context-tag.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildFireworksSettings,
+  mappingFromSettings,
+  modelEnvFromMapping,
+} from "../../../lib/harnesses/claude/core.mjs";
+import { resolveClaudeModelMapping } from "../../../lib/harnesses/claude/model-profile.mjs";
+import { firerouterStatusFromEnv, stripFirerouterOwnedEnv } from "../../../lib/firerouter/core.mjs";
+
+const FW_KEY = "fw_test_claude_key_00000000000000";
+
+/*
+ * `CLAUDE_CODE_SUBAGENT_MODEL` used to be written without the `[1m]` tag every
+ * other slot gets, on the theory that Claude Code forwarded the subagent id to
+ * the provider verbatim and Fireworks would reject "deepseek-flash-latest[1m]".
+ * It doesn't: Claude Code consumes the tag to size the context window and sends
+ * the bare id on the wire, the same as for the ANTHROPIC_DEFAULT_* slots.
+ * Verified against Claude Code 2.0.30 through 2.1.252 by pointing the real
+ * binary at a recording endpoint — the subagent request carries model
+ * "deepseek-flash-latest" plus the context-1m-2025-08-07 beta either way.
+ *
+ * Dropping the tag is not free. Claude Code sizes an unrecognized model at the
+ * window it assumes (200K) rather than the 1M the server serves, and since
+ * 2.1.250 auto-compact holds the session to that assumption instead of waiting
+ * for the API to object — so a tagless 1M subagent compacts until it dies.
+ */
+function settingsFor(overrides) {
+  const { settings } = buildFireworksSettings({ env: {} }, {
+    apiKey: FW_KEY,
+    mapping: resolveClaudeModelMapping(overrides, "fireworks"),
+  });
+  return settings;
+}
+
+describe("Claude subagent slot carries the 1M context tag", () => {
+  it("tags the default subagent model like every other slot", () => {
+    const { env } = settingsFor({});
+    assert.equal(env.CLAUDE_CODE_SUBAGENT_MODEL, "deepseek-flash-latest[1m]");
+    assert.equal(env.ANTHROPIC_DEFAULT_HAIKU_MODEL, "deepseek-flash-latest[1m]");
+  });
+
+  it("tags every 1M slot identically, subagent included", () => {
+    const env = modelEnvFromMapping({
+      opus: "glm-latest",
+      sonnet: "kimi-fast-latest",
+      haiku: "deepseek-flash-latest",
+      fable: "glm-flash-latest",
+      subagent: "kimi-fast-latest",
+    });
+    assert.deepEqual(env, {
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "glm-latest[1m]",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "kimi-fast-latest[1m]",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "deepseek-flash-latest[1m]",
+      ANTHROPIC_DEFAULT_FABLE_MODEL: "glm-flash-latest[1m]",
+      CLAUDE_CODE_SUBAGENT_MODEL: "kimi-fast-latest[1m]",
+    });
+  });
+
+  it("tags a FireRouter subagent and still recognizes it as FireRouter-owned", () => {
+    const { env } = settingsFor({ subagent: "firerouter" });
+    assert.equal(env.CLAUDE_CODE_SUBAGENT_MODEL, "firerouter[1m]");
+    assert.equal(firerouterStatusFromEnv(env), "firerouter");
+    const { env: stripped } = stripFirerouterOwnedEnv(env);
+    assert.equal(Object.hasOwn(stripped, "CLAUDE_CODE_SUBAGENT_MODEL"), false);
+  });
+
+  it("leaves a sub-1M subagent model untagged", () => {
+    const { env } = settingsFor({ subagent: "kimi-k2p6" });
+    assert.equal(env.CLAUDE_CODE_SUBAGENT_MODEL, "kimi-k2p6");
+  });
+
+  it("pins nothing when the subagent slot is native", () => {
+    const { env } = settingsFor({ subagent: "native" });
+    assert.equal(Object.hasOwn(env, "CLAUDE_CODE_SUBAGENT_MODEL"), false);
+  });
+
+  it("reads the tagged slot back as the bare model id", () => {
+    const settings = settingsFor({});
+    assert.equal(mappingFromSettings(settings).subagent, "deepseek-flash-latest");
+  });
+});

--- a/packages/setup-cli/test/harnesses/claude/usage/meter-accuracy.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/meter-accuracy.test.mjs
@@ -523,6 +523,38 @@ describe("live meter billing accuracy", () => {
     assert.ok(!/\$0\.0000/.test(firstRow), `cost should land on turn 1: ${firstRow}`);
   });
 
+  it("shows full footer model names so Flash does not collide with GLM 5.3", async () => {
+    const usage = { input_tokens: 0, cache_read_input_tokens: 16_300, output_tokens: 3 };
+    const frame = await render([
+      { type: "user", message: { content: "go" } },
+      assistant("a", usage, "accounts/fireworks/models/glm-5p3"),
+      assistant("b", usage, "accounts/fireworks/models/glm-5p3-flash"),
+    ]);
+
+    const footer = plainLines(frame).filter((l) => l.includes("●"));
+    assert.equal(footer.length, 2, `expected two model rows:\n${frame}`);
+    assert.ok(footer.some((l) => /● GLM 5\.3 Flash/.test(l)), `flash label missing:\n${footer.join("\n")}`);
+    assert.ok(
+      footer.some((l) => /● GLM 5\.3\s+\d/.test(l) && !/Flash/.test(l)),
+      `base GLM 5.3 row missing:\n${footer.join("\n")}`,
+    );
+  });
+
+  it("drops an empty footer bucket when revision moves spend to another model", async () => {
+    const usage = { input_tokens: 0, cache_read_input_tokens: 16_300, output_tokens: 3 };
+    const zero = { input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 };
+    const frame = await render([
+      { type: "user", message: { content: "go" } },
+      assistant("msg_1", zero, "accounts/fireworks/models/glm-5p3-flash"),
+      assistant("msg_1", usage, "accounts/fireworks/models/glm-5p3"),
+    ]);
+
+    const footer = plainLines(frame).filter((l) => l.includes("●"));
+    assert.equal(footer.length, 1, `orphan flash bucket should be gone:\n${frame}`);
+    assert.match(footer[0], /GLM 5\.3/);
+    assert.doesNotMatch(footer[0], /Flash/);
+  });
+
   it("restarts cleanly when the log is truncated and rewritten", async () => {
     // Keeping the old byte offset skipped the head of the new content, so turns
     // written before that offset never appeared and stale turns lingered.
@@ -1096,18 +1128,16 @@ describe("column layout is derived, not duplicated", () => {
     const footer = lines.find((l) => l.trimStart().startsWith("●"));
     assert.ok(header && turn && footer, `need header, turn and footer rows:\n${frame}`);
 
-    // Each heading's right edge must line up with its cell's right edge on BOTH
-    // the turn row and the footer row — that is the property the shared table
-    // buys, and the one a stray literal would break.
+    // Each heading's right edge must line up with its cell's right edge on the
+    // turn row. Footer model names use a wider label block, so footer numeric
+    // columns start further right on purpose.
     for (const head of ["uncached", "cached", "write", "cache%", "out"]) {
       const at = header.indexOf(head) + head.length;
-      for (const [name, row] of [["turn", turn], ["footer", footer]]) {
-        assert.equal(
-          row.slice(0, at).trimEnd().length,
-          at,
-          `${head} not right-aligned on the ${name} row at col ${at}:\n${header}\n${row}`,
-        );
-      }
+      assert.equal(
+        turn.slice(0, at).trimEnd().length,
+        at,
+        `${head} not right-aligned on the turn row at col ${at}:\n${header}\n${turn}`,
+      );
     }
   });
 

--- a/packages/setup-cli/test/harnesses/claude/usage/report.test.mjs
+++ b/packages/setup-cli/test/harnesses/claude/usage/report.test.mjs
@@ -283,6 +283,18 @@ describe("claude usage", () => {
     );
   });
 
+  it("prices Fable 5.1 cache reads at the reduced $0.25/Mtok tier", () => {
+    const row = computeClaudeUsageCost("claude-fable-5-1", {
+      input_tokens: 100,
+      cache_read_input_tokens: 1_000_000,
+      output_tokens: 500,
+    });
+    const expected = (100 * 10 + 1_000_000 * 0.25 + 500 * 50) / 1_000_000;
+    assert.equal(row.cost, expected);
+    assert.equal(row.rates.cacheReadPerMillion, 0.25);
+    assert.equal(row.rates.label, "Claude Fable 5.1");
+  });
+
   it("computes Anthropic cache write, cache read, geo, batch, and web-search costs", () => {
     const row = computeClaudeUsageCost("claude-opus-4-8", {
       input_tokens: 100,

--- a/packages/setup-cli/test/harnesses/codex/codex-toml-patch.test.mjs
+++ b/packages/setup-cli/test/harnesses/codex/codex-toml-patch.test.mjs
@@ -245,6 +245,51 @@ describe("codex-toml-patch", () => {
     assert.match(patched, /model_catalog_json = "~\/\.codex\/fireworks-model-catalog\.json"/);
   });
 
+  it("patchFireconnectRoutingRaw writes web_search = disabled when webSearch option is set", () => {
+    const patched = patchFireconnectRoutingRaw("", { ...ROUTING, webSearch: "disabled" });
+    assert.match(patched, /^web_search = "disabled"$/m);
+    assert.equal(parseToml(patched).root.web_search, "disabled");
+  });
+
+  it("patchFireconnectRoutingRaw omits web_search when webSearch option is absent", () => {
+    const patched = patchFireconnectRoutingRaw("", ROUTING);
+    assert.doesNotMatch(patched, /web_search/);
+  });
+
+  it("patchFireconnectRoutingRaw overrides an existing web_search line without duplicating", () => {
+    const input = [
+      'model_provider = "openai"',
+      'model = "gpt-4.1"',
+      'web_search = "live"',
+      "",
+    ].join("\n");
+    const patched = patchFireconnectRoutingRaw(input, { ...ROUTING, webSearch: "disabled" });
+    assert.equal(
+      (patched.match(/^web_search = .+$/gm) ?? []).length,
+      1,
+      "should not duplicate web_search",
+    );
+    assert.match(patched, /^web_search = "disabled"$/m);
+    assert.equal(parseToml(patched).root.web_search, "disabled");
+  });
+
+  it("stripFireconnectRoutingRaw with stripRootRouting removes fireconnect-managed web_search", () => {
+    const input = [
+      'model_provider = "fireworks-ai"',
+      'model = "accounts/fireworks/routers/glm-latest"',
+      'web_search = "disabled"',
+      "",
+      "[model_providers.fireworks-ai]",
+      'name = "Fireworks"',
+      'base_url = "https://api.fireworks.ai/inference/v1"',
+      'env_key = "FIREWORKS_API_KEY"',
+      "requires_openai_auth = false",
+      "",
+    ].join("\n");
+    const stripped = stripFireconnectRoutingRaw(input, { stripRootRouting: true });
+    assert.doesNotMatch(stripped, /web_search/);
+  });
+
   it("patchCodexCatalogRefRaw updates an existing model_catalog_json line", () => {
     const input = [
       'model_provider = "fireworks-ai"',


### PR DESCRIPTION
## Summary

FireConnect **v0.9.6**.

### Highlights
- **Codex 0.153 works with Fireworks again.** Codex 0.153 turns on a `web_search` tool the Responses API can't accept; FireConnect now bakes `web_search = "disabled"` and repairs existing setups on `fireconnect codex on`.
- **Cleaner cost breakdown** — the status line and meter dedupe and name model labels instead of listing the same one twice.

### Also improved
- Claude Fable 5.1 pricing added; estimates and `fireconnect model list` are accurate.
- Subagent slot keeps its `[1m]` tag when routed.
- `fireconnect model list` aligns price precision across models.
- `fireconnect claude demo` disables your user MCPs so they can't skew the race.

> Using Codex? Run `fireconnect upgrade` and 0.153 keeps working through Fireworks.

Made with [Cursor](https://cursor.com)